### PR TITLE
feat: 批量启用/停用 Skill 及批量更新到项目

### DIFF
--- a/src/components/MultiSelectToolbar.tsx
+++ b/src/components/MultiSelectToolbar.tsx
@@ -1,0 +1,84 @@
+import { Trash2, CheckCircle2, Circle } from "lucide-react";
+import { cn } from "../utils";
+
+interface MultiSelectToolbarLabels {
+  hint: string;
+  selected: string;
+  delete: string;
+  enable: string;
+  disable: string;
+  selectAll: string;
+  deselectAll: string;
+  cancel: string;
+}
+
+interface MultiSelectToolbarProps {
+  selectedCount: number;
+  isAllSelected: boolean;
+  anyDisabled: boolean;
+  showToggle: boolean;
+  labels: MultiSelectToolbarLabels;
+  onDelete: () => void;
+  onToggle: () => void;
+  onSelectAll: () => void;
+  onCancel: () => void;
+}
+
+export function MultiSelectToolbar({
+  selectedCount,
+  isAllSelected,
+  anyDisabled,
+  showToggle,
+  labels,
+  onDelete,
+  onToggle,
+  onSelectAll,
+  onCancel,
+}: MultiSelectToolbarProps) {
+  return (
+    <div className="flex items-center gap-2 px-1 py-1.5">
+      <span className="text-[13px] text-muted">
+        {selectedCount > 0 ? labels.selected : labels.hint}
+      </span>
+      {selectedCount > 0 && (
+        <>
+          <button
+            onClick={onDelete}
+            className="inline-flex items-center gap-1.5 rounded-md bg-red-600/90 px-2.5 py-1 text-[13px] font-medium text-white hover:bg-red-500 transition-colors"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            {labels.delete}
+          </button>
+          {showToggle && (
+            <button
+              onClick={onToggle}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[13px] font-medium text-white transition-colors",
+                anyDisabled
+                  ? "bg-emerald-600/90 hover:bg-emerald-500"
+                  : "bg-amber-600/90 hover:bg-amber-500"
+              )}
+            >
+              {anyDisabled
+                ? <CheckCircle2 className="h-3.5 w-3.5" />
+                : <Circle className="h-3.5 w-3.5" />}
+              {anyDisabled ? labels.enable : labels.disable}
+            </button>
+          )}
+        </>
+      )}
+      <button
+        onClick={onSelectAll}
+        className="rounded-md px-2.5 py-1 text-[13px] font-medium text-muted hover:text-secondary hover:bg-surface-hover transition-colors"
+      >
+        {isAllSelected ? labels.deselectAll : labels.selectAll}
+      </button>
+      <button
+        onClick={onCancel}
+        className="rounded-md px-2.5 py-1 text-[13px] font-medium text-muted hover:text-secondary hover:bg-surface-hover transition-colors"
+      >
+        {labels.cancel}
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useMultiSelect.ts
+++ b/src/hooks/useMultiSelect.ts
@@ -1,0 +1,56 @@
+import { useState } from "react";
+
+interface UseMultiSelectOptions<T> {
+  items: T[];
+  filtered: T[];
+  getKey: (item: T) => string;
+  isItemActive: (item: T) => boolean;
+}
+
+export function useMultiSelect<T>({
+  items,
+  filtered,
+  getKey,
+  isItemActive,
+}: UseMultiSelectOptions<T>) {
+  const [isMultiSelect, setIsMultiSelect] = useState(false);
+  const [selectedIds, setSelectedIds] = useState(new Set<string>());
+
+  const toggleSelect = (key: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const isAllSelected =
+    filtered.length > 0 && filtered.every((s) => selectedIds.has(getKey(s)));
+
+  const anyDisabled = items
+    .filter((s) => selectedIds.has(getKey(s)))
+    .some((s) => !isItemActive(s));
+
+  const handleSelectAll = () => {
+    setSelectedIds(
+      isAllSelected ? new Set<string>() : new Set(filtered.map(getKey))
+    );
+  };
+
+  const exitMultiSelect = () => {
+    setIsMultiSelect(false);
+    setSelectedIds(new Set<string>());
+  };
+
+  return {
+    isMultiSelect,
+    setIsMultiSelect,
+    selectedIds,
+    toggleSelect,
+    isAllSelected,
+    anyDisabled,
+    handleSelectAll,
+    exitMultiSelect,
+  };
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -161,7 +161,13 @@
     "batchDeleteConfirm": "Delete {{count}} selected skills permanently? This removes their central library files, scenario links, and synced agent targets.",
     "batchDeleted": "{{count}} skills deleted",
     "batchDeleteFailed": "{{count}} skills failed to delete",
-    "cancelSelect": "Cancel selection"
+    "cancelSelect": "Cancel selection",
+    "selectAll": "Select All",
+    "deselectAll": "Deselect All",
+    "batchEnable": "Enable {{count}}",
+    "batchDisable": "Disable {{count}}",
+    "batchEnabled": "{{count}} skills enabled",
+    "batchDisabled": "{{count}} skills disabled"
   },
   "install": {
     "title": "Install Skills",
@@ -465,8 +471,21 @@
     "searchCenterSkills": "Search skills in the central library...",
     "noSkillsToExport": "No skills available to update from center",
     "import": "Update",
+    "updateSelected": "Update {{count}}",
+    "batchImported": "{{count}} skills updated",
     "deleteSkill": "Delete skill",
     "deleteSkillConfirm": "Permanently delete skill \"{{name}}\"? This action cannot be undone.",
-    "skillDeleted": "\"{{name}}\" deleted"
+    "skillDeleted": "\"{{name}}\" deleted",
+    "selectMode": "Select",
+    "cancelSelect": "Exit Select",
+    "selectedCount": "{{count}} selected",
+    "selectHint": "Click skills to select",
+    "deleteSelected": "Delete {{count}}",
+    "batchDeleteConfirm": "Permanently delete {{count}} selected skills? This action cannot be undone.",
+    "batchDeleted": "{{count}} skills deleted",
+    "batchEnable": "Enable {{count}}",
+    "batchDisable": "Disable {{count}}",
+    "batchEnabled": "{{count}} skills enabled",
+    "batchDisabled": "{{count}} skills disabled"
   }
 }

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -161,7 +161,13 @@
     "batchDeleteConfirm": "确定彻底删除选中的 {{count}} 个 Skill 吗？中央仓库文件、场景关联和已同步到各 Agent 的目标都会被移除。",
     "batchDeleted": "已删除 {{count}} 个 Skill",
     "batchDeleteFailed": "{{count}} 个 Skill 删除失败",
-    "cancelSelect": "取消多选"
+    "cancelSelect": "取消多选",
+    "selectAll": "全选",
+    "deselectAll": "取消全选",
+    "batchEnable": "启用 {{count}} 个",
+    "batchDisable": "停用 {{count}} 个",
+    "batchEnabled": "已启用 {{count}} 个 Skill",
+    "batchDisabled": "已停用 {{count}} 个 Skill"
   },
   "install": {
     "title": "安装 Skills",
@@ -465,8 +471,21 @@
     "searchCenterSkills": "搜索中央仓库中的 Skills...",
     "noSkillsToExport": "中央仓库中没有可更新到项目的 Skill",
     "import": "更新",
+    "updateSelected": "更新 {{count}} 个",
+    "batchImported": "已更新 {{count}} 个 Skill",
     "deleteSkill": "删除 Skill",
     "deleteSkillConfirm": "确定永久删除 Skill \"{{name}}\" 吗？此操作不可恢复。",
-    "skillDeleted": "\"{{name}}\" 已删除"
+    "skillDeleted": "\"{{name}}\" 已删除",
+    "selectMode": "多选",
+    "cancelSelect": "退出多选",
+    "selectedCount": "已选 {{count}} 个",
+    "selectHint": "点击 Skill 开始选择",
+    "deleteSelected": "删除 {{count}} 个",
+    "batchDeleteConfirm": "确定永久删除选中的 {{count}} 个 Skill 吗？此操作不可恢复。",
+    "batchDeleted": "已删除 {{count}} 个 Skill",
+    "batchEnable": "启用 {{count}} 个",
+    "batchDisable": "停用 {{count}} 个",
+    "batchEnabled": "已启用 {{count}} 个 Skill",
+    "batchDisabled": "已停用 {{count}} 个 Skill"
   }
 }

--- a/src/views/MySkills.tsx
+++ b/src/views/MySkills.tsx
@@ -25,8 +25,10 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { cn } from "../utils";
 import { useApp } from "../context/AppContext";
+import { useMultiSelect } from "../hooks/useMultiSelect";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { SkillDetailPanel } from "../components/SkillDetailPanel";
+import { MultiSelectToolbar } from "../components/MultiSelectToolbar";
 import * as api from "../lib/tauri";
 import type { ManagedSkill, ToolInfo, GitBackupStatus, GitBackupVersion } from "../lib/tauri";
 import { getErrorMessage, getErrorKind } from "../lib/error";
@@ -64,6 +66,7 @@ export function MySkills() {
   const [allTags, setAllTags] = useState<string[]>([]);
   const [search, setSearch] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<ManagedSkill | null>(null);
+  const [batchDeleteConfirm, setBatchDeleteConfirm] = useState(false);
   const [syncingSkillId, setSyncingSkillId] = useState<string | null>(null);
   const [checkingAll, setCheckingAll] = useState(false);
   const [checkingSkillId, setCheckingSkillId] = useState<string | null>(null);
@@ -79,9 +82,6 @@ export function MySkills() {
   const [tagEditSkillId, setTagEditSkillId] = useState<string | null>(null);
   const [tagInput, setTagInput] = useState("");
   const tagInputRef = useRef<HTMLInputElement>(null);
-  const [isMultiSelect, setIsMultiSelect] = useState(false);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [batchDeleteConfirm, setBatchDeleteConfirm] = useState(false);
 
   const installedTools = tools.filter((tool) => tool.installed && tool.enabled);
   const activeScenarioName = activeScenario?.name || t("mySkills.currentScenarioFallback");
@@ -136,6 +136,21 @@ export function MySkills() {
 
     return result;
   }, [skills, search, sourceFilters, tagFilters, filterMode, activeScenario]);
+
+  const {
+    isMultiSelect, setIsMultiSelect,
+    selectedIds,
+    toggleSelect,
+    isAllSelected,
+    anyDisabled,
+    handleSelectAll,
+    exitMultiSelect,
+  } = useMultiSelect({
+    items: skills,
+    filtered,
+    getKey: (s) => s.id,
+    isItemActive: (s) => activeScenario ? s.scenario_ids.includes(activeScenario.id) : true,
+  });
 
   const selectedSkill = useMemo(
     () => skills.find((skill) => skill.id === detailSkillId) || null,
@@ -320,37 +335,43 @@ export function MySkills() {
     await Promise.all([refreshManagedSkills(), refreshScenarios()]);
   };
 
-  const toggleSelect = (id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
-
   const handleBatchDelete = async () => {
     const ids = Array.from(selectedIds);
-    let deleted = 0;
-    for (const id of ids) {
-      try {
+    try {
+      for (const id of ids) {
         await api.deleteManagedSkill(id);
         if (selectedSkill?.id === id) closeSkillDetail();
-        deleted++;
-      } catch {
-        // continue deleting remaining
       }
+      toast.success(t("mySkills.batchDeleted", { count: ids.length }));
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("common.error")));
+    } finally {
+      exitMultiSelect();
+      setBatchDeleteConfirm(false);
+      await Promise.all([refreshManagedSkills(), refreshScenarios()]);
     }
-    if (deleted < ids.length) {
-      toast.error(t("mySkills.batchDeleteFailed", { count: ids.length - deleted }));
+  };
+
+  const handleBatchToggleScenario = async () => {
+    if (!activeScenario) return;
+    const selectedSkillsList = skills.filter((s) => selectedIds.has(s.id));
+    try {
+      for (const skill of selectedSkillsList) {
+        const enabledInScenario = skill.scenario_ids.includes(activeScenario.id);
+        if (anyDisabled && !enabledInScenario) {
+          await api.addSkillToScenario(skill.id, activeScenario.id);
+        } else if (!anyDisabled && enabledInScenario) {
+          await api.removeSkillFromScenario(skill.id, activeScenario.id);
+        }
+      }
+      toast.success(anyDisabled
+        ? t("mySkills.batchEnabled", { count: selectedIds.size })
+        : t("mySkills.batchDisabled", { count: selectedIds.size }));
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("common.error")));
+    } finally {
+      await Promise.all([refreshManagedSkills(), refreshScenarios()]);
     }
-    if (deleted > 0) {
-      toast.success(t("mySkills.batchDeleted", { count: deleted }));
-    }
-    setSelectedIds(new Set());
-    setIsMultiSelect(false);
-    setBatchDeleteConfirm(false);
-    await Promise.all([refreshManagedSkills(), refreshScenarios()]);
   };
 
   const handleToggleScenario = async (skill: ManagedSkill) => {
@@ -545,13 +566,6 @@ export function MySkills() {
         label: t("mySkills.gitRepoNeedRemote"),
         disabled: true,
         toneClassName: "text-red-500",
-      };
-    }
-    if (gitStatus.behind > 0 && (gitStatus.has_changes || gitStatus.ahead > 0)) {
-      return {
-        label: t("mySkills.gitRepoSync"),
-        disabled: false,
-        toneClassName: "text-amber-500",
       };
     }
     if (gitStatus.has_changes || gitStatus.ahead > 0 || gitStatus.behind > 0) {
@@ -766,7 +780,7 @@ export function MySkills() {
             <List className="h-4 w-4" />
           </button>
           <button
-            onClick={() => { setIsMultiSelect((v) => !v); setSelectedIds(new Set()); }}
+            onClick={() => isMultiSelect ? exitMultiSelect() : setIsMultiSelect(true)}
             className={cn(
               "rounded-md p-2 transition-colors outline-none",
               isMultiSelect ? "bg-surface-active text-secondary" : "text-muted hover:text-tertiary"
@@ -837,28 +851,26 @@ export function MySkills() {
       </div>
 
       {isMultiSelect && (
-        <div className="flex items-center gap-2 px-1 py-1.5">
-          <span className="text-[13px] text-muted">
-            {selectedIds.size > 0
-              ? t("mySkills.selectedCount", { count: selectedIds.size })
-              : t("mySkills.selectHint")}
-          </span>
-          {selectedIds.size > 0 && (
-            <button
-              onClick={() => setBatchDeleteConfirm(true)}
-              className="inline-flex items-center gap-1.5 rounded-md bg-red-600/90 px-2.5 py-1 text-[13px] font-medium text-white hover:bg-red-500 transition-colors"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-              {t("mySkills.deleteSelected", { count: selectedIds.size })}
-            </button>
-          )}
-          <button
-            onClick={() => { setIsMultiSelect(false); setSelectedIds(new Set()); }}
-            className="rounded-md px-2.5 py-1 text-[13px] font-medium text-muted hover:text-secondary hover:bg-surface-hover transition-colors"
-          >
-            {t("common.cancel")}
-          </button>
-        </div>
+        <MultiSelectToolbar
+          selectedCount={selectedIds.size}
+          isAllSelected={isAllSelected}
+          anyDisabled={activeScenario ? anyDisabled : false}
+          showToggle={!!activeScenario}
+          labels={{
+            hint: t("mySkills.selectHint"),
+            selected: t("mySkills.selectedCount", { count: selectedIds.size }),
+            delete: t("mySkills.deleteSelected", { count: selectedIds.size }),
+            enable: t("mySkills.batchEnable", { count: selectedIds.size }),
+            disable: t("mySkills.batchDisable", { count: selectedIds.size }),
+            selectAll: t("mySkills.selectAll"),
+            deselectAll: t("mySkills.deselectAll"),
+            cancel: t("common.cancel"),
+          }}
+          onDelete={() => setBatchDeleteConfirm(true)}
+          onToggle={handleBatchToggleScenario}
+          onSelectAll={handleSelectAll}
+          onCancel={exitMultiSelect}
+        />
       )}
 
       {gitVersionsOpen && gitStatus?.is_repo && (

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -14,12 +14,16 @@ import {
   X,
   Loader2,
   Trash2,
+  SquareCheck,
+  Square,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { useApp } from "../context/AppContext";
+import { useMultiSelect } from "../hooks/useMultiSelect";
 import { ConfirmDialog } from "../components/ConfirmDialog";
+import { MultiSelectToolbar } from "../components/MultiSelectToolbar";
 import { SkillMarkdown } from "../components/SkillMarkdown";
 import { cn } from "../utils";
 import * as api from "../lib/tauri";
@@ -74,6 +78,7 @@ export function ProjectDetail() {
   const [togglingSkill, setTogglingSkill] = useState<string | null>(null);
   const [showExportDialog, setShowExportDialog] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<ProjectSkill | null>(null);
+  const [batchDeleteConfirm, setBatchDeleteConfirm] = useState(false);
 
   const project = projects.find((p) => p.id === id);
 
@@ -111,6 +116,21 @@ export function ProjectDetail() {
       return true;
     });
   }, [skills, search, filterMode]);
+
+  const {
+    isMultiSelect, setIsMultiSelect,
+    selectedIds,
+    toggleSelect,
+    isAllSelected,
+    anyDisabled,
+    handleSelectAll,
+    exitMultiSelect,
+  } = useMultiSelect({
+    items: skills,
+    filtered,
+    getKey: (s) => s.dir_name,
+    isItemActive: (s) => s.enabled,
+  });
 
   const enabledCount = skills.filter((s) => s.enabled).length;
 
@@ -191,6 +211,21 @@ export function ProjectDetail() {
     }
   };
 
+  const handleBatchExportFromCenter = async (skills: ManagedSkill[]) => {
+    if (!id) return;
+    try {
+      for (const skill of skills) {
+        await api.exportSkillToProject(skill.id, id);
+      }
+      toast.success(t("project.batchImported", { count: skills.length }));
+      setShowExportDialog(false);
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("common.error")));
+    } finally {
+      await loadSkills();
+    }
+  };
+
   const handleDeleteSkill = async () => {
     if (!id || !deleteTarget) return;
     try {
@@ -199,6 +234,44 @@ export function ProjectDetail() {
       await loadSkills();
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
+    }
+  };
+
+  const handleBatchDeleteProject = async () => {
+    if (!id) return;
+    const dirNames = Array.from(selectedIds);
+    try {
+      for (const dirName of dirNames) {
+        await api.deleteProjectSkill(id, dirName);
+      }
+      toast.success(t("project.batchDeleted", { count: dirNames.length }));
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("common.error")));
+    } finally {
+      exitMultiSelect();
+      setBatchDeleteConfirm(false);
+      await loadSkills();
+    }
+  };
+
+  const handleBatchToggleProject = async () => {
+    if (!id) return;
+    const selectedSkillsList = skills.filter((s) => selectedIds.has(s.dir_name));
+    try {
+      for (const skill of selectedSkillsList) {
+        if (anyDisabled && !skill.enabled) {
+          await api.toggleProjectSkill(id, skill.dir_name, true);
+        } else if (!anyDisabled && skill.enabled) {
+          await api.toggleProjectSkill(id, skill.dir_name, false);
+        }
+      }
+      toast.success(anyDisabled
+        ? t("project.batchEnabled", { count: selectedIds.size })
+        : t("project.batchDisabled", { count: selectedIds.size }));
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("common.error")));
+    } finally {
+      await loadSkills();
     }
   };
 
@@ -281,8 +354,41 @@ export function ProjectDetail() {
           >
             <List className="h-4 w-4" />
           </button>
+          <button
+            onClick={() => isMultiSelect ? exitMultiSelect() : setIsMultiSelect(true)}
+            className={cn(
+              "rounded-md p-2 transition-colors outline-none",
+              isMultiSelect ? "bg-surface-active text-secondary" : "text-muted hover:text-tertiary"
+            )}
+            title={isMultiSelect ? t("project.cancelSelect") : t("project.selectMode")}
+          >
+            <SquareCheck className="h-4 w-4" />
+          </button>
         </div>
       </div>
+
+      {isMultiSelect && (
+        <MultiSelectToolbar
+          selectedCount={selectedIds.size}
+          isAllSelected={isAllSelected}
+          anyDisabled={anyDisabled}
+          showToggle={true}
+          labels={{
+            hint: t("project.selectHint"),
+            selected: t("project.selectedCount", { count: selectedIds.size }),
+            delete: t("project.deleteSelected", { count: selectedIds.size }),
+            enable: t("project.batchEnable", { count: selectedIds.size }),
+            disable: t("project.batchDisable", { count: selectedIds.size }),
+            selectAll: t("project.selectAll"),
+            deselectAll: t("project.deselectAll"),
+            cancel: t("common.cancel"),
+          }}
+          onDelete={() => setBatchDeleteConfirm(true)}
+          onToggle={handleBatchToggleProject}
+          onSelectAll={handleSelectAll}
+          onCancel={exitMultiSelect}
+        />
+      )}
 
       {loading ? (
         <div className="flex flex-1 flex-col items-center justify-center pb-20 text-center">
@@ -308,6 +414,7 @@ export function ProjectDetail() {
           )}
         >
           {filtered.map((skill) => {
+            const isSelected = selectedIds.has(skill.dir_name);
             const isUpdatingCenter = updatingCenterSkill === skill.dir_name;
             const isUpdatingProject = updatingProjectSkill === skill.dir_name;
             const isToggling = togglingSkill === skill.dir_name;
@@ -328,13 +435,22 @@ export function ProjectDetail() {
                   className={cn(
                     "app-panel group relative flex flex-col overflow-hidden transition-all hover:border-border hover:bg-surface-hover",
                     skill.enabled && "border-l-2 border-l-accent",
-                    !skill.enabled && "opacity-60"
+                    !skill.enabled && "opacity-60",
+                    isMultiSelect && "cursor-pointer",
+                    isMultiSelect && isSelected && "ring-1 ring-accent border-accent/40"
                   )}
+                  onClick={isMultiSelect ? () => toggleSelect(skill.dir_name) : undefined}
                 >
                   <div className="flex items-center gap-2.5 px-3.5 pt-3 pb-1.5">
+                    {isMultiSelect && (
+                      isSelected
+                        ? <SquareCheck className="h-3.5 w-3.5 shrink-0 text-accent" />
+                        : <Square className="h-3.5 w-3.5 shrink-0 text-faint" />
+                    )}
                     <h3
-                      className="flex-1 cursor-pointer truncate text-[14px] font-semibold text-primary hover:text-accent-light"
-                      onClick={() => handleOpenDetail(skill)}
+                      className="flex-1 truncate text-[14px] font-semibold text-primary"
+                      onClick={!isMultiSelect ? () => handleOpenDetail(skill) : undefined}
+                      style={!isMultiSelect ? { cursor: "pointer" } : undefined}
                       title={skill.name}
                     >
                       {skill.name}
@@ -364,67 +480,69 @@ export function ProjectDetail() {
                         </span>
                       )}
                     </div>
-                    <div className="flex items-center gap-1.5 shrink-0">
-                      {canUpdateCenter && (
+                    {!isMultiSelect && (
+                      <div className="flex items-center gap-1.5 shrink-0">
+                        {canUpdateCenter && (
+                          <button
+                            onClick={() => handleUpdateCenter(skill)}
+                            disabled={isUpdatingCenter || isUpdatingProject}
+                            className="rounded px-2 py-1 text-[13px] font-medium text-muted transition-colors outline-none hover:bg-surface-hover hover:text-secondary disabled:opacity-50"
+                            title={t("project.updateCenter")}
+                          >
+                            {isUpdatingCenter ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                              <Upload className="h-3.5 w-3.5" />
+                            )}
+                          </button>
+                        )}
+                        {canUpdateProject && (
+                          <button
+                            onClick={() => handleUpdateProject(skill)}
+                            disabled={isUpdatingCenter || isUpdatingProject}
+                            className="rounded px-2 py-1 text-[13px] font-medium text-muted transition-colors outline-none hover:bg-surface-hover hover:text-secondary disabled:opacity-50"
+                            title={
+                              skill.sync_status === "project_newer"
+                                ? t("project.resetFromCenter")
+                                : t("project.updateProject")
+                            }
+                          >
+                            {isUpdatingProject ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : skill.sync_status === "project_newer" ? (
+                              <RotateCcw className="h-3.5 w-3.5" />
+                            ) : (
+                              <Download className="h-3.5 w-3.5" />
+                            )}
+                          </button>
+                        )}
                         <button
-                          onClick={() => handleUpdateCenter(skill)}
-                          disabled={isUpdatingCenter || isUpdatingProject}
-                          className="rounded px-2 py-1 text-[13px] font-medium text-muted transition-colors outline-none hover:bg-surface-hover hover:text-secondary disabled:opacity-50"
-                          title={t("project.updateCenter")}
+                          onClick={() => handleToggleSkill(skill)}
+                          disabled={isToggling}
+                          className={cn(
+                            "rounded px-2 py-1 text-[13px] font-medium transition-colors outline-none",
+                            skill.enabled
+                              ? "text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10"
+                              : "text-muted hover:bg-surface-hover hover:text-secondary"
+                          )}
                         >
-                          {isUpdatingCenter ? (
+                          {isToggling ? (
                             <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : skill.enabled ? (
+                            t("project.enabled")
                           ) : (
-                            <Upload className="h-3.5 w-3.5" />
+                            t("project.enableSkill")
                           )}
                         </button>
-                      )}
-                      {canUpdateProject && (
                         <button
-                          onClick={() => handleUpdateProject(skill)}
-                          disabled={isUpdatingCenter || isUpdatingProject}
-                          className="rounded px-2 py-1 text-[13px] font-medium text-muted transition-colors outline-none hover:bg-surface-hover hover:text-secondary disabled:opacity-50"
-                          title={
-                            skill.sync_status === "project_newer"
-                              ? t("project.resetFromCenter")
-                              : t("project.updateProject")
-                          }
+                          onClick={() => setDeleteTarget(skill)}
+                          className="rounded px-2 py-1 text-muted transition-colors outline-none opacity-0 group-hover:opacity-100 hover:bg-red-500/10 hover:text-red-500"
+                          title={t("project.deleteSkill")}
                         >
-                          {isUpdatingProject ? (
-                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          ) : skill.sync_status === "project_newer" ? (
-                            <RotateCcw className="h-3.5 w-3.5" />
-                          ) : (
-                            <Download className="h-3.5 w-3.5" />
-                          )}
+                          <Trash2 className="h-3.5 w-3.5" />
                         </button>
-                      )}
-                      <button
-                        onClick={() => handleToggleSkill(skill)}
-                        disabled={isToggling}
-                        className={cn(
-                          "rounded px-2 py-1 text-[13px] font-medium transition-colors outline-none",
-                          skill.enabled
-                            ? "text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10"
-                            : "text-muted hover:bg-surface-hover hover:text-secondary"
-                        )}
-                      >
-                        {isToggling ? (
-                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                        ) : skill.enabled ? (
-                          t("project.enabled")
-                        ) : (
-                          t("project.enableSkill")
-                        )}
-                      </button>
-                      <button
-                        onClick={() => setDeleteTarget(skill)}
-                        className="rounded px-2 py-1 text-muted transition-colors outline-none opacity-0 group-hover:opacity-100 hover:bg-red-500/10 hover:text-red-500"
-                        title={t("project.deleteSkill")}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
+                      </div>
+                    )}
                   </div>
                 </div>
               );
@@ -437,12 +555,21 @@ export function ProjectDetail() {
                 className={cn(
                   "app-panel group flex items-center gap-3.5 rounded-xl border-transparent px-3.5 py-3 transition-all hover:border-border hover:bg-surface-hover",
                   skill.enabled && "border-l-2 border-l-accent",
-                  !skill.enabled && "opacity-60"
+                  !skill.enabled && "opacity-60",
+                  isMultiSelect && "cursor-pointer",
+                  isMultiSelect && isSelected && "ring-1 ring-accent border-accent/40"
                 )}
+                onClick={isMultiSelect ? () => toggleSelect(skill.dir_name) : undefined}
               >
+                {isMultiSelect && (
+                  isSelected
+                    ? <SquareCheck className="h-3.5 w-3.5 shrink-0 text-accent" />
+                    : <Square className="h-3.5 w-3.5 shrink-0 text-faint" />
+                )}
                 <h3
-                  className="w-[180px] shrink-0 truncate cursor-pointer text-[14px] font-semibold text-secondary hover:text-primary"
-                  onClick={() => handleOpenDetail(skill)}
+                  className="w-[180px] shrink-0 truncate text-[14px] font-semibold text-secondary"
+                  onClick={!isMultiSelect ? () => handleOpenDetail(skill) : undefined}
+                  style={!isMultiSelect ? { cursor: "pointer" } : undefined}
                   title={skill.name}
                 >
                   {skill.name}
@@ -469,67 +596,69 @@ export function ProjectDetail() {
                   )}
                 </div>
 
-                <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-                  {canUpdateCenter && (
+                {!isMultiSelect && (
+                  <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                    {canUpdateCenter && (
+                      <button
+                        onClick={() => handleUpdateCenter(skill)}
+                        disabled={isUpdatingCenter || isUpdatingProject}
+                        className="rounded p-0.5 text-muted transition-colors hover:bg-surface-hover hover:text-secondary disabled:opacity-50"
+                        title={t("project.updateCenter")}
+                      >
+                        {isUpdatingCenter ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Upload className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                    )}
+                    {canUpdateProject && (
+                      <button
+                        onClick={() => handleUpdateProject(skill)}
+                        disabled={isUpdatingCenter || isUpdatingProject}
+                        className="rounded p-0.5 text-muted transition-colors hover:bg-surface-hover hover:text-secondary disabled:opacity-50"
+                        title={
+                          skill.sync_status === "project_newer"
+                            ? t("project.resetFromCenter")
+                            : t("project.updateProject")
+                        }
+                      >
+                        {isUpdatingProject ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : skill.sync_status === "project_newer" ? (
+                          <RotateCcw className="h-3.5 w-3.5" />
+                        ) : (
+                          <Download className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                    )}
                     <button
-                      onClick={() => handleUpdateCenter(skill)}
-                      disabled={isUpdatingCenter || isUpdatingProject}
-                      className="rounded p-0.5 text-muted transition-colors hover:bg-surface-hover hover:text-secondary disabled:opacity-50"
-                      title={t("project.updateCenter")}
+                      onClick={() => handleToggleSkill(skill)}
+                      disabled={isToggling}
+                      className={cn(
+                        "rounded px-2 py-0.5 text-[13px] font-medium transition-colors outline-none",
+                        skill.enabled
+                          ? "text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10"
+                          : "text-muted hover:bg-surface-hover hover:text-secondary"
+                      )}
                     >
-                      {isUpdatingCenter ? (
+                      {isToggling ? (
                         <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : skill.enabled ? (
+                        t("project.enabled")
                       ) : (
-                        <Upload className="h-3.5 w-3.5" />
+                        t("project.enableSkill")
                       )}
                     </button>
-                  )}
-                  {canUpdateProject && (
                     <button
-                      onClick={() => handleUpdateProject(skill)}
-                      disabled={isUpdatingCenter || isUpdatingProject}
-                      className="rounded p-0.5 text-muted transition-colors hover:bg-surface-hover hover:text-secondary disabled:opacity-50"
-                      title={
-                        skill.sync_status === "project_newer"
-                          ? t("project.resetFromCenter")
-                          : t("project.updateProject")
-                      }
+                      onClick={() => setDeleteTarget(skill)}
+                      className="rounded p-0.5 text-muted transition-colors hover:bg-red-500/10 hover:text-red-500"
+                      title={t("project.deleteSkill")}
                     >
-                      {isUpdatingProject ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : skill.sync_status === "project_newer" ? (
-                        <RotateCcw className="h-3.5 w-3.5" />
-                      ) : (
-                        <Download className="h-3.5 w-3.5" />
-                      )}
+                      <Trash2 className="h-3.5 w-3.5" />
                     </button>
-                  )}
-                  <button
-                    onClick={() => handleToggleSkill(skill)}
-                    disabled={isToggling}
-                    className={cn(
-                      "rounded px-2 py-0.5 text-[13px] font-medium transition-colors outline-none",
-                      skill.enabled
-                        ? "text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10"
-                        : "text-muted hover:bg-surface-hover hover:text-secondary"
-                    )}
-                  >
-                    {isToggling ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : skill.enabled ? (
-                      t("project.enabled")
-                    ) : (
-                      t("project.enableSkill")
-                    )}
-                  </button>
-                  <button
-                    onClick={() => setDeleteTarget(skill)}
-                    className="rounded p-0.5 text-muted transition-colors hover:bg-red-500/10 hover:text-red-500"
-                    title={t("project.deleteSkill")}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </button>
-                </div>
+                  </div>
+                )}
               </div>
             );
           })}
@@ -556,12 +685,23 @@ export function ProjectDetail() {
         onConfirm={handleDeleteSkill}
       />
 
+      {/* Batch Delete Confirm Dialog */}
+      <ConfirmDialog
+        open={batchDeleteConfirm}
+        title={t("project.deleteSkill")}
+        message={t("project.batchDeleteConfirm", { count: selectedIds.size })}
+        tone="danger"
+        onClose={() => setBatchDeleteConfirm(false)}
+        onConfirm={handleBatchDeleteProject}
+      />
+
       {/* Export from Center Dialog */}
       {showExportDialog && id && (
         <ExportFromCenterDialog
           managedSkills={managedSkills}
           projectSkillDirNames={skills.map((s) => s.dir_name.toLowerCase())}
           onExport={handleExportFromCenter}
+          onBatchExport={handleBatchExportFromCenter}
           onClose={() => setShowExportDialog(false)}
         />
       )}
@@ -632,16 +772,19 @@ function ExportFromCenterDialog({
   managedSkills,
   projectSkillDirNames,
   onExport,
+  onBatchExport,
   onClose,
 }: {
   managedSkills: ManagedSkill[];
   projectSkillDirNames: string[];
   onExport: (skill: ManagedSkill) => Promise<void>;
+  onBatchExport: (skills: ManagedSkill[]) => Promise<void>;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
   const [exporting, setExporting] = useState<string | null>(null);
+  const [batchExporting, setBatchExporting] = useState(false);
   const [dirNameMap, setDirNameMap] = useState<Record<string, string>>({});
   const [dirNameMapError, setDirNameMapError] = useState(false);
 
@@ -684,12 +827,40 @@ function ExportFromCenterDialog({
     return matchesSearch;
   });
 
+  const isAlreadyExists = (skill: ManagedSkill) => {
+    const exportDirName = dirNameMap[skill.id];
+    return dirNameMapError ? true : (exportDirName ? projectSkillDirNames.includes(exportDirName) : false);
+  };
+
+  const {
+    isMultiSelect, setIsMultiSelect,
+    selectedIds,
+    toggleSelect,
+    exitMultiSelect,
+  } = useMultiSelect({
+    items: managedSkills,
+    filtered: filtered.filter((s) => !isAlreadyExists(s)),
+    getKey: (s) => s.id,
+    isItemActive: () => true,
+  });
+
   const handleExport = async (skill: ManagedSkill) => {
     setExporting(skill.id);
     try {
       await onExport(skill);
     } finally {
       setExporting(null);
+    }
+  };
+
+  const handleBatchExport = async () => {
+    const selected = managedSkills.filter((s) => selectedIds.has(s.id));
+    if (selected.length === 0) return;
+    setBatchExporting(true);
+    try {
+      await onBatchExport(selected);
+    } finally {
+      setBatchExporting(false);
     }
   };
 
@@ -710,19 +881,42 @@ function ExportFromCenterDialog({
         </div>
 
         <div className="px-5 py-3 border-b border-border-subtle">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted" />
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder={t("project.searchCenterSkills")}
-              className="app-input w-full pl-9 font-medium"
-              autoCapitalize="none"
-              autoCorrect="off"
-              spellCheck={false}
-              autoFocus
-            />
+          <div className="flex items-center gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t("project.searchCenterSkills")}
+                className="app-input w-full pl-9 font-medium"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                autoFocus
+              />
+            </div>
+            {selectedIds.size > 0 && isMultiSelect && (
+              <button
+                onClick={handleBatchExport}
+                disabled={batchExporting}
+                className="shrink-0 inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[13px] font-medium text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
+              >
+                {batchExporting
+                  ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  : t("project.updateSelected", { count: selectedIds.size })}
+              </button>
+            )}
+            <button
+              onClick={() => isMultiSelect ? exitMultiSelect() : setIsMultiSelect(true)}
+              className={cn(
+                "shrink-0 rounded-md p-2 transition-colors outline-none",
+                isMultiSelect ? "bg-surface-active text-secondary" : "text-muted hover:text-tertiary hover:bg-surface-hover"
+              )}
+              title={isMultiSelect ? t("project.cancelSelect") : t("project.selectMode")}
+            >
+              <SquareCheck className="h-4 w-4" />
+            </button>
           </div>
         </div>
 
@@ -734,15 +928,24 @@ function ExportFromCenterDialog({
           ) : (
             <div className="divide-y divide-border-subtle">
               {filtered.map((skill) => {
-                const exportDirName = dirNameMap[skill.id];
-                const alreadyExists = dirNameMapError
-                  ? true
-                  : (exportDirName ? projectSkillDirNames.includes(exportDirName) : false);
+                const alreadyExists = isAlreadyExists(skill);
+                const isSelected = selectedIds.has(skill.id);
+                const selectable = isMultiSelect && !alreadyExists;
                 return (
                   <div
                     key={skill.id}
-                    className="flex items-center gap-3 px-5 py-3 hover:bg-surface-hover transition-colors"
+                    className={cn(
+                      "flex items-center gap-3 px-5 py-3 transition-colors",
+                      selectable ? "cursor-pointer hover:bg-surface-hover" : "hover:bg-surface-hover",
+                      selectable && isSelected && "bg-accent/5"
+                    )}
+                    onClick={selectable ? () => toggleSelect(skill.id) : undefined}
                   >
+                    {isMultiSelect && !alreadyExists && (
+                      isSelected
+                        ? <SquareCheck className="h-3.5 w-3.5 shrink-0 text-accent" />
+                        : <Square className="h-3.5 w-3.5 shrink-0 text-faint" />
+                    )}
                     <div className="flex-1 min-w-0">
                       <div className="text-[13px] font-medium text-primary truncate">
                         {skill.name}
@@ -757,7 +960,7 @@ function ExportFromCenterDialog({
                       <span className="rounded-full bg-surface-hover px-2 py-0.5 text-[12px] font-medium text-muted shrink-0">
                         {t("project.alreadyExists")}
                       </span>
-                    ) : (
+                    ) : !isMultiSelect && (
                       <button
                         onClick={() => handleExport(skill)}
                         disabled={exporting === skill.id}


### PR DESCRIPTION
## 功能说明

在现有多选基础上，新增批量场景启用/停用和批量更新到项目两项操作；同时将多选逻辑抽取为可复用基础设施，应用于项目技能页。

## 改动内容

### 我的技能页（MySkills）— 新增批量启用/停用

- 多选模式下，工具栏新增「启用 N 个 / 停用 N 个」按钮
- 按当前活跃场景判断状态：只要选中项中有任意一个未启用，则操作为「全部启用」；反之为「全部停用」
- 新增翻译 key：`batchEnable`、`batchDisable`、`batchEnabled`、`batchDisabled`、`selectAll`、`deselectAll`

### 从中央仓库更新对话框（ExportFromCenterDialog）— 新增批量更新

- 对话框右上角新增多选模式切换按钮
- 多选模式下可勾选多个 Skill，点击「更新 N 个」一次性批量更新到当前项目
- 已存在于项目中的 Skill 不可选中

### 项目技能页（ProjectDetail）— 新增多选批量操作

- 工具栏新增多选模式切换按钮
- 多选模式下支持批量删除、批量启用/停用
- 批量删除需二次确认

### 通用基础设施（复用）

- **`src/hooks/useMultiSelect.ts`**：抽取通用多选 Hook，同时服务 MySkills、ProjectDetail 和 ExportFromCenterDialog 三处，减少重复状态逻辑
- **`src/components/MultiSelectToolbar.tsx`**：多选工具栏纯展示组件，通过 `labels` prop 接收国际化文本

## 持久化

全部调用已有 IPC 接口，无新增后端逻辑。