### PR TITLE
feat: 支持隐藏到系统托盘，关闭时弹窗询问并记住选择

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-build = { version = "2.5.4", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.10.0", features = [] }
+tauri = { version = "2.10.0", features = ["tray-icon"] }
 tauri-plugin-log = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -112,7 +112,7 @@ pub async fn check_app_update(app: tauri::AppHandle) -> Result<AppUpdateInfo, Ap
 }
 
 #[tauri::command]
-pub fn app_exit(app: tauri::AppHandle) {
+pub async fn app_exit(app: tauri::AppHandle) {
     app.exit(0);
 }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -111,6 +111,16 @@ pub async fn check_app_update(app: tauri::AppHandle) -> Result<AppUpdateInfo, Ap
     .await?
 }
 
+#[tauri::command]
+pub fn app_exit(app: tauri::AppHandle) {
+    app.exit(0);
+}
+
+#[tauri::command]
+pub async fn hide_to_tray(window: tauri::WebviewWindow) -> Result<(), AppError> {
+    window.hide().map_err(|e| AppError::io(e.to_string()))
+}
+
 fn version_gt(a: &str, b: &str) -> bool {
     // Prefer strict SemVer comparison (supports pre-release/build metadata).
     if let (Ok(a_ver), Ok(b_ver)) = (Version::parse(a), Version::parse(b)) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,8 +49,14 @@ pub fn run() {
             let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
             let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
 
+            let tray_icon = app
+                .default_window_icon()
+                .cloned()
+                .unwrap_or_else(|| tauri::include_image!("icons/32x32.png"));
+
             let _tray = TrayIconBuilder::new()
-                .icon(app.default_window_icon().unwrap().clone())
+                .icon(tray_icon)
+                .icon_as_template(true)
                 .menu(&menu)
                 .show_menu_on_left_click(false)
                 .on_menu_event(|app, event| match event.id.as_ref() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 mod commands;
 mod core;
@@ -40,6 +40,55 @@ pub fn run() {
                         .build(),
                 )?;
             }
+
+            // System tray
+            use tauri::menu::{Menu, MenuItem};
+            use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+
+            let show_item = MenuItem::with_id(app, "show", "Show", true, None::<&str>)?;
+            let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+            let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
+
+            let _tray = TrayIconBuilder::new()
+                .icon(app.default_window_icon().unwrap().clone())
+                .menu(&menu)
+                .show_menu_on_left_click(false)
+                .on_menu_event(|app, event| match event.id.as_ref() {
+                    "show" => {
+                        if let Some(w) = app.get_webview_window("main") {
+                            let _ = w.show();
+                            let _ = w.set_focus();
+                        }
+                    }
+                    "quit" => app.exit(0),
+                    _ => {}
+                })
+                .on_tray_icon_event(|tray, event| {
+                    if let TrayIconEvent::Click {
+                        button: MouseButton::Left,
+                        button_state: MouseButtonState::Up,
+                        ..
+                    } = event
+                    {
+                        let app = tray.app_handle();
+                        if let Some(w) = app.get_webview_window("main") {
+                            let _ = w.show();
+                            let _ = w.set_focus();
+                        }
+                    }
+                })
+                .build(app)?;
+
+            // Intercept window close — let frontend decide (close vs hide to tray)
+            let win = app.get_webview_window("main").unwrap();
+            let win_for_event = win.clone();
+            win.on_window_event(move |event| {
+                if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                    win_for_event.emit("window-close-requested", ()).ok();
+                    api.prevent_close();
+                }
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -77,6 +126,8 @@ pub fn run() {
             commands::settings::get_central_repo_path,
             commands::settings::open_central_repo_folder,
             commands::settings::check_app_update,
+            commands::settings::app_exit,
+            commands::settings::hide_to_tray,
             // Git Backup
             commands::git_backup::git_backup_status,
             commands::git_backup::git_backup_init,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster } from "sonner";
 import { AppProvider } from "./context/AppContext";
 import { ThemeProvider, useThemeContext } from "./context/ThemeContext";
 import { HelpDialog } from "./components/HelpDialog";
+import { CloseActionGuard } from "./components/CloseActionGuard";
 import { Layout } from "./components/Layout";
 import { Dashboard } from "./views/Dashboard";
 import { MySkills } from "./views/MySkills";
@@ -42,6 +43,7 @@ function App() {
             </Route>
           </Routes>
           <HelpDialog />
+          <CloseActionGuard />
         </BrowserRouter>
         <ThemedToaster />
       </AppProvider>

--- a/src/components/CloseActionDialog.tsx
+++ b/src/components/CloseActionDialog.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  open: boolean;
+  onCancel: () => void;
+  onClose: (remember: boolean) => void;
+  onHide: (remember: boolean) => void;
+}
+
+export function CloseActionDialog({ open, onCancel, onClose, onHide }: Props) {
+  const { t } = useTranslation();
+  const [remember, setRemember] = useState(false);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onCancel} />
+      <div className="relative bg-surface border border-border rounded-xl w-full max-w-sm p-5 shadow-2xl">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-[13px] font-semibold text-primary">
+            {t("closeAction.title")}
+          </h2>
+          <button
+            onClick={onCancel}
+            className="text-muted hover:text-secondary p-1 rounded transition-colors outline-none"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <p className="text-[13px] text-tertiary mb-4">{t("closeAction.message")}</p>
+
+        <label className="flex items-center gap-2 mb-5 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={remember}
+            onChange={(e) => setRemember(e.target.checked)}
+            className="w-3.5 h-3.5 accent-[var(--color-accent)]"
+          />
+          <span className="text-[13px] text-muted">{t("closeAction.remember")}</span>
+        </label>
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={() => onClose(remember)}
+            className="px-3 py-1.5 rounded-[4px] text-[13px] font-medium text-tertiary hover:text-secondary hover:bg-surface-hover transition-colors outline-none"
+          >
+            {t("closeAction.close")}
+          </button>
+          <button
+            onClick={() => onHide(remember)}
+            className="px-3 py-1.5 rounded-[4px] bg-accent-dark hover:bg-accent text-white text-[13px] font-medium transition-colors border border-accent-border outline-none"
+          >
+            {t("closeAction.hide")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CloseActionGuard.tsx
+++ b/src/components/CloseActionGuard.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { CloseActionDialog } from "./CloseActionDialog";
+import * as api from "../lib/tauri";
+
+export function CloseActionGuard() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    const unlisten = listen("window-close-requested", async () => {
+      const pref = await api.getSettings("close_action");
+      if (pref === "close") {
+        api.appExit();
+      } else if (pref === "hide") {
+        await api.hideToTray();
+      } else {
+        setDialogOpen(true);
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const handleClose = async (remember: boolean) => {
+    setDialogOpen(false);
+    if (remember) await api.setSettings("close_action", "close");
+    api.appExit();
+  };
+
+  const handleHide = async (remember: boolean) => {
+    setDialogOpen(false);
+    if (remember) await api.setSettings("close_action", "hide");
+    await api.hideToTray();
+  };
+
+  return (
+    <CloseActionDialog
+      open={dialogOpen}
+      onCancel={() => setDialogOpen(false)}
+      onClose={handleClose}
+      onHide={handleHide}
+    />
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -328,7 +328,19 @@
     "gitErrorNetwork": "Network connection failed. Check your network and remote URL.",
     "gitErrorConflict": "Sync conflict detected. Pull and resolve conflicts first.",
     "gitErrorNotRepo": "Git repository not found. Start backup first.",
-    "gitErrorGeneric": "Git operation failed. Please check Advanced Settings and try again."
+    "gitErrorGeneric": "Git operation failed. Please check Advanced Settings and try again.",
+    "closeAction": "Close Behavior",
+    "closeActionDesc": "What happens when you click the window close button.",
+    "closeAction_ask": "Ask each time",
+    "closeAction_hide": "Hide to tray",
+    "closeAction_close": "Quit app"
+  },
+  "closeAction": {
+    "title": "Close or hide?",
+    "message": "What should happen when you click the close button?",
+    "close": "Quit app",
+    "hide": "Hide to tray",
+    "remember": "Remember my choice and don't ask again"
   },
   "common": {
     "loading": "Loading...",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -328,7 +328,19 @@
     "gitErrorNetwork": "网络连接失败，请检查网络和远程仓库地址。",
     "gitErrorConflict": "检测到同步冲突，请先拉取并解决冲突。",
     "gitErrorNotRepo": "未检测到 Git 仓库，请先开始备份。",
-    "gitErrorGeneric": "Git 操作失败，请检查高级设置后重试。"
+    "gitErrorGeneric": "Git 操作失败，请检查高级设置后重试。",
+    "closeAction": "关闭行为",
+    "closeActionDesc": "点击窗口关闭按钮时的默认动作。",
+    "closeAction_ask": "每次询问",
+    "closeAction_hide": "隐藏到托盘",
+    "closeAction_close": "退出应用"
+  },
+  "closeAction": {
+    "title": "关闭还是隐藏？",
+    "message": "点击关闭按钮时，你希望应用如何响应？",
+    "close": "退出应用",
+    "hide": "隐藏到托盘",
+    "remember": "记住我的选择，下次不再提示"
   },
   "common": {
     "loading": "加载中...",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -210,6 +210,10 @@ export const setSettings = (key: string, value: string) =>
 export const getCentralRepoPath = () =>
   invoke<string>("get_central_repo_path");
 
+export const appExit = () => invoke<void>("app_exit");
+
+export const hideToTray = () => invoke<void>("hide_to_tray");
+
 export const openCentralRepoFolder = () =>
   invoke<void>("open_central_repo_folder");
 

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -36,6 +36,7 @@ export function Settings() {
   const { theme, setTheme } = useThemeContext();
   const [syncMode, setSyncMode] = useState("symlink");
   const [defaultScenario, setDefaultScenario] = useState("");
+  const [closeAction, setCloseAction] = useState("");
   const [refreshing, setRefreshing] = useState(false);
   const [openingRepo, setOpeningRepo] = useState(false);
   const [openingGithub, setOpeningGithub] = useState(false);
@@ -50,6 +51,7 @@ export function Settings() {
   useEffect(() => {
     api.getSettings("sync_mode").then((v) => { if (v) setSyncMode(v); });
     api.getSettings("default_scenario").then((v) => { if (v) setDefaultScenario(v); });
+    api.getSettings("close_action").then((v) => { setCloseAction(v ?? ""); });
     api.getCentralRepoPath().then(setCentralRepoPath).catch(() => {});
 
     (async () => {
@@ -84,6 +86,11 @@ export function Settings() {
   const handleDefaultScenarioChange = async (id: string) => {
     setDefaultScenario(id);
     await api.setSettings("default_scenario", id);
+  };
+
+  const handleCloseActionChange = async (action: string) => {
+    setCloseAction(action);
+    await api.setSettings("close_action", action);
   };
 
   const handleLanguageChange = (lng: string) => {
@@ -365,6 +372,28 @@ export function Settings() {
                   <option value="zh">简体中文 (zh-CN)</option>
                   <option value="en">English (en-US)</option>
                 </select>
+              </div>
+            </div>
+
+            {/* Close action */}
+            <div className="px-4 py-3 flex items-center justify-between gap-4">
+              <div>
+                <h3 className="text-[13px] text-secondary font-medium mb-0.5">{t("settings.closeAction")}</h3>
+                <p className="text-[13px] text-muted">{t("settings.closeActionDesc")}</p>
+              </div>
+              <div className="flex bg-background border border-border-subtle rounded-[4px] p-px shrink-0">
+                {(["", "hide", "close"] as const).map((val) => (
+                  <button
+                    key={val}
+                    onClick={() => handleCloseActionChange(val)}
+                    className={cn(
+                      segmentedButtonClass,
+                      closeAction === val ? "bg-surface-active text-secondary" : "text-muted hover:text-tertiary"
+                    )}
+                  >
+                    {t(`settings.closeAction_${val || "ask"}`)}
+                  </button>
+                ))}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 功能说明

新增"关闭还是隐藏到托盘"功能，让用户自主决定点击关闭按钮时的行为。

## 改动内容

- **系统托盘**：注册托盘图标，支持 Show / Quit 右键菜单，左键单击恢复窗口
- **关闭拦截**：Rust 层拦截 `CloseRequested` 事件，通过 IPC 事件通知前端，不再直接关闭
- **弹窗询问**：首次关闭时弹出 `CloseActionDialog`，提供"退出应用"与"隐藏到托盘"两个选项
- **记住选择**：勾选"记住我的选择"后，下次直接执行对应动作，不再弹窗
- **设置项**：在设置页"全局配置"新增"关闭行为"分段按钮，可随时切换（每次询问 / 隐藏到托盘 / 退出应用）
- **分层解耦**：`CloseActionDialog`（纯 UI）+ `CloseActionGuard`（逻辑/事件）组合，`App.tsx` 只加一行挂载，不侵入原有代码

## 持久化

偏好写入 SQLite（`close_action` key），跨重启生效。