### PR TITLE
feat: 来源筛选标签动态溢出与浮窗

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -347,7 +347,8 @@
     "delete": "Delete",
     "rename": "Rename",
     "save": "Save",
-    "create": "Create"
+    "create": "Create",
+    "search": "Search"
   },
   "scenario": {
     "create": "New Scenario",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -347,7 +347,8 @@
     "delete": "删除",
     "rename": "重命名",
     "save": "保存",
-    "create": "创建"
+    "create": "创建",
+    "search": "搜索"
   },
   "scenario": {
     "create": "新建场景",

--- a/src/views/InstallSkills.tsx
+++ b/src/views/InstallSkills.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo, useDeferredValue } from "react";
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo, useDeferredValue } from "react";
 import {
   DownloadCloud,
   UploadCloud,
@@ -18,6 +18,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Search,
+  MoreHorizontal,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -64,6 +65,18 @@ export function InstallSkills() {
   const [importingPaths, setImportingPaths] = useState<Set<string>>(new Set());
   const [importingAll, setImportingAll] = useState(false);
   const marketListRef = useRef<HTMLDivElement | null>(null);
+  const [sourceOverflowOpen, setSourceOverflowOpen] = useState(false);
+  const [sourceOverflowSide, setSourceOverflowSide] = useState<"left" | "right">("left");
+  const [sourceSearch, setSourceSearch] = useState("");
+  const [sourceFocusedIndex, setSourceFocusedIndex] = useState(-1);
+  const sourceListRef = useRef<HTMLDivElement | null>(null);
+  const [visibleSourceCount, setVisibleSourceCount] = useState<number>(0);
+  const sourceOverflowBtnRef = useRef<HTMLButtonElement | null>(null);
+  const sourceOverflowPanelRef = useRef<HTMLDivElement | null>(null);
+  const filterContainerRef = useRef<HTMLDivElement | null>(null);
+  const allBtnMeasureRef = useRef<HTMLButtonElement | null>(null);
+  const moreBtnMeasureRef = useRef<HTMLButtonElement | null>(null);
+  const sourceMeasureRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const marketSearchCacheRef = useRef<Map<string, { timestamp: number; data: SkillsShSkill[] }>>(new Map());
   const marketSkillsLengthRef = useRef(0);
   const [debouncedMarketQuery, setDebouncedMarketQuery] = useState("");
@@ -112,6 +125,21 @@ export function InstallSkills() {
   useEffect(() => {
     marketSkillsLengthRef.current = marketSkills.length;
   }, [marketSkills.length]);
+
+  useEffect(() => {
+    if (!sourceOverflowOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        sourceOverflowBtnRef.current?.contains(e.target as Node) ||
+        sourceOverflowPanelRef.current?.contains(e.target as Node)
+      ) return;
+      setSourceOverflowOpen(false);
+      setSourceSearch("");
+      setSourceFocusedIndex(-1);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [sourceOverflowOpen]);
 
   useEffect(() => {
     const tab = searchParams.get("tab");
@@ -446,9 +474,52 @@ export function InstallSkills() {
   const scanGroups = scanResult?.groups ?? [];
   const pendingGroups = scanGroups.filter((group) => !group.imported);
   const sourceOptions = useMemo(
-    () => Array.from(new Set(marketSkills.map((skill) => skill.source))).slice(0, 8),
+    () => Array.from(new Set(marketSkills.map((skill) => skill.source))),
     [marketSkills]
   );
+
+  const computeVisibleCount = useCallback(() => {
+    const container = filterContainerRef.current;
+    if (!container || sourceOptions.length === 0) {
+      setVisibleSourceCount(sourceOptions.length);
+      return;
+    }
+    const GAP = 6; // gap-1.5 = 6px
+    const containerWidth = container.offsetWidth;
+    const allBtnWidth = allBtnMeasureRef.current?.offsetWidth ?? 80;
+    const moreBtnWidth = moreBtnMeasureRef.current?.offsetWidth ?? 28;
+    const available = containerWidth - allBtnWidth - GAP;
+    const widths = sourceOptions.map((_, i) => sourceMeasureRefs.current[i]?.offsetWidth ?? 0);
+    const totalNeeded = widths.reduce((sum, w) => sum + w + GAP, 0);
+    if (totalNeeded <= available) {
+      setVisibleSourceCount(sourceOptions.length);
+      return;
+    }
+    const availableWithMore = available - moreBtnWidth - GAP;
+    let used = 0;
+    let count = 0;
+    for (const w of widths) {
+      if (used + w + GAP <= availableWithMore) {
+        used += w + GAP;
+        count++;
+      } else {
+        break;
+      }
+    }
+    setVisibleSourceCount(count);
+  }, [sourceOptions]);
+
+  useLayoutEffect(() => {
+    computeVisibleCount();
+  }, [computeVisibleCount]);
+
+  useEffect(() => {
+    const container = filterContainerRef.current;
+    if (!container) return;
+    const observer = new ResizeObserver(computeVisibleCount);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [computeVisibleCount]);
   const filteredMarketSkills = useMemo(() => {
     const filtered = marketSourceFilter === "all"
       ? marketSkills
@@ -581,36 +652,183 @@ export function InstallSkills() {
                   <span className="shrink-0 text-[13px] font-medium text-tertiary">
                     {t("install.filters.source")}
                   </span>
-                  <div className="min-w-0 flex-1 overflow-x-auto scrollbar-hide">
-                  <div className="flex min-w-max justify-end gap-1.5 pr-1">
-                    <button
-                      type="button"
-                      onClick={() => setMarketSourceFilter("all")}
-                      className={cn(
-                        "rounded-full border px-2.5 py-1 text-[13px] font-medium whitespace-nowrap transition-colors",
-                        marketSourceFilter === "all"
-                          ? "border-accent-border bg-accent-bg text-accent-light"
-                          : "border-border-subtle bg-background text-muted hover:text-secondary"
-                      )}
-                    >
-                      {t("install.filters.allSources")}
-                    </button>
-                    {sourceOptions.map((source) => (
+                  <div ref={filterContainerRef} className="relative min-w-0 flex-1">
+                    {/* Hidden measurement layer — never visible, keeps all pills in DOM for width queries */}
+                    <div className="pointer-events-none invisible absolute left-0 top-0 flex items-center gap-1.5" aria-hidden="true">
                       <button
-                        key={source}
+                        ref={allBtnMeasureRef}
+                        tabIndex={-1}
+                        className="rounded-full border px-2.5 py-1 text-[13px] font-medium whitespace-nowrap"
+                      >
+                        {t("install.filters.allSources")}
+                      </button>
+                      {sourceOptions.map((source, i) => (
+                        <button
+                          key={source}
+                          ref={(el) => { sourceMeasureRefs.current[i] = el; }}
+                          tabIndex={-1}
+                          className="rounded-full border px-2.5 py-1 text-[13px] font-medium whitespace-nowrap"
+                        >
+                          @{source}
+                        </button>
+                      ))}
+                      <button
+                        ref={moreBtnMeasureRef}
+                        tabIndex={-1}
+                        className="flex items-center rounded-full border px-2 py-1"
+                      >
+                        <MoreHorizontal className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                    {/* Visible row */}
+                    <div className="flex items-center gap-1.5">
+                      <button
                         type="button"
-                        onClick={() => setMarketSourceFilter(source)}
+                        onClick={() => setMarketSourceFilter("all")}
                         className={cn(
                           "rounded-full border px-2.5 py-1 text-[13px] font-medium whitespace-nowrap transition-colors",
-                          marketSourceFilter === source
+                          marketSourceFilter === "all"
                             ? "border-accent-border bg-accent-bg text-accent-light"
                             : "border-border-subtle bg-background text-muted hover:text-secondary"
                         )}
                       >
-                        @{source}
+                        {t("install.filters.allSources")}
                       </button>
-                    ))}
-                  </div>
+                      {sourceOptions.slice(0, visibleSourceCount).map((source) => (
+                        <button
+                          key={source}
+                          type="button"
+                          onClick={() => setMarketSourceFilter(source)}
+                          className={cn(
+                            "rounded-full border px-2.5 py-1 text-[13px] font-medium whitespace-nowrap transition-colors",
+                            marketSourceFilter === source
+                              ? "border-accent-border bg-accent-bg text-accent-light"
+                              : "border-border-subtle bg-background text-muted hover:text-secondary"
+                          )}
+                        >
+                          @{source}
+                        </button>
+                      ))}
+                      {visibleSourceCount < sourceOptions.length && (
+                        <div className="relative">
+                          <button
+                            ref={sourceOverflowBtnRef}
+                            type="button"
+                            onClick={() => {
+                              if (sourceOverflowBtnRef.current) {
+                                const rect = sourceOverflowBtnRef.current.getBoundingClientRect();
+                                setSourceOverflowSide(rect.left + 192 > window.innerWidth ? "right" : "left");
+                              }
+                              setSourceOverflowOpen((v) => !v);
+                            }}
+                            className={cn(
+                              "flex items-center rounded-full border px-2 py-1 text-[13px] font-medium transition-colors",
+                              sourceOverflowOpen
+                                ? "border-accent-border bg-accent-bg text-accent-light"
+                                : "border-border-subtle bg-background text-muted hover:text-secondary"
+                            )}
+                            title={`${sourceOptions.length - visibleSourceCount} more`}
+                          >
+                            <MoreHorizontal className="h-3.5 w-3.5" />
+                          </button>
+                          {sourceOverflowOpen && (
+                            <div
+                              ref={sourceOverflowPanelRef}
+                              className={cn(
+                                "absolute top-full z-50 mt-1.5 w-48 overflow-hidden rounded-xl border border-border bg-surface shadow-lg",
+                                sourceOverflowSide === "left" ? "left-0" : "right-0"
+                              )}
+                            >
+                              <div className="border-b border-border-subtle px-2 py-1.5">
+                                <div className="relative">
+                                  <Search className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted" />
+                                  <input
+                                    type="text"
+                                    value={sourceSearch}
+                                    onChange={(e) => {
+                                      setSourceSearch(e.target.value);
+                                      setSourceFocusedIndex(-1);
+                                    }}
+                                    onKeyDown={(e) => {
+                                      const filtered = sourceOptions.filter((s) =>
+                                        s.toLowerCase().includes(sourceSearch.toLowerCase())
+                                      );
+                                      if (e.key === "ArrowDown") {
+                                        e.preventDefault();
+                                        setSourceFocusedIndex((i) => {
+                                          const next = Math.min(i + 1, filtered.length - 1);
+                                          requestAnimationFrame(() => {
+                                            sourceListRef.current
+                                              ?.children[next]
+                                              ?.scrollIntoView({ block: "nearest" });
+                                          });
+                                          return next;
+                                        });
+                                      } else if (e.key === "ArrowUp") {
+                                        e.preventDefault();
+                                        setSourceFocusedIndex((i) => {
+                                          const next = Math.max(i - 1, 0);
+                                          requestAnimationFrame(() => {
+                                            sourceListRef.current
+                                              ?.children[next]
+                                              ?.scrollIntoView({ block: "nearest" });
+                                          });
+                                          return next;
+                                        });
+                                      } else if (e.key === "Enter") {
+                                        const target = filtered[sourceFocusedIndex] ?? filtered[0];
+                                        if (target) {
+                                          setMarketSourceFilter(target);
+                                          setSourceOverflowOpen(false);
+                                          setSourceSearch("");
+                                          setSourceFocusedIndex(-1);
+                                        }
+                                      } else if (e.key === "Escape") {
+                                        setSourceOverflowOpen(false);
+                                        setSourceSearch("");
+                                        setSourceFocusedIndex(-1);
+                                      }
+                                    }}
+                                    placeholder={t("common.search")}
+                                    className="app-input w-full bg-background py-1 pl-6 pr-2 text-[12px]"
+                                    autoFocus
+                                    autoCapitalize="none"
+                                    autoCorrect="off"
+                                    spellCheck={false}
+                                  />
+                                </div>
+                              </div>
+                              <div ref={sourceListRef} className="max-h-48 overflow-y-auto scrollbar-hide py-1">
+                                {sourceOptions.filter((s) =>
+                                  s.toLowerCase().includes(sourceSearch.toLowerCase())
+                                ).map((source, idx) => (
+                                  <button
+                                    key={source}
+                                    type="button"
+                                    onClick={() => {
+                                      setMarketSourceFilter(source);
+                                      setSourceOverflowOpen(false);
+                                      setSourceSearch("");
+                                      setSourceFocusedIndex(-1);
+                                    }}
+                                    className={cn(
+                                      "flex w-full items-center px-3 py-1.5 text-left text-[13px] transition-colors",
+                                      idx === sourceFocusedIndex
+                                        ? "bg-surface-hover text-primary"
+                                        : marketSourceFilter === source
+                                          ? "bg-accent-bg text-accent-light"
+                                          : "text-secondary hover:bg-surface-hover"
+                                    )}
+                                  >
+                                    @{source}
+                                  </button>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## 功能说明

「安装 Skills」页面的来源筛选标签栏，原来标签多时会溢出到看不见的区域，无法点击。本次改为动态溢出方案。

## 改动内容

**`src/views/InstallSkills.tsx`**
- 移除旧的 `overflow-x-auto` 横向滚动方案和 `.slice(0, 8)` 硬限制
- 新增隐藏测量层（`visibility: hidden; position: absolute`），始终渲染所有标签用于宽度测量
- 用 `ResizeObserver` 监听容器宽度变化，实时计算当前行能容纳的最大标签数
- 超出部分折叠进「⋯」按钮；点击弹出浮窗，支持边缘自动左右翻转（`getBoundingClientRect` 检测）
- 浮窗内置搜索框（`autoFocus`，打开即可输入），支持 `↑` / `↓` 键移动高亮、`Enter` 选中、`Escape` 关闭，列表自动 scroll 跟随高亮项
- 点击外部自动关闭，关闭时重置搜索词和键盘高亮状态

**`src/i18n/zh.json` / `en.json`**
- `common` 节新增 `"search"` 翻译 key，供浮窗搜索框 placeholder 使用

## 持久化

纯 UI 交互，无数据持久化。