### PR TITLE
feat: git 安装预览对话框 & git backup 同步修复

### DIFF
--- a/src-tauri/src/commands/git_backup.rs
+++ b/src-tauri/src/commands/git_backup.rs
@@ -71,10 +71,11 @@ pub async fn git_backup_push(
 pub async fn git_backup_pull(
     store: State<'_, Arc<SkillStore>>,
 ) -> Result<(), AppError> {
-    let _ = store;
+    let store = store.inner().clone();
     let skills_dir = central_repo::skills_dir();
     tokio::task::spawn_blocking(move || {
-        git_backup::pull(&skills_dir).map_err(AppError::git)
+        git_backup::pull(&skills_dir).map_err(AppError::git)?;
+        reconcile_skills_index(&store).map_err(AppError::db)
     })
     .await?
 }
@@ -84,10 +85,11 @@ pub async fn git_backup_clone(
     store: State<'_, Arc<SkillStore>>,
     url: String,
 ) -> Result<(), AppError> {
-    let _ = store;
+    let store = store.inner().clone();
     let skills_dir = central_repo::skills_dir();
     tokio::task::spawn_blocking(move || {
-        git_backup::clone_into(&skills_dir, &url).map_err(AppError::git)
+        git_backup::clone_into(&skills_dir, &url).map_err(AppError::git)?;
+        reconcile_skills_index(&store).map_err(AppError::db)
     })
     .await?
 }

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -76,6 +76,25 @@ struct GitSkillSource {
     locator_skill_id: Option<String>,
 }
 
+#[derive(Debug, serde::Serialize)]
+pub struct GitSkillPreview {
+    pub dir_name: String,
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct GitPreviewResult {
+    pub temp_dir: String,
+    pub skills: Vec<GitSkillPreview>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct SkillInstallItem {
+    pub dir_name: String,
+    pub name: String,
+}
+
 struct CancelRegistrationGuard {
     registry: Arc<InstallCancelRegistry>,
     key: String,
@@ -360,6 +379,124 @@ pub async fn install_from_skillssh(
         store_installed_skill(&store, &result, &metadata, active.as_deref())?;
 
         emit_progress("done");
+        Ok(())
+    })
+    .await?
+}
+
+/// Clone a git repo and return a preview list of skills found, without installing.
+/// The caller must follow up with `confirm_git_install` using the returned `temp_dir`.
+#[tauri::command]
+pub async fn preview_git_install(
+    repo_url: String,
+    store: State<'_, Arc<SkillStore>>,
+    cancel_registry: State<'_, Arc<InstallCancelRegistry>>,
+    app_handle: tauri::AppHandle,
+) -> Result<GitPreviewResult, AppError> {
+    let store = store.inner().clone();
+    let proxy_url = store.get_setting("proxy_url").ok().flatten();
+    let registry = cancel_registry.inner().clone();
+    let cancel_key = repo_url.clone();
+    let cancel = registry.register(&cancel_key);
+    let _cancel_guard = CancelRegistrationGuard::new(registry.clone(), cancel_key);
+
+    tauri::async_runtime::spawn_blocking(move || {
+        use tauri::Emitter;
+        app_handle.emit("install-progress", serde_json::json!({
+            "skill_id": repo_url,
+            "phase": "cloning",
+        })).ok();
+
+        let parsed = git_fetcher::parse_git_source(&repo_url);
+        let temp_dir = git_fetcher::clone_repo_ref(
+            &parsed.clone_url,
+            parsed.branch.as_deref(),
+            Some(&cancel),
+            proxy_url.as_deref(),
+        ).map_err(AppError::git_or_cancelled)?;
+
+        let skill_dir = resolve_skill_dir(&temp_dir, parsed.subpath.as_deref(), None)?;
+        let dirs = collect_git_skill_dirs(&skill_dir);
+
+        let skills: Vec<GitSkillPreview> = dirs.iter().map(|dir| {
+            let meta = skill_metadata::parse_skill_md(dir);
+            let dir_name = dir.file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            let name = meta.name
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| dir_name.clone());
+            GitSkillPreview { dir_name, name, description: meta.description }
+        }).collect();
+
+        Ok(GitPreviewResult {
+            temp_dir: temp_dir.to_string_lossy().to_string(),
+            skills,
+        })
+    })
+    .await?
+}
+
+/// Install selected skills from a previously cloned temp directory.
+#[tauri::command]
+pub async fn confirm_git_install(
+    repo_url: String,
+    temp_dir: String,
+    items: Vec<SkillInstallItem>,
+    store: State<'_, Arc<SkillStore>>,
+) -> Result<(), AppError> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let temp_path = PathBuf::from(&temp_dir);
+
+        // Security: temp_path must be inside OS temp dir and carry our prefix.
+        let expected_prefix = std::env::temp_dir();
+        if !temp_path.starts_with(&expected_prefix) {
+            return Err(AppError::invalid_input("Invalid temp directory"));
+        }
+        let dir_name_str = temp_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if !dir_name_str.starts_with("skills-manager-clone-") {
+            return Err(AppError::invalid_input("Invalid temp directory"));
+        }
+        if !temp_path.exists() {
+            return Err(AppError::invalid_input("Clone session expired, please try again"));
+        }
+
+        let parsed = git_fetcher::parse_git_source(&repo_url);
+        let skill_dir = resolve_skill_dir(&temp_path, parsed.subpath.as_deref(), None)?;
+        let all_dirs = collect_git_skill_dirs(&skill_dir);
+        let revision = git_fetcher::get_head_revision(&temp_path).map_err(AppError::git)?;
+        let active = store.get_active_scenario_id().ok().flatten();
+
+        for dir in &all_dirs {
+            let dir_name_entry = dir.file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let item = match items.iter().find(|i| i.dir_name == dir_name_entry) {
+                Some(i) => i,
+                None => continue,
+            };
+            let custom_name = item.name.trim();
+            let install_name = if custom_name.is_empty() { None } else { Some(custom_name) };
+            let result = installer::install_from_git_dir(dir, install_name).map_err(AppError::io)?;
+            let subpath = git_fetcher::relative_subpath(&temp_path, dir);
+            let metadata = InstallSourceMetadata {
+                source_type: "git".to_string(),
+                source_ref: Some(repo_url.clone()),
+                source_ref_resolved: Some(parsed.clone_url.clone()),
+                source_subpath: subpath,
+                source_branch: parsed.branch.clone(),
+                source_revision: Some(revision.clone()),
+                remote_revision: Some(revision.clone()),
+                update_status: "up_to_date".to_string(),
+            };
+            store_installed_skill(&store, &result, &metadata, active.as_deref())?;
+        }
+
+        git_fetcher::cleanup_temp(&temp_path);
         Ok(())
     })
     .await?
@@ -869,6 +1006,28 @@ fn skill_ssh_id(skill: &SkillRecord) -> Option<String> {
     skill.source_ref
         .as_deref()
         .and_then(|source_ref| source_ref.rsplit_once('/').map(|(_, skill_id)| skill_id.to_string()))
+}
+
+/// Return the list of individual skill directories to install from a resolved repo dir.
+/// If `skill_dir` is itself a valid skill, returns `[skill_dir]`.
+/// Otherwise enumerates immediate subdirs that are valid skills; falls back to `[skill_dir]`.
+fn collect_git_skill_dirs(skill_dir: &Path) -> Vec<PathBuf> {
+    if is_valid_skill_dir(skill_dir) {
+        return vec![skill_dir.to_path_buf()];
+    }
+    let mut dirs: Vec<PathBuf> = std::fs::read_dir(skill_dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir() && is_valid_skill_dir(p))
+        .collect();
+    dirs.sort();
+    if dirs.is_empty() {
+        vec![skill_dir.to_path_buf()]
+    } else {
+        dirs
+    }
 }
 
 fn resolve_skill_dir(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,6 +52,8 @@ pub fn run() {
             commands::skills::delete_managed_skill,
             commands::skills::install_local,
             commands::skills::install_git,
+            commands::skills::preview_git_install,
+            commands::skills::confirm_git_install,
             commands::skills::install_from_skillssh,
             commands::skills::check_skill_update,
             commands::skills::check_all_skill_updates,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -218,10 +218,16 @@
     "gitDesc": "Enter a public or private Git repository URL. For private repos, ensure SSH keys are configured.",
     "repoUrl": "Repository URL",
     "repoUrlPlaceholder": "https://github.com/user/repo.git or git@github.com...",
-    "customName": "Custom Name",
-    "customNameOptional": "Optional",
-    "customNamePlaceholder": "Leave blank to use repo name",
-    "installClone": "Install & Clone",
+    "installClone": "Clone & Preview",
+    "gitPreview": {
+      "title": "Select Skills to Import",
+      "description": "The following skills were found in the repository. Rename them if needed, then confirm.",
+      "selectAll": "Select All",
+      "deselectAll": "Deselect All",
+      "namePlaceholder": "Skill name",
+      "confirm": "Import Selected",
+      "empty": "No importable skills found"
+    },
     "scan": {
       "title": "Scan Local Skills",
       "initial": "Scan agent skill folders already present on this machine.",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -218,10 +218,16 @@
     "gitDesc": "输入公共或私有 Git 仓库地址。私有仓库请确保本地已配置对应的 SSH 密钥。",
     "repoUrl": "仓库地址",
     "repoUrlPlaceholder": "https://github.com/user/repo.git 或 git@github.com...",
-    "customName": "自定义名称",
-    "customNameOptional": "可选",
-    "customNamePlaceholder": "留空则使用仓库名称",
-    "installClone": "安装并克隆",
+    "installClone": "克隆并预览",
+    "gitPreview": {
+      "title": "选择要导入的技能",
+      "description": "从仓库中发现了以下技能，可自定义名称后导入。",
+      "selectAll": "全选",
+      "deselectAll": "取消全选",
+      "namePlaceholder": "技能名称",
+      "confirm": "导入选中项",
+      "empty": "未发现可导入的技能"
+    },
     "scan": {
       "title": "扫描本地 Skills 并导入",
       "initial": "扫描当前机器上各 Agent 已安装的 Skills。",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -133,6 +133,28 @@ export const installLocal = (sourcePath: string, name?: string) =>
 export const installGit = (repoUrl: string, name?: string) =>
   invoke<void>("install_git", { repoUrl, name: name || null });
 
+export interface GitSkillPreview {
+  dir_name: string;
+  name: string;
+  description: string | null;
+}
+
+export interface GitPreviewResult {
+  temp_dir: string;
+  skills: GitSkillPreview[];
+}
+
+export interface SkillInstallItem {
+  dir_name: string;
+  name: string;
+}
+
+export const previewGitInstall = (repoUrl: string) =>
+  invoke<GitPreviewResult>("preview_git_install", { repoUrl });
+
+export const confirmGitInstall = (repoUrl: string, tempDir: string, items: SkillInstallItem[]) =>
+  invoke<void>("confirm_git_install", { repoUrl, tempDir, items });
+
 export const installFromSkillssh = (source: string, skillId: string) =>
   invoke<void>("install_from_skillssh", { source, skillId });
 

--- a/src/views/InstallSkills.tsx
+++ b/src/views/InstallSkills.tsx
@@ -18,13 +18,15 @@ import {
   ChevronLeft,
   ChevronRight,
   Search,
+  MoreHorizontal,
+  X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { cn } from "../utils";
 import { useApp } from "../context/AppContext";
 import * as api from "../lib/tauri";
-import type { ScanResult, SkillsShSkill, BatchImportResult } from "../lib/tauri";
+import type { ScanResult, SkillsShSkill, BatchImportResult, GitPreviewResult } from "../lib/tauri";
 import { open } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useSearchParams } from "react-router-dom";
@@ -55,9 +57,11 @@ export function InstallSkills() {
   const [marketReloadKey, setMarketReloadKey] = useState(0);
   const [installing, setInstalling] = useState<string | null>(null);
   const [gitUrl, setGitUrl] = useState("");
-  const [gitName, setGitName] = useState("");
   const [gitLoading, setGitLoading] = useState(false);
   const [gitCancelKey, setGitCancelKey] = useState<string | null>(null);
+  const [gitPreview, setGitPreview] = useState<GitPreviewResult | null>(null);
+  const [gitSelections, setGitSelections] = useState<{ dir_name: string; name: string; description: string | null; selected: boolean }[]>([]);
+  const [gitConfirmLoading, setGitConfirmLoading] = useState(false);
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
   const [scanLoading, setScanLoading] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
@@ -361,13 +365,11 @@ export function InstallSkills() {
     });
   };
 
-  const handleGitInstall = async () => {
+  const handleGitPreview = async () => {
     if (!gitUrl.trim()) return;
     setGitLoading(true);
     const url = gitUrl.trim();
-    const name = gitName.trim() || undefined;
-    const cancelKey = url;
-    setGitCancelKey(cancelKey);
+    setGitCancelKey(url);
 
     const toastId = toast.loading(t("install.toast.cloning"));
     let unlisten: (() => void) | null = null;
@@ -376,19 +378,21 @@ export function InstallSkills() {
       unlisten = await listen<{ skill_id: string; phase: string }>(
         "install-progress",
         (event) => {
-          if (event.payload.skill_id !== cancelKey) return;
+          if (event.payload.skill_id !== url) return;
           if (event.payload.phase === "cloning") {
             toast.loading(t("install.toast.cloning"), { id: toastId });
-          } else if (event.payload.phase === "installing") {
-            toast.loading(t("install.toast.installing", { name: name || url }), { id: toastId });
           }
         }
       );
-      await api.installGit(url, name);
-      setGitUrl("");
-      setGitName("");
-      await Promise.all([refreshScenarios(), refreshManagedSkills()]);
-      toast.success(t("install.toast.success", { name: name || url }), { id: toastId });
+      const preview = await api.previewGitInstall(url);
+      toast.dismiss(toastId);
+      setGitPreview(preview);
+      setGitSelections(preview.skills.map((s) => ({
+        dir_name: s.dir_name,
+        name: s.name,
+        description: s.description,
+        selected: true,
+      })));
     } catch (error: unknown) {
       if (getErrorKind(error) === "cancelled") {
         toast.info(t("install.toast.cancelled"), { id: toastId });
@@ -399,6 +403,29 @@ export function InstallSkills() {
       setGitLoading(false);
       setGitCancelKey(null);
       unlisten?.();
+    }
+  };
+
+  const handleGitConfirm = async () => {
+    if (!gitPreview) return;
+    const selected = gitSelections.filter((s) => s.selected);
+    if (selected.length === 0) return;
+    setGitConfirmLoading(true);
+    try {
+      await api.confirmGitInstall(
+        gitUrl.trim(),
+        gitPreview.temp_dir,
+        selected.map((s) => ({ dir_name: s.dir_name, name: s.name }))
+      );
+      await Promise.all([refreshScenarios(), refreshManagedSkills()]);
+      toast.success(t("install.toast.success", { name: selected.map((s) => s.name).join(", ") }));
+      setGitUrl("");
+      setGitPreview(null);
+      setGitSelections([]);
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("common.error")));
+    } finally {
+      setGitConfirmLoading(false);
     }
   };
 
@@ -1035,23 +1062,8 @@ export function InstallSkills() {
                   type="text"
                   value={gitUrl}
                   onChange={(e) => setGitUrl(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === "Enter" && !gitLoading && gitUrl.trim()) handleGitPreview(); }}
                   placeholder={t("install.repoUrlPlaceholder")}
-                  disabled={gitLoading}
-                  className="app-input w-full bg-background"
-                />
-              </div>
-              <div>
-                <label className="mb-1 flex items-center gap-2 text-[13px] font-medium text-tertiary">
-                  {t("install.customName")}
-                  <span className="text-[13px] font-normal text-muted">
-                    {t("install.customNameOptional")}
-                  </span>
-                </label>
-                <input
-                  type="text"
-                  value={gitName}
-                  onChange={(e) => setGitName(e.target.value)}
-                  placeholder={t("install.customNamePlaceholder")}
                   disabled={gitLoading}
                   className="app-input w-full bg-background"
                 />
@@ -1068,7 +1080,7 @@ export function InstallSkills() {
                   </button>
                 ) : (
                   <button
-                    onClick={handleGitInstall}
+                    onClick={handleGitPreview}
                     disabled={!gitUrl.trim()}
                     className="app-button-primary flex w-full"
                   >
@@ -1077,6 +1089,116 @@ export function InstallSkills() {
                   </button>
                 )}
               </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Git preview / selection dialog */}
+      {gitPreview && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+            onClick={() => { setGitPreview(null); setGitSelections([]); }}
+          />
+          <div className="relative w-full max-w-md rounded-xl border border-border bg-surface p-5 shadow-2xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-[14px] font-semibold text-primary">{t("install.gitPreview.title")}</h2>
+              <button
+                onClick={() => { setGitPreview(null); setGitSelections([]); }}
+                className="rounded p-1 text-muted transition-colors hover:text-secondary"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <p className="mb-3 text-[13px] text-muted">{t("install.gitPreview.description")}</p>
+
+            {/* Select all / deselect all */}
+            <div className="mb-2 flex gap-2">
+              <button
+                type="button"
+                onClick={() => setGitSelections((prev) => prev.map((s) => ({ ...s, selected: true })))}
+                className="text-[13px] text-accent-light hover:underline"
+              >
+                {t("install.gitPreview.selectAll")}
+              </button>
+              <span className="text-faint">·</span>
+              <button
+                type="button"
+                onClick={() => setGitSelections((prev) => prev.map((s) => ({ ...s, selected: false })))}
+                className="text-[13px] text-muted hover:underline"
+              >
+                {t("install.gitPreview.deselectAll")}
+              </button>
+            </div>
+
+            {gitSelections.length === 0 ? (
+              <p className="py-6 text-center text-[13px] text-muted">{t("install.gitPreview.empty")}</p>
+            ) : (
+              <div className="max-h-64 space-y-2 overflow-y-auto scrollbar-hide pr-1">
+                {gitSelections.map((item, idx) => (
+                  <div
+                    key={item.dir_name}
+                    className={cn(
+                      "flex items-center gap-3 rounded-lg border px-3 py-2 transition-colors",
+                      item.selected
+                        ? "border-accent-border bg-accent-bg/40"
+                        : "border-border-subtle bg-background opacity-50"
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={item.selected}
+                      onChange={(e) =>
+                        setGitSelections((prev) =>
+                          prev.map((s, i) => i === idx ? { ...s, selected: e.target.checked } : s)
+                        )
+                      }
+                      className="h-4 w-4 shrink-0 accent-accent"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <input
+                        type="text"
+                        value={item.name}
+                        onChange={(e) =>
+                          setGitSelections((prev) =>
+                            prev.map((s, i) => i === idx ? { ...s, name: e.target.value } : s)
+                          )
+                        }
+                        disabled={!item.selected}
+                        placeholder={t("install.gitPreview.namePlaceholder")}
+                        className="app-input w-full bg-background py-1 text-[13px]"
+                      />
+                      {item.description ? (
+                        <p className="mt-1 truncate text-[12px] text-muted">{item.description}</p>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => { setGitPreview(null); setGitSelections([]); }}
+                className="px-3 py-1.5 text-[13px] font-medium text-muted hover:text-secondary transition-colors"
+              >
+                {t("common.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={handleGitConfirm}
+                disabled={gitConfirmLoading || gitSelections.every((s) => !s.selected)}
+                className="app-button-primary"
+              >
+                {gitConfirmLoading ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <DownloadCloud className="h-3.5 w-3.5" />
+                )}
+                {t("install.gitPreview.confirm")}
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 改动说明

### 问题一：git pull / clone 后技能不出现在 UI

`git_backup_pull` 和 `git_backup_clone` 命令只执行 git 操作，不同步 DB。`restore_version` 已有 `reconcile_skills_index` 调用，pull / clone 缺失。

**修复**：`git_backup_pull` 和 `git_backup_clone` 成功后调用 `reconcile_skills_index`，把文件系统变动同步进 DB，UI 立即刷新。

### 问题二：git 安装会把整个仓库当成一个大包装入

`find_skill_dir` 找到容器目录（如 `skills/`）后，`install_git` 将其整体安装为单一技能，而不是拆分每个子技能。

**修复**：新增 `collect_git_skill_dirs` 辅助函数：
- 若目标目录本身是有效 skill（含 `SKILL.md` 等标记）→ 单包安装（原逻辑）
- 否则枚举一级子目录中所有有效 skill 目录 → 多包拆分安装
- 无法识别时 fallback 到原逻辑

### 新功能：git 安装改为两步预览流程

原来是一键 clone + 安装，现在改为：

1. **预览**：`preview_git_install` 克隆仓库，返回发现的 skill 目录列表（含名称、描述），临时目录保留
2. **选择对话框**：前端弹出选择面板，默认全选，每项支持**重命名**
3. **确认**：`confirm_git_install` 按选择结果安装，清理临时目录

移除了原有的"自定义名称"输入框（多技能场景下无意义，改为对话框内逐项重命名）。

## 改动范围

| 文件 | 类型 |
|------|------|
| `src-tauri/src/commands/git_backup.rs` | 修改（2 处，各加 1 行） |
| `src-tauri/src/commands/skills.rs` | 新增（3 个结构体 + 2 个命令 + 1 个辅助函数） |
| `src-tauri/src/lib.rs` | 注册 2 个新命令 |
| `src/lib/tauri.ts` | 新增类型和封装函数 |
| `src/views/InstallSkills.tsx` | 替换 git tab 逻辑与 UI，其余 tab 完全未动 |
| `src/i18n/zh.json` / `en.json` | 移除旧 customName key，新增 gitPreview.* key |

原有 `install_git` 命令保留，无破坏性变更。