### PR TITLE
feat: 为侧边栏场景和项目列表添加拖拽排序功能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "skills-manager",
       "version": "1.1.2",
       "dependencies": {
+        "@hello-pangea/dnd": "^18.0.1",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/cli": "^2.10.0",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -947,6 +948,23 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
+      "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "css-box-model": "^1.2.1",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1830,6 +1848,12 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
@@ -2629,6 +2653,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/cssesc": {
@@ -5039,6 +5072,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -5112,6 +5151,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -5197,6 +5259,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
@@ -5614,6 +5682,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
+    "@hello-pangea/dnd": "^18.0.1",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/cli": "^2.10.0",
     "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -220,6 +220,20 @@ pub async fn remove_project(store: State<'_, Arc<SkillStore>>, id: String) -> Re
 }
 
 #[tauri::command]
+pub async fn reorder_projects(
+    ids: Vec<String>,
+    store: State<'_, Arc<SkillStore>>,
+) -> Result<(), AppError> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        store
+            .reorder_projects(&ids)
+            .map_err(AppError::db)
+    })
+    .await?
+}
+
+#[tauri::command]
 pub async fn scan_projects(root: String) -> Result<Vec<String>, AppError> {
     tauri::async_runtime::spawn_blocking(move || {
         let root_path = Path::new(&root);

--- a/src-tauri/src/core/skill_store.rs
+++ b/src-tauri/src/core/skill_store.rs
@@ -530,12 +530,27 @@ impl SkillStore {
 
     pub fn reorder_scenarios(&self, ids: &[String]) -> Result<()> {
         let conn = self.conn.lock().unwrap();
+        let tx = conn.unchecked_transaction()?;
         for (i, id) in ids.iter().enumerate() {
-            conn.execute(
+            tx.execute(
                 "UPDATE scenarios SET sort_order = ?1 WHERE id = ?2",
                 params![i as i32, id],
             )?;
         }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn reorder_projects(&self, ids: &[String]) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        let tx = conn.unchecked_transaction()?;
+        for (i, id) in ids.iter().enumerate() {
+            tx.execute(
+                "UPDATE projects SET sort_order = ?1 WHERE id = ?2",
+                params![i as i32, id],
+            )?;
+        }
+        tx.commit()?;
         Ok(())
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,6 +112,7 @@ pub fn run() {
             commands::scenarios::add_skill_to_scenario,
             commands::scenarios::remove_skill_from_scenario,
             commands::scenarios::reorder_scenarios,
+            commands::projects::reorder_projects,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   LayoutDashboard,
@@ -9,6 +10,7 @@ import {
   Pencil,
   Trash2,
   FolderOpen,
+  GripVertical,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -31,6 +33,29 @@ export function Sidebar() {
   const [renameTarget, setRenameTarget] = useState<{ id: string; name: string; icon?: string | null } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [deleteProjectTarget, setDeleteProjectTarget] = useState<{ id: string; name: string } | null>(null);
+  const [orderedScenarios, setOrderedScenarios] = useState(scenarios);
+  const [orderedProjects, setOrderedProjects] = useState(projects);
+
+  useEffect(() => { setOrderedScenarios(scenarios); }, [scenarios]);
+  useEffect(() => { setOrderedProjects(projects); }, [projects]);
+
+  const handleDragEnd = async (result: DropResult) => {
+    if (!result.destination || result.destination.index === result.source.index) return;
+    const reordered = [...orderedScenarios];
+    const [moved] = reordered.splice(result.source.index, 1);
+    reordered.splice(result.destination.index, 0, moved);
+    setOrderedScenarios(reordered);
+    await api.reorderScenarios(reordered.map((s) => s.id));
+  };
+
+  const handleProjectDragEnd = async (result: DropResult) => {
+    if (!result.destination || result.destination.index === result.source.index) return;
+    const reordered = [...orderedProjects];
+    const [moved] = reordered.splice(result.source.index, 1);
+    reordered.splice(result.destination.index, 0, moved);
+    setOrderedProjects(reordered);
+    await api.reorderProjects(reordered.map((p) => p.id));
+  };
 
   const NAV_ITEMS = [
     { name: t("sidebar.dashboard"), path: "/", icon: LayoutDashboard },
@@ -153,71 +178,93 @@ export function Sidebar() {
           <div className="text-[13px] font-semibold text-muted mb-1.5 px-2.5 tracking-[0.1em] uppercase">
             {t("sidebar.scenarios")}
           </div>
-          <div className="space-y-0.5">
-            {scenarios.map((scenario) => {
-              const isActive = activeScenario?.id === scenario.id;
-              const scenarioIcon = getScenarioIconOption(scenario);
-              const ScenarioIcon = scenarioIcon.icon;
-              return (
+          <DragDropContext onDragEnd={handleDragEnd}>
+            <Droppable droppableId="scenarios">
+              {(droppableProvided) => (
                 <div
-                  key={scenario.id}
-                  className={cn(
-                    "group flex items-center gap-0.5 rounded-[5px] transition-colors",
-                    isActive ? "bg-surface-active" : "hover:bg-surface-hover"
-                  )}
+                  className="space-y-0.5"
+                  ref={droppableProvided.innerRef}
+                  {...droppableProvided.droppableProps}
                 >
-                  <button
-                    onClick={() => handleSwitchScenario(scenario.id)}
-                    className={cn(
-                      "flex min-w-0 flex-1 items-center gap-2 px-2.5 py-[7px] text-left text-sm outline-none",
-                      isActive ? "font-medium text-primary" : "text-tertiary group-hover:text-secondary"
-                    )}
-                  >
-                    <span
-                      className={cn(
-                        "flex h-[20px] w-[20px] shrink-0 items-center justify-center rounded border",
-                        isActive
-                          ? `${scenarioIcon.activeClass} ${scenarioIcon.colorClass}`
-                          : "border-border bg-surface text-muted group-hover:border-border group-hover:text-tertiary"
-                      )}
-                    >
-                      <ScenarioIcon className="h-3 w-3" />
-                    </span>
-                    <span className="flex-1 truncate">{scenario.name}</span>
-                    {scenario.skill_count > 0 && (
-                      <span
-                        className={cn(
-                          "rounded-full px-1.5 text-[13px] font-medium leading-[18px]",
-                          isActive
-                            ? "bg-accent-bg text-accent-light"
-                            : "bg-surface-hover text-muted group-hover:bg-surface-active"
-                        )}
-                      >
-                        {scenario.skill_count}
-                      </span>
-                    )}
-                  </button>
+                  {orderedScenarios.map((scenario, index) => {
+                    const isActive = activeScenario?.id === scenario.id;
+                    const scenarioIcon = getScenarioIconOption(scenario);
+                    const ScenarioIcon = scenarioIcon.icon;
+                    return (
+                      <Draggable key={scenario.id} draggableId={scenario.id} index={index}>
+                        {(provided) => (
+                          <div
+                            ref={provided.innerRef}
+                            {...provided.draggableProps}
+                            className={cn(
+                              "group flex items-center gap-0.5 rounded-[5px] transition-colors",
+                              isActive ? "bg-surface-active" : "hover:bg-surface-hover"
+                            )}
+                          >
+                            <button
+                              onClick={() => handleSwitchScenario(scenario.id)}
+                              className={cn(
+                                "flex min-w-0 flex-1 items-center gap-2 px-2.5 py-[7px] text-left text-sm outline-none",
+                                isActive ? "font-medium text-primary" : "text-tertiary group-hover:text-secondary"
+                              )}
+                            >
+                              <span
+                                className={cn(
+                                  "flex h-[20px] w-[20px] shrink-0 items-center justify-center rounded border",
+                                  isActive
+                                    ? `${scenarioIcon.activeClass} ${scenarioIcon.colorClass}`
+                                    : "border-border bg-surface text-muted group-hover:border-border group-hover:text-tertiary"
+                                )}
+                              >
+                                <ScenarioIcon className="h-3 w-3" />
+                              </span>
+                              <span className="flex-1 truncate">{scenario.name}</span>
+                              {scenario.skill_count > 0 && (
+                                <span
+                                  className={cn(
+                                    "rounded-full px-1.5 text-[13px] font-medium leading-[18px]",
+                                    isActive
+                                      ? "bg-accent-bg text-accent-light"
+                                      : "bg-surface-hover text-muted group-hover:bg-surface-active"
+                                  )}
+                                >
+                                  {scenario.skill_count}
+                                </span>
+                              )}
+                            </button>
 
-                  <div className="mr-1.5 flex items-center opacity-0 transition group-hover:opacity-100">
-                    <button
-                      onClick={(event) => handleRenameClick(event, scenario)}
-                      className="rounded p-1 text-faint transition hover:bg-surface-hover hover:text-secondary"
-                      title={t("common.rename")}
-                    >
-                      <Pencil className="h-3 w-3" />
-                    </button>
-                    <button
-                      onClick={(event) => handleDeleteClick(event, scenario)}
-                      className="rounded p-1 text-faint transition hover:bg-surface-hover hover:text-red-400"
-                      title={t("common.delete")}
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </button>
-                  </div>
+                            <div className="mr-1.5 flex items-center opacity-0 transition group-hover:opacity-100">
+                              <div
+                                {...provided.dragHandleProps}
+                                className="rounded p-1 text-faint cursor-grab active:cursor-grabbing"
+                              >
+                                <GripVertical className="h-3 w-3" />
+                              </div>
+                              <button
+                                onClick={(event) => handleRenameClick(event, scenario)}
+                                className="rounded p-1 text-faint transition hover:bg-surface-hover hover:text-secondary"
+                                title={t("common.rename")}
+                              >
+                                <Pencil className="h-3 w-3" />
+                              </button>
+                              <button
+                                onClick={(event) => handleDeleteClick(event, scenario)}
+                                className="rounded p-1 text-faint transition hover:bg-surface-hover hover:text-red-400"
+                                title={t("common.delete")}
+                              >
+                                <Trash2 className="h-3 w-3" />
+                              </button>
+                            </div>
+                          </div>
+                        )}
+                      </Draggable>
+                    );
+                  })}
+                  {droppableProvided.placeholder}
                 </div>
-              );
-            })}
-          </div>
+              )}
+            </Droppable>
+          </DragDropContext>
 
           <button
             onClick={() => setShowCreate(true)}
@@ -234,66 +281,88 @@ export function Sidebar() {
           <div className="text-[13px] font-semibold text-muted mb-1.5 px-2.5 tracking-[0.1em] uppercase">
             {t("sidebar.projects")}
           </div>
-          <div className="space-y-0.5">
-            {projects.map((project) => {
-              const isActive = location.pathname === `/project/${project.id}`;
-              return (
+          <DragDropContext onDragEnd={handleProjectDragEnd}>
+            <Droppable droppableId="projects">
+              {(droppableProvided) => (
                 <div
-                  key={project.id}
-                  className={cn(
-                    "group flex items-center gap-0.5 rounded-[5px] transition-colors",
-                    isActive ? "bg-surface-active" : "hover:bg-surface-hover"
-                  )}
+                  className="space-y-0.5"
+                  ref={droppableProvided.innerRef}
+                  {...droppableProvided.droppableProps}
                 >
-                  <button
-                    onClick={() => navigate(`/project/${project.id}`)}
-                    className={cn(
-                      "flex min-w-0 flex-1 items-center gap-2 px-2.5 py-[7px] text-left text-sm outline-none",
-                      isActive ? "font-medium text-primary" : "text-tertiary group-hover:text-secondary"
-                    )}
-                  >
-                    <span
-                      className={cn(
-                        "flex h-[20px] w-[20px] shrink-0 items-center justify-center rounded border",
-                        isActive
-                          ? "border-blue-500/30 bg-blue-500/10 text-blue-500"
-                          : "border-border bg-surface text-muted group-hover:border-border group-hover:text-tertiary"
-                      )}
-                    >
-                      <FolderOpen className="h-3 w-3" />
-                    </span>
-                    <span className="flex-1 truncate">{project.name}</span>
-                    {project.skill_count > 0 && (
-                      <span
-                        className={cn(
-                          "rounded-full px-1.5 text-[13px] font-medium leading-[18px]",
-                          isActive
-                            ? "bg-accent-bg text-accent-light"
-                            : "bg-surface-hover text-muted group-hover:bg-surface-active"
-                        )}
-                      >
-                        {project.skill_count}
-                      </span>
-                    )}
-                  </button>
+                  {orderedProjects.map((project, index) => {
+                    const isActive = location.pathname === `/project/${project.id}`;
+                    return (
+                      <Draggable key={project.id} draggableId={project.id} index={index}>
+                        {(provided) => (
+                          <div
+                            ref={provided.innerRef}
+                            {...provided.draggableProps}
+                            className={cn(
+                              "group flex items-center gap-0.5 rounded-[5px] transition-colors",
+                              isActive ? "bg-surface-active" : "hover:bg-surface-hover"
+                            )}
+                          >
+                            <button
+                              onClick={() => navigate(`/project/${project.id}`)}
+                              className={cn(
+                                "flex min-w-0 flex-1 items-center gap-2 px-2.5 py-[7px] text-left text-sm outline-none",
+                                isActive ? "font-medium text-primary" : "text-tertiary group-hover:text-secondary"
+                              )}
+                            >
+                              <span
+                                className={cn(
+                                  "flex h-[20px] w-[20px] shrink-0 items-center justify-center rounded border",
+                                  isActive
+                                    ? "border-blue-500/30 bg-blue-500/10 text-blue-500"
+                                    : "border-border bg-surface text-muted group-hover:border-border group-hover:text-tertiary"
+                                )}
+                              >
+                                <FolderOpen className="h-3 w-3" />
+                              </span>
+                              <span className="flex-1 truncate">{project.name}</span>
+                              {project.skill_count > 0 && (
+                                <span
+                                  className={cn(
+                                    "rounded-full px-1.5 text-[13px] font-medium leading-[18px]",
+                                    isActive
+                                      ? "bg-accent-bg text-accent-light"
+                                      : "bg-surface-hover text-muted group-hover:bg-surface-active"
+                                  )}
+                                >
+                                  {project.skill_count}
+                                </span>
+                              )}
+                            </button>
 
-                  <div className="mr-1.5 flex items-center opacity-0 transition group-hover:opacity-100">
-                    <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        setDeleteProjectTarget(project);
-                      }}
-                      className="rounded p-1 text-faint transition hover:bg-surface-hover hover:text-red-400"
-                      title={t("common.delete")}
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </button>
-                  </div>
+                            <div className="mr-1.5 flex items-center opacity-0 transition group-hover:opacity-100">
+                              <div
+                                {...provided.dragHandleProps}
+                                className="rounded p-1 text-faint cursor-grab active:cursor-grabbing"
+                              >
+                                <GripVertical className="h-3 w-3" />
+                              </div>
+                              <button
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  setDeleteProjectTarget(project);
+                                }}
+                                className="rounded p-1 text-faint transition hover:bg-surface-hover hover:text-red-400"
+                                title={t("common.delete")}
+                              >
+                                <Trash2 className="h-3 w-3" />
+                              </button>
+                            </div>
+                          </div>
+                        )}
+                      </Draggable>
+                    );
+                  })}
+                  {droppableProvided.placeholder}
                 </div>
-              );
-            })}
-          </div>
+              )}
+            </Droppable>
+          </DragDropContext>
 
           <button
             onClick={() => setShowAddProject(true)}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -316,6 +316,9 @@ export const removeSkillFromScenario = (skillId: string, scenarioId: string) =>
 export const reorderScenarios = (ids: string[]) =>
   invoke<void>("reorder_scenarios", { ids });
 
+export const reorderProjects = (ids: string[]) =>
+  invoke<void>("reorder_projects", { ids });
+
 // ── Projects ──
 
 export const getProjects = () => invoke<Project[]>("get_projects");


### PR DESCRIPTION
## 改动概述

- 引入 `@hello-pangea/dnd`，用 `DragDropContext` / `Droppable` / `Draggable` 包装侧边栏的场景列表和项目列表，支持拖拽排序
- 悬停时在现有重命名/删除按钮旁显示 `GripVertical` 拖拽把手，对原有条目结构改动极小
- 后端新增 `reorder_projects` Tauri 命令和 `SkillStore::reorder_projects()` 方法，与已有的 `reorder_scenarios` 完全对称；在 `lib.rs` 注册并通过 `src/lib/tauri.ts` 暴露给前端
- 拖拽结束后乐观更新本地顺序，同步通过 IPC 持久化到 SQLite