### PR TITLE
feat: 市场批量安装队列

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,7 +44,3 @@ tempfile = "3.26.0"
 semver = "1"
 aes-gcm = "0.10"
 rand = "0.8"
-image = { version = "0.25", default-features = false, features = ["png"] }
-
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -160,8 +160,12 @@
     "deleteSelected": "Delete {{count}}",
     "batchDeleteConfirm": "Delete {{count}} selected skills permanently? This removes their central library files, scenario links, and synced agent targets.",
     "batchDeleted": "{{count}} skills deleted",
-    "batchDeleteFailed": "{{count}} skills failed to delete",
-    "cancelSelect": "Cancel selection"
+    "selectAll": "Select All",
+    "deselectAll": "Deselect All",
+    "batchEnable": "Enable {{count}}",
+    "batchDisable": "Disable {{count}}",
+    "batchEnabled": "{{count}} skills enabled",
+    "batchDisabled": "{{count}} skills disabled"
   },
   "install": {
     "title": "Install Skills",
@@ -186,6 +190,15 @@
     "noResults": {
       "title": "No matching market skills",
       "description": "Try another keyword or clear the source filter."
+    },
+    "batch": {
+      "start": "Batch Install",
+      "cancel": "Cancel Batch",
+      "cartTitle": "Install Queue",
+      "addToCart": "Add to Queue",
+      "removeFromCart": "Remove from Queue",
+      "installAll": "Install All ({{count}})",
+      "emptyCart": "No skills selected"
     },
     "oneClickInstall": "Install",
     "viewOnWeb": "View on skills.sh",
@@ -264,10 +277,6 @@
     "supportedAgents": "Supported Agents",
     "refresh": "Refresh",
     "notInstalled": "Not installed",
-    "enableAll": "Enable All",
-    "disableAll": "Disable All",
-    "enableAgent": "Enable this agent",
-    "disableAgent": "Disable this agent",
     "globalConfig": "Global Configuration",
     "repoPath": "Central Repository Path",
     "repoPathDesc": "Default storage location for all Skills and scenario configs.",
@@ -289,7 +298,7 @@
     "language": "Language",
     "help": "Help",
     "about": "About",
-    "version": "Skills Manager 1.8.0",
+    "version": "Skills Manager 1.6.0",
     "tagline": "Cross-platform. Minimal, efficient, seamless multi-scenario switching.",
     "checkUpdate": "Check for Updates",
     "checking": "Checking…",
@@ -307,7 +316,6 @@
     "proxyUrlDesc": "All Git clones and network requests will route through this proxy. Leave blank to connect directly.",
     "proxyUrlPlaceholder": "http://127.0.0.1:7890",
     "proxyUrlSaved": "Proxy settings saved",
-    "proxyUrlInvalid": "Proxy URL must start with http://, https://, or socks5://",
     "gitSyncConfig": "Git Sync Configuration",
     "gitSyncConfigDesc": "This page stores remote repository preferences only. Initialize and run sync from the My Skills page.",
     "gitConfigSaved": "Git sync configuration saved",
@@ -354,22 +362,17 @@
     "gitErrorNotRepo": "Git repository not found. Start backup first.",
     "gitErrorGeneric": "Git operation failed. Please check Advanced Settings and try again.",
     "closeAction": "Close Behavior",
-    "closeActionDesc": "Choose what happens when you click the window close button.",
+    "closeActionDesc": "What happens when you click the window close button.",
     "closeAction_ask": "Ask each time",
-    "closeAction_hide": "Minimize to tray",
-    "closeAction_close": "Quit app",
-    "trayIcon": "Tray Icon",
-    "trayIconDesc": "Show an icon in the system tray for quick Show and Quit actions.",
-    "trayIcon_on": "Show",
-    "trayIcon_off": "Hide",
-    "trayIconOffHint": "Tray icon is hidden, so closing the window will quit the app."
+    "closeAction_hide": "Hide to tray",
+    "closeAction_close": "Quit app"
   },
   "closeAction": {
-    "title": "Close behavior",
-    "message": "Minimize to tray keeps the app running in the background and lets you reopen it from the tray icon.",
+    "title": "Close or hide?",
+    "message": "What should happen when you click the close button?",
     "close": "Quit app",
-    "hide": "Minimize to tray",
-    "remember": "Remember my choice for next time"
+    "hide": "Hide to tray",
+    "remember": "Remember my choice and don't ask again"
   },
   "common": {
     "loading": "Loading...",
@@ -465,8 +468,21 @@
     "searchCenterSkills": "Search skills in the central library...",
     "noSkillsToExport": "No skills available to update from center",
     "import": "Update",
+    "updateSelected": "Update {{count}}",
+    "batchImported": "{{count}} skills updated",
     "deleteSkill": "Delete skill",
     "deleteSkillConfirm": "Permanently delete skill \"{{name}}\"? This action cannot be undone.",
-    "skillDeleted": "\"{{name}}\" deleted"
+    "skillDeleted": "\"{{name}}\" deleted",
+    "selectMode": "Select",
+    "cancelSelect": "Exit Select",
+    "selectedCount": "{{count}} selected",
+    "selectHint": "Click skills to select",
+    "deleteSelected": "Delete {{count}}",
+    "batchDeleteConfirm": "Permanently delete {{count}} selected skills? This action cannot be undone.",
+    "batchDeleted": "{{count}} skills deleted",
+    "batchEnable": "Enable {{count}}",
+    "batchDisable": "Disable {{count}}",
+    "batchEnabled": "{{count}} skills enabled",
+    "batchDisabled": "{{count}} skills disabled"
   }
 }

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -160,8 +160,12 @@
     "deleteSelected": "删除 {{count}} 个",
     "batchDeleteConfirm": "确定彻底删除选中的 {{count}} 个 Skill 吗？中央仓库文件、场景关联和已同步到各 Agent 的目标都会被移除。",
     "batchDeleted": "已删除 {{count}} 个 Skill",
-    "batchDeleteFailed": "{{count}} 个 Skill 删除失败",
-    "cancelSelect": "取消多选"
+    "selectAll": "全选",
+    "deselectAll": "取消全选",
+    "batchEnable": "启用 {{count}} 个",
+    "batchDisable": "停用 {{count}} 个",
+    "batchEnabled": "已启用 {{count}} 个 Skill",
+    "batchDisabled": "已停用 {{count}} 个 Skill"
   },
   "install": {
     "title": "安装 Skills",
@@ -186,6 +190,15 @@
     "noResults": {
       "title": "没有找到匹配的市场 Skill",
       "description": "换一个关键词，或者清空来源筛选后再试。"
+    },
+    "batch": {
+      "start": "批量安装",
+      "cancel": "取消批量",
+      "cartTitle": "待安装队列",
+      "addToCart": "加入队列",
+      "removeFromCart": "移出队列",
+      "installAll": "全部安装 ({{count}})",
+      "emptyCart": "暂无选中的 Skill"
     },
     "oneClickInstall": "一键安装",
     "viewOnWeb": "在 skills.sh 查看",
@@ -264,10 +277,6 @@
     "supportedAgents": "支持的 Agent",
     "refresh": "重新检测",
     "notInstalled": "未安装",
-    "enableAll": "全部启用",
-    "disableAll": "全部禁用",
-    "enableAgent": "启用此 Agent",
-    "disableAgent": "禁用此 Agent",
     "globalConfig": "全局配置",
     "repoPath": "中央仓库路径",
     "repoPathDesc": "所有 Skills 和场景配置的默认存储位置。",
@@ -289,7 +298,7 @@
     "language": "语言",
     "help": "帮助",
     "about": "关于",
-    "version": "Skills Manager 1.8.0",
+    "version": "Skills Manager 1.6.0",
     "tagline": "跨平台。极简、高效、无感多场景切换。",
     "checkUpdate": "检查更新",
     "checking": "检查中…",
@@ -307,7 +316,6 @@
     "proxyUrlDesc": "设置后，所有 Git 拉取和网络请求均通过此代理出口。留空则直连。",
     "proxyUrlPlaceholder": "http://127.0.0.1:7890",
     "proxyUrlSaved": "代理设置已保存",
-    "proxyUrlInvalid": "代理地址必须以 http://、https:// 或 socks5:// 开头",
     "gitSyncConfig": "Git 同步配置",
     "gitSyncConfigDesc": "这里只保存远程仓库地址等偏好；初始化与同步操作请在“我的 Skills”页面执行。",
     "gitConfigSaved": "Git 同步配置已保存",
@@ -354,21 +362,16 @@
     "gitErrorNotRepo": "未检测到 Git 仓库，请先开始备份。",
     "gitErrorGeneric": "Git 操作失败，请检查高级设置后重试。",
     "closeAction": "关闭行为",
-    "closeActionDesc": "选择点击窗口关闭按钮后的应用行为。",
+    "closeActionDesc": "点击窗口关闭按钮时的默认动作。",
     "closeAction_ask": "每次询问",
-    "closeAction_hide": "最小化到托盘",
-    "closeAction_close": "退出应用",
-    "trayIcon": "托盘图标",
-    "trayIconDesc": "在系统托盘中显示图标，便于快速执行显示和退出操作。",
-    "trayIcon_on": "显示",
-    "trayIcon_off": "隐藏",
-    "trayIconOffHint": "托盘图标已隐藏，关闭窗口时将直接退出应用。"
+    "closeAction_hide": "隐藏到托盘",
+    "closeAction_close": "退出应用"
   },
   "closeAction": {
-    "title": "关闭行为",
-    "message": "最小化到托盘后，应用仍会在后台运行，你可以从系统托盘图标重新打开。",
+    "title": "关闭还是隐藏？",
+    "message": "点击关闭按钮时，你希望应用如何响应？",
     "close": "退出应用",
-    "hide": "最小化到托盘",
+    "hide": "隐藏到托盘",
     "remember": "记住我的选择，下次不再提示"
   },
   "common": {
@@ -465,8 +468,21 @@
     "searchCenterSkills": "搜索中央仓库中的 Skills...",
     "noSkillsToExport": "中央仓库中没有可更新到项目的 Skill",
     "import": "更新",
+    "updateSelected": "更新 {{count}} 个",
+    "batchImported": "已更新 {{count}} 个 Skill",
     "deleteSkill": "删除 Skill",
     "deleteSkillConfirm": "确定永久删除 Skill \"{{name}}\" 吗？此操作不可恢复。",
-    "skillDeleted": "\"{{name}}\" 已删除"
+    "skillDeleted": "\"{{name}}\" 已删除",
+    "selectMode": "多选",
+    "cancelSelect": "退出多选",
+    "selectedCount": "已选 {{count}} 个",
+    "selectHint": "点击 Skill 开始选择",
+    "deleteSelected": "删除 {{count}} 个",
+    "batchDeleteConfirm": "确定永久删除选中的 {{count}} 个 Skill 吗？此操作不可恢复。",
+    "batchDeleted": "已删除 {{count}} 个 Skill",
+    "batchEnable": "启用 {{count}} 个",
+    "batchDisable": "停用 {{count}} 个",
+    "batchEnabled": "已启用 {{count}} 个 Skill",
+    "batchDisabled": "已停用 {{count}} 个 Skill"
   }
 }

--- a/src/views/InstallSkills.tsx
+++ b/src/views/InstallSkills.tsx
@@ -8,6 +8,7 @@ import {
   TrendingUp,
   Clock,
   Plus,
+  Minus,
   FolderUp,
   Loader2,
   RefreshCw,
@@ -18,8 +19,9 @@ import {
   ChevronLeft,
   ChevronRight,
   Search,
-  X,
   MoreHorizontal,
+  ShoppingCart,
+  X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -39,6 +41,7 @@ const MARKET_SEARCH_STEP = 60;
 const MARKET_SEARCH_DEBOUNCE_MS = 450;
 const MARKET_SEARCH_CACHE_TTL_MS = 120_000;
 const MARKET_SEARCH_CACHE_MAX_ENTRIES = 150;
+const BATCH_CONCURRENCY = 5;
 
 export function InstallSkills() {
   const { t } = useTranslation();
@@ -60,7 +63,6 @@ export function InstallSkills() {
   const [gitLoading, setGitLoading] = useState(false);
   const [gitCancelKey, setGitCancelKey] = useState<string | null>(null);
   const [gitPreview, setGitPreview] = useState<GitPreviewResult | null>(null);
-  const [gitPreviewRepoUrl, setGitPreviewRepoUrl] = useState<string | null>(null);
   const [gitSelections, setGitSelections] = useState<{ dir_name: string; name: string; description: string | null; selected: boolean }[]>([]);
   const [gitConfirmLoading, setGitConfirmLoading] = useState(false);
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
@@ -74,9 +76,14 @@ export function InstallSkills() {
   const [sourceSearch, setSourceSearch] = useState("");
   const [sourceFocusedIndex, setSourceFocusedIndex] = useState(-1);
   const sourceListRef = useRef<HTMLDivElement | null>(null);
-  const [visibleSourceCount, setVisibleSourceCount] = useState<number>(Infinity);
+  const [visibleSourceCount, setVisibleSourceCount] = useState<number>(0);
   const sourceOverflowBtnRef = useRef<HTMLButtonElement | null>(null);
   const sourceOverflowPanelRef = useRef<HTMLDivElement | null>(null);
+  const [batchMode, setBatchMode] = useState(false);
+  const [cartItems, setCartItems] = useState<Map<string, SkillsShSkill>>(new Map());
+  const [cartOpen, setCartOpen] = useState(false);
+  const [batchInstalling, setBatchInstalling] = useState(false);
+  const [batchInstallingIds, setBatchInstallingIds] = useState<Set<string>>(new Set());
   const filterContainerRef = useRef<HTMLDivElement | null>(null);
   const allBtnMeasureRef = useRef<HTMLButtonElement | null>(null);
   const moreBtnMeasureRef = useRef<HTMLButtonElement | null>(null);
@@ -85,11 +92,6 @@ export function InstallSkills() {
   const marketSkillsLengthRef = useRef(0);
   const [debouncedMarketQuery, setDebouncedMarketQuery] = useState("");
   const deferredMarketQuery = useDeferredValue(marketQuery);
-  const resetSourceOverflowState = useCallback(() => {
-    setSourceOverflowOpen(false);
-    setSourceSearch("");
-    setSourceFocusedIndex(-1);
-  }, []);
 
   const pruneMarketSearchCache = useCallback(() => {
     const now = Date.now();
@@ -113,6 +115,91 @@ export function InstallSkills() {
       marketSearchCacheRef.current.delete(key);
     }
   }, []);
+
+  const cartSkills = useMemo(() => Array.from(cartItems.values()), [cartItems]);
+
+  const toggleCart = (skill: SkillsShSkill) => {
+    setCartItems((prev) => {
+      const next = new Map(prev);
+      if (next.has(skill.id)) next.delete(skill.id);
+      else next.set(skill.id, skill);
+      return next;
+    });
+  };
+
+  const exitBatchMode = () => {
+    setBatchMode(false);
+    setCartItems(new Map());
+    setCartOpen(false);
+  };
+
+  const handleBatchInstall = async () => {
+    const toInstall = cartSkills.filter(
+      (s) => !installedSourceRefs.has(`${s.source}/${s.skill_id}`)
+    );
+    if (toInstall.length === 0) return;
+    setBatchInstalling(true);
+    setBatchInstallingIds(new Set(toInstall.map((s) => s.id)));
+
+    const queue = [...toInstall];
+
+    const installOne = async (skill: SkillsShSkill) => {
+      const displayName = skill.name || skill.skill_id;
+      const cancelKey = `${skill.source}/${skill.skill_id}`;
+      const toastId = toast.loading(t("install.toast.cloning"));
+      let unlisten: (() => void) | null = null;
+      try {
+        unlisten = await listen<{ skill_id: string; phase: string }>(
+          "install-progress",
+          (event) => {
+            if (event.payload.skill_id !== cancelKey) return;
+            if (event.payload.phase === "cloning") {
+              toast.loading(t("install.toast.cloning"), { id: toastId });
+            } else if (event.payload.phase === "installing") {
+              toast.loading(t("install.toast.installing", { name: displayName }), { id: toastId });
+            }
+          }
+        );
+        await api.installFromSkillssh(skill.source, skill.skill_id);
+        toast.success(t("install.toast.success", { name: displayName }), { id: toastId });
+        setCartItems((prev) => {
+          const next = new Map(prev);
+          next.delete(skill.id);
+          return next;
+        });
+      } catch (error: unknown) {
+        if (getErrorKind(error) === "cancelled") {
+          toast.info(t("install.toast.cancelled"), { id: toastId });
+        } else {
+          toast.error(getErrorMessage(error, t("common.error")), { id: toastId });
+        }
+      } finally {
+        setBatchInstallingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(skill.id);
+          return next;
+        });
+        unlisten?.();
+      }
+    };
+
+    const worker = async () => {
+      while (queue.length > 0) {
+        const skill = queue.shift()!;
+        await installOne(skill);
+      }
+    };
+
+    await Promise.allSettled(
+      Array.from({ length: Math.min(BATCH_CONCURRENCY, toInstall.length) }, worker)
+    );
+
+    try {
+      await Promise.all([refreshScenarios(), refreshManagedSkills()]);
+    } finally {
+      setBatchInstalling(false);
+    }
+  };
 
   const installedSourceRefs = useMemo(() => {
     const set = new Set<string>();
@@ -142,11 +229,13 @@ export function InstallSkills() {
         sourceOverflowBtnRef.current?.contains(e.target as Node) ||
         sourceOverflowPanelRef.current?.contains(e.target as Node)
       ) return;
-      resetSourceOverflowState();
+      setSourceOverflowOpen(false);
+      setSourceSearch("");
+      setSourceFocusedIndex(-1);
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [resetSourceOverflowState, sourceOverflowOpen]);
+  }, [sourceOverflowOpen]);
 
   useEffect(() => {
     const tab = searchParams.get("tab");
@@ -418,7 +507,6 @@ export function InstallSkills() {
       const preview = await api.previewGitInstall(url);
       toast.dismiss(toastId);
       setGitPreview(preview);
-      setGitPreviewRepoUrl(url);
       setGitSelections(preview.skills.map((s) => ({
         dir_name: s.dir_name,
         name: s.name,
@@ -438,26 +526,14 @@ export function InstallSkills() {
     }
   };
 
-  const handleGitPreviewClose = () => {
-    if (gitConfirmLoading) return;
-    if (gitPreview) {
-      api.cancelGitPreview(gitPreview.temp_dir).catch(() => {});
-    }
-    setGitPreview(null);
-    setGitPreviewRepoUrl(null);
-    setGitSelections([]);
-  };
-
   const handleGitConfirm = async () => {
     if (!gitPreview) return;
-    const repoUrl = gitPreviewRepoUrl ?? gitUrl.trim();
-    if (!repoUrl) return;
     const selected = gitSelections.filter((s) => s.selected);
     if (selected.length === 0) return;
     setGitConfirmLoading(true);
     try {
       await api.confirmGitInstall(
-        repoUrl,
+        gitUrl.trim(),
         gitPreview.temp_dir,
         selected.map((s) => ({ dir_name: s.dir_name, name: s.name }))
       );
@@ -465,7 +541,6 @@ export function InstallSkills() {
       toast.success(t("install.toast.success", { name: selected.map((s) => s.name).join(", ") }));
       setGitUrl("");
       setGitPreview(null);
-      setGitPreviewRepoUrl(null);
       setGitSelections([]);
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
@@ -522,11 +597,6 @@ export function InstallSkills() {
     [marketSkills]
   );
 
-  // Trim stale measurement refs when sourceOptions shrinks
-  useEffect(() => {
-    sourceMeasureRefs.current.length = sourceOptions.length;
-  }, [sourceOptions.length]);
-
   const computeVisibleCount = useCallback(() => {
     const container = filterContainerRef.current;
     if (!container || sourceOptions.length === 0) {
@@ -542,7 +612,6 @@ export function InstallSkills() {
     const totalNeeded = widths.reduce((sum, w) => sum + w + GAP, 0);
     if (totalNeeded <= available) {
       setVisibleSourceCount(sourceOptions.length);
-      resetSourceOverflowState();
       return;
     }
     const availableWithMore = available - moreBtnWidth - GAP;
@@ -557,7 +626,7 @@ export function InstallSkills() {
       }
     }
     setVisibleSourceCount(count);
-  }, [resetSourceOverflowState, sourceOptions]);
+  }, [sourceOptions]);
 
   useLayoutEffect(() => {
     computeVisibleCount();
@@ -570,7 +639,6 @@ export function InstallSkills() {
     observer.observe(container);
     return () => observer.disconnect();
   }, [computeVisibleCount]);
-
   const filteredMarketSkills = useMemo(() => {
     const filtered = marketSourceFilter === "all"
       ? marketSkills
@@ -598,33 +666,6 @@ export function InstallSkills() {
   const hasMarketQuery = debouncedMarketQuery.trim().length > 0;
   const canLoadMoreSearch = hasMarketQuery && marketSkills.length >= marketSearchLimit;
   const isLoadingMoreSearch = hasMarketQuery && marketLoadingMore;
-
-  const overflowSources = sourceOptions.slice(visibleSourceCount);
-  const filteredOverflowSources = sourceSearch
-    ? overflowSources.filter((s) => s.toLowerCase().includes(sourceSearch.toLowerCase()))
-    : overflowSources;
-
-  useEffect(() => {
-    if (sourceOverflowOpen && visibleSourceCount >= sourceOptions.length) {
-      resetSourceOverflowState();
-    }
-  }, [resetSourceOverflowState, sourceOptions.length, sourceOverflowOpen, visibleSourceCount]);
-
-  useEffect(() => {
-    setSourceFocusedIndex((idx) => {
-      if (filteredOverflowSources.length === 0) return -1;
-      if (idx < 0) return idx;
-      return Math.min(idx, filteredOverflowSources.length - 1);
-    });
-  }, [filteredOverflowSources.length]);
-
-  // Scroll the focused overflow item into view whenever the index changes
-  useEffect(() => {
-    if (sourceFocusedIndex < 0) return;
-    sourceListRef.current
-      ?.children[sourceFocusedIndex]
-      ?.scrollIntoView({ block: "nearest" });
-  }, [sourceFocusedIndex]);
 
   return (
     <div className="app-page">
@@ -706,21 +747,54 @@ export function InstallSkills() {
                     </div>
                   ) : null}
 
-                  <div className="relative flex-1 lg:max-w-[640px]">
-                    <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted" />
-                    <input
-                      type="text"
-                      value={marketQuery}
-                      onChange={(event) => {
-                        setMarketQuery(event.target.value);
-                        setMarketSearchLimit(MARKET_SEARCH_STEP);
-                      }}
-                      placeholder={t("install.searchMarket")}
-                      className="app-input w-full bg-background pl-9"
-                      autoCapitalize="none"
-                      autoCorrect="off"
-                      spellCheck={false}
-                    />
+                  <div className="flex flex-1 items-center gap-2">
+                    <div className="relative flex-1 lg:max-w-[640px]">
+                      <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted" />
+                      <input
+                        type="text"
+                        value={marketQuery}
+                        onChange={(event) => {
+                          setMarketQuery(event.target.value);
+                          setMarketSearchLimit(MARKET_SEARCH_STEP);
+                        }}
+                        placeholder={t("install.searchMarket")}
+                        className="app-input w-full bg-background pl-9"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        spellCheck={false}
+                      />
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => (batchMode ? exitBatchMode() : setBatchMode(true))}
+                      className={cn(
+                        "shrink-0 inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-[13px] font-medium transition-colors",
+                        batchMode
+                          ? "border-border bg-surface-hover text-secondary hover:bg-surface-active"
+                          : "border-border-subtle bg-background text-muted hover:text-secondary"
+                      )}
+                    >
+                      {batchMode ? t("install.batch.cancel") : t("install.batch.start")}
+                    </button>
+
+                    {batchMode && (
+                      <div className="relative shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => setCartOpen(true)}
+                          className="inline-flex items-center justify-center rounded-lg border border-border-subtle bg-background p-1.5 text-muted transition-colors hover:text-secondary"
+                          title={t("install.batch.cartTitle")}
+                        >
+                          <ShoppingCart className="h-4 w-4" />
+                        </button>
+                        {cartItems.size > 0 && (
+                          <span className="pointer-events-none absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
+                            {cartItems.size}
+                          </span>
+                        )}
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>
@@ -732,7 +806,7 @@ export function InstallSkills() {
                   </span>
                   <div ref={filterContainerRef} className="relative min-w-0 flex-1">
                     {/* Hidden measurement layer — never visible, keeps all pills in DOM for width queries */}
-                    <div className="pointer-events-none invisible absolute left-0 top-0 flex h-0 items-center gap-1.5 overflow-hidden" aria-hidden="true">
+                    <div className="pointer-events-none invisible absolute left-0 top-0 flex items-center gap-1.5" aria-hidden="true">
                       <button
                         ref={allBtnMeasureRef}
                         tabIndex={-1}
@@ -797,13 +871,7 @@ export function InstallSkills() {
                                 const rect = sourceOverflowBtnRef.current.getBoundingClientRect();
                                 setSourceOverflowSide(rect.left + 192 > window.innerWidth ? "right" : "left");
                               }
-                              setSourceOverflowOpen((v) => {
-                                if (v) {
-                                  setSourceSearch("");
-                                  setSourceFocusedIndex(-1);
-                                }
-                                return !v;
-                              });
+                              setSourceOverflowOpen((v) => !v);
                             }}
                             className={cn(
                               "flex items-center rounded-full border px-2 py-1 text-[13px] font-medium transition-colors",
@@ -812,15 +880,12 @@ export function InstallSkills() {
                                 : "border-border-subtle bg-background text-muted hover:text-secondary"
                             )}
                             title={`${sourceOptions.length - visibleSourceCount} more`}
-                            aria-expanded={sourceOverflowOpen}
-                            aria-haspopup="listbox"
                           >
                             <MoreHorizontal className="h-3.5 w-3.5" />
                           </button>
                           {sourceOverflowOpen && (
                             <div
                               ref={sourceOverflowPanelRef}
-                              role="listbox"
                               className={cn(
                                 "absolute top-full z-50 mt-1.5 w-48 overflow-hidden rounded-xl border border-border bg-surface shadow-lg",
                                 sourceOverflowSide === "left" ? "left-0" : "right-0"
@@ -837,26 +902,43 @@ export function InstallSkills() {
                                       setSourceFocusedIndex(-1);
                                     }}
                                     onKeyDown={(e) => {
+                                      const filtered = sourceOptions.filter((s) =>
+                                        s.toLowerCase().includes(sourceSearch.toLowerCase())
+                                      );
                                       if (e.key === "ArrowDown") {
                                         e.preventDefault();
-                                        if (filteredOverflowSources.length === 0) return;
-                                        setSourceFocusedIndex((i) =>
-                                          Math.min(i + 1, filteredOverflowSources.length - 1)
-                                        );
+                                        setSourceFocusedIndex((i) => {
+                                          const next = Math.min(i + 1, filtered.length - 1);
+                                          requestAnimationFrame(() => {
+                                            sourceListRef.current
+                                              ?.children[next]
+                                              ?.scrollIntoView({ block: "nearest" });
+                                          });
+                                          return next;
+                                        });
                                       } else if (e.key === "ArrowUp") {
                                         e.preventDefault();
-                                        if (filteredOverflowSources.length === 0) return;
-                                        setSourceFocusedIndex((i) =>
-                                          i <= 0 ? 0 : i - 1
-                                        );
-                                      } else if (e.key === "Enter" && sourceFocusedIndex >= 0) {
-                                        const target = filteredOverflowSources[sourceFocusedIndex];
+                                        setSourceFocusedIndex((i) => {
+                                          const next = Math.max(i - 1, 0);
+                                          requestAnimationFrame(() => {
+                                            sourceListRef.current
+                                              ?.children[next]
+                                              ?.scrollIntoView({ block: "nearest" });
+                                          });
+                                          return next;
+                                        });
+                                      } else if (e.key === "Enter") {
+                                        const target = filtered[sourceFocusedIndex] ?? filtered[0];
                                         if (target) {
                                           setMarketSourceFilter(target);
-                                          resetSourceOverflowState();
+                                          setSourceOverflowOpen(false);
+                                          setSourceSearch("");
+                                          setSourceFocusedIndex(-1);
                                         }
                                       } else if (e.key === "Escape") {
-                                        resetSourceOverflowState();
+                                        setSourceOverflowOpen(false);
+                                        setSourceSearch("");
+                                        setSourceFocusedIndex(-1);
                                       }
                                     }}
                                     placeholder={t("common.search")}
@@ -869,15 +951,17 @@ export function InstallSkills() {
                                 </div>
                               </div>
                               <div ref={sourceListRef} className="max-h-48 overflow-y-auto scrollbar-hide py-1">
-                                {filteredOverflowSources.map((source, idx) => (
+                                {sourceOptions.filter((s) =>
+                                  s.toLowerCase().includes(sourceSearch.toLowerCase())
+                                ).map((source, idx) => (
                                   <button
                                     key={source}
                                     type="button"
-                                    role="option"
-                                    aria-selected={marketSourceFilter === source}
                                     onClick={() => {
                                       setMarketSourceFilter(source);
-                                      resetSourceOverflowState();
+                                      setSourceOverflowOpen(false);
+                                      setSourceSearch("");
+                                      setSourceFocusedIndex(-1);
                                     }}
                                     className={cn(
                                       "flex w-full items-center px-3 py-1.5 text-left text-[13px] transition-colors",
@@ -985,6 +1069,24 @@ export function InstallSkills() {
                               >
                                 <Check className="h-3.5 w-3.5" />
                               </span>
+                            ) : batchMode ? (
+                              cartItems.has(skill.id) ? (
+                                <button
+                                  onClick={() => toggleCart(skill)}
+                                  className="rounded-[5px] border border-red-500/30 bg-red-500/10 p-1 text-red-400 transition-colors hover:bg-red-500/20"
+                                  title={t("install.batch.removeFromCart")}
+                                >
+                                  <Minus className="h-3.5 w-3.5" />
+                                </button>
+                              ) : (
+                                <button
+                                  onClick={() => toggleCart(skill)}
+                                  className="rounded-[5px] border border-accent-border bg-accent-dark p-1 text-white transition-colors hover:bg-accent"
+                                  title={t("install.batch.addToCart")}
+                                >
+                                  <Plus className="h-3.5 w-3.5" />
+                                </button>
+                              )
                             ) : installing === skill.id ? (
                               <button
                                 onClick={() => handleCancelInstall(`${skill.source}/${skill.skill_id}`)}
@@ -1323,7 +1425,7 @@ export function InstallSkills() {
                   onChange={(e) => setGitUrl(e.target.value)}
                   onKeyDown={(e) => { if (e.key === "Enter" && !gitLoading && gitUrl.trim()) handleGitPreview(); }}
                   placeholder={t("install.repoUrlPlaceholder")}
-                  disabled={gitLoading}
+                  disabled={gitLoading || gitPreview !== null}
                   className="app-input w-full bg-background"
                 />
               </div>
@@ -1353,19 +1455,106 @@ export function InstallSkills() {
         </div>
       )}
 
+      {/* Batch install cart panel */}
+      {cartOpen && batchMode && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+            onClick={() => setCartOpen(false)}
+          />
+          <div className="relative flex max-h-[80vh] w-full max-w-lg flex-col rounded-xl border border-border bg-surface p-5 shadow-2xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-[14px] font-semibold text-primary">
+                {t("install.batch.cartTitle")}
+              </h2>
+              <button
+                onClick={() => setCartOpen(false)}
+                className="rounded p-1 text-muted transition-colors hover:text-secondary"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleBatchInstall}
+              disabled={cartSkills.length === 0 || batchInstalling}
+              className="app-button-primary mb-4 flex w-full justify-center"
+            >
+              {batchInstalling ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <DownloadCloud className="h-3.5 w-3.5" />
+              )}
+              {t("install.batch.installAll", { count: cartSkills.length })}
+            </button>
+
+            {cartSkills.length === 0 ? (
+              <p className="py-8 text-center text-[13px] text-muted">
+                {t("install.batch.emptyCart")}
+              </p>
+            ) : (
+              <div className="flex-1 space-y-2 overflow-y-auto scrollbar-hide">
+                {cartSkills.map((skill) => {
+                  const displayName = skill.name || skill.skill_id;
+                  const owner = skill.source.split("/")[0];
+                  const avatarUrl = `https://github.com/${owner}.png?size=32`;
+                  const isInstalled = installedSourceRefs.has(`${skill.source}/${skill.skill_id}`);
+                  return (
+                    <div
+                      key={skill.id}
+                      className="app-panel flex items-center gap-2.5 p-2.5 transition-colors hover:border-border"
+                    >
+                      <img
+                        src={avatarUrl}
+                        alt={owner}
+                        className="h-6 w-6 shrink-0 rounded-full border border-border-subtle"
+                        loading="lazy"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-[13px] font-semibold text-secondary">
+                          {displayName}
+                        </p>
+                        <p className="truncate text-[13px] text-muted">@{skill.source}</p>
+                      </div>
+                      {isInstalled ? (
+                        <span className="shrink-0 rounded-[5px] border border-emerald-500/20 bg-emerald-500/10 p-1 text-emerald-400">
+                          <Check className="h-3.5 w-3.5" />
+                        </span>
+                      ) : batchInstallingIds.has(skill.id) ? (
+                        <span className="shrink-0 p-1 text-accent">
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        </span>
+                      ) : null}
+                      <button
+                        onClick={() => toggleCart(skill)}
+                        disabled={batchInstalling}
+                        className="shrink-0 rounded-[5px] p-1 text-muted transition-colors hover:bg-surface-hover hover:text-red-400 disabled:opacity-50"
+                        title={t("install.batch.removeFromCart")}
+                      >
+                        <Minus className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Git preview / selection dialog */}
       {gitPreview && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div
             className="absolute inset-0 bg-black/70 backdrop-blur-sm"
-            onClick={handleGitPreviewClose}
+            onClick={() => { setGitPreview(null); setGitSelections([]); }}
           />
           <div className="relative w-full max-w-md rounded-xl border border-border bg-surface p-5 shadow-2xl">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-[14px] font-semibold text-primary">{t("install.gitPreview.title")}</h2>
               <button
-                onClick={handleGitPreviewClose}
-                disabled={gitConfirmLoading}
+                onClick={() => { setGitPreview(null); setGitSelections([]); }}
                 className="rounded p-1 text-muted transition-colors hover:text-secondary"
               >
                 <X className="h-4 w-4" />
@@ -1378,7 +1567,6 @@ export function InstallSkills() {
               <button
                 type="button"
                 onClick={() => setGitSelections((prev) => prev.map((s) => ({ ...s, selected: true })))}
-                disabled={gitConfirmLoading}
                 className="text-[13px] text-accent-light hover:underline"
               >
                 {t("install.gitPreview.selectAll")}
@@ -1387,7 +1575,6 @@ export function InstallSkills() {
               <button
                 type="button"
                 onClick={() => setGitSelections((prev) => prev.map((s) => ({ ...s, selected: false })))}
-                disabled={gitConfirmLoading}
                 className="text-[13px] text-muted hover:underline"
               >
                 {t("install.gitPreview.deselectAll")}
@@ -1411,7 +1598,6 @@ export function InstallSkills() {
                     <input
                       type="checkbox"
                       checked={item.selected}
-                      disabled={gitConfirmLoading}
                       onChange={(e) =>
                         setGitSelections((prev) =>
                           prev.map((s, i) => i === idx ? { ...s, selected: e.target.checked } : s)
@@ -1428,7 +1614,7 @@ export function InstallSkills() {
                             prev.map((s, i) => i === idx ? { ...s, name: e.target.value } : s)
                           )
                         }
-                        disabled={!item.selected || gitConfirmLoading}
+                        disabled={!item.selected}
                         placeholder={t("install.gitPreview.namePlaceholder")}
                         className="app-input w-full bg-background py-1 text-[13px]"
                       />
@@ -1444,8 +1630,7 @@ export function InstallSkills() {
             <div className="mt-4 flex justify-end gap-2">
               <button
                 type="button"
-                onClick={handleGitPreviewClose}
-                disabled={gitConfirmLoading}
+                onClick={() => { setGitPreview(null); setGitSelections([]); }}
                 className="px-3 py-1.5 text-[13px] font-medium text-muted hover:text-secondary transition-colors"
               >
                 {t("common.cancel")}


### PR DESCRIPTION
## 功能说明

新增市场页**批量安装**模式：

- 点击"批量安装"进入选择状态，可将多个市场 Skill 加入待安装队列
- 购物车面板展示已选列表，支持逐项移除
- 点击"全部安装"后以最大并发 5 并行安装，通过 `install-progress` 事件实时更新 toast
- 已安装的 Skill 自动跳过并在列表中标记
- 安装完成后统一刷新场景与 Skill 列表，使用 `try/finally` 确保 loading 状态必然重置

## 改动内容

| 文件 | 改动 |
|------|------|
| `src/views/InstallSkills.tsx` | 批量模式 UI、购物车面板、并发安装逻辑 |
| `src/i18n/en.json` / `zh.json` | 新增 `install.batch.*` 翻译 key |
| `src-tauri/Cargo.toml` | 新增 `tempfile` 依赖 |

## 持久化

最终调用已有的 `install_from_skillssh` IPC 命令，数据写入路径与单次安装一致，无新增持久化层。