### PR TITLE
fix: 升级 flatted 至 3.4.2 修复高危漏洞

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3132,9 +3132,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## 问题描述

`package-lock.json` 中 `flatted@3.3.3` 存在两个高危漏洞（通过 `eslint → file-entry-cache → flat-cache` 引入）：

- **GHSA-25h7-pfq9-p65f**：`parse()` revive 阶段无界递归导致 DoS
- **GHSA-rf6f-7fwh-wjgh**：`parse()` 存在 Prototype Pollution

## 改动内容

仅更新 `package-lock.json` 中 `flatted` 版本：`3.3.3` → `3.4.2`

变更仅 3 行，不涉及任何源码或其他依赖。

## 验证

```bash
npm audit
# found 0 vulnerabilities
```