### PR TITLE
feat: add Hermes Agent support with recursive skill scanning

### DIFF
--- a/src-tauri/src/core/scanner.rs
+++ b/src-tauri/src/core/scanner.rs
@@ -29,12 +29,46 @@ pub struct DiscoveredLocation {
     pub found_path: String,
 }
 
+/// Directories to skip during recursive scans (internal/tool-specific metadata).
+const RECURSIVE_SCAN_SKIP_DIRS: &[&str] = &[".hub", ".git", "node_modules"];
+
 fn is_symlink_to_central(path: &Path) -> bool {
     if let Ok(target) = std::fs::read_link(path) {
         let central = super::central_repo::skills_dir();
         return target.starts_with(&central);
     }
     false
+}
+
+/// Recursively walk `dir` and collect all subdirectories that contain SKILL.md.
+/// Skips entries in `RECURSIVE_SCAN_SKIP_DIRS`.
+fn collect_skill_dirs_recursive(dir: &Path, results: &mut Vec<std::path::PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() && !path.is_symlink() {
+            continue;
+        }
+        let dir_name = entry.file_name();
+        let dir_name_str = dir_name.to_string_lossy();
+        // Skip internal directories
+        if RECURSIVE_SCAN_SKIP_DIRS.iter().any(|s| dir_name_str == *s) {
+            continue;
+        }
+        if is_symlink_to_central(&path) {
+            continue;
+        }
+        // If this directory is a valid skill dir, collect it and DON'T descend further
+        if skill_metadata::is_valid_skill_dir(&path) {
+            results.push(path);
+            continue;
+        }
+        // Otherwise descend into it
+        collect_skill_dirs_recursive(&path, results);
+    }
 }
 
 #[allow(dead_code)]
@@ -56,50 +90,85 @@ pub fn scan_local_skills_with_adapters(
 
         tools_scanned += 1;
 
-        for scan_dir in adapter.all_scan_dirs() {
-            if !scan_dir.exists() {
-                continue;
+        if adapter.recursive_scan {
+            // Recursive mode: walk the tree and collect directories that contain SKILL.md
+            for scan_dir in adapter.all_scan_dirs() {
+                if !scan_dir.exists() {
+                    continue;
+                }
+                let mut skill_dirs = Vec::new();
+                collect_skill_dirs_recursive(&scan_dir, &mut skill_dirs);
+                for path in skill_dirs {
+                    let path_str = path.to_string_lossy().to_string();
+                    if managed_paths.contains(&path_str) {
+                        continue;
+                    }
+                    let name = skill_metadata::infer_skill_name(&path);
+                    let fingerprint = content_hash::hash_directory(&path).ok();
+                    let found_at = std::fs::metadata(&path)
+                        .and_then(|m| m.modified())
+                        .ok()
+                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                        .map(|d| d.as_millis() as i64)
+                        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+                    discovered.push(DiscoveredSkillRecord {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        tool: adapter.key.clone(),
+                        found_path: path_str,
+                        name_guess: Some(name),
+                        fingerprint,
+                        found_at,
+                        imported_skill_id: None,
+                    });
+                }
             }
-
-            let entries = match std::fs::read_dir(&scan_dir) {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if !path.is_dir() && !path.is_symlink() {
+        } else {
+            // Flat mode (default): treat immediate children as skills
+            for scan_dir in adapter.all_scan_dirs() {
+                if !scan_dir.exists() {
                     continue;
                 }
 
-                if is_symlink_to_central(&path) {
-                    continue;
+                let entries = match std::fs::read_dir(&scan_dir) {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if !path.is_dir() && !path.is_symlink() {
+                        continue;
+                    }
+
+                    if is_symlink_to_central(&path) {
+                        continue;
+                    }
+
+                    let path_str = path.to_string_lossy().to_string();
+                    if managed_paths.contains(&path_str) {
+                        continue;
+                    }
+
+                    let name = skill_metadata::infer_skill_name(&path);
+                    let fingerprint = content_hash::hash_directory(&path).ok();
+
+                    let found_at = std::fs::metadata(&path)
+                        .and_then(|m| m.modified())
+                        .ok()
+                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                        .map(|d| d.as_millis() as i64)
+                        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+
+                    discovered.push(DiscoveredSkillRecord {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        tool: adapter.key.clone(),
+                        found_path: path_str,
+                        name_guess: Some(name),
+                        fingerprint,
+                        found_at,
+                        imported_skill_id: None,
+                    });
                 }
-
-                let path_str = path.to_string_lossy().to_string();
-                if managed_paths.contains(&path_str) {
-                    continue;
-                }
-
-                let name = skill_metadata::infer_skill_name(&path);
-                let fingerprint = content_hash::hash_directory(&path).ok();
-
-                let found_at = std::fs::metadata(&path)
-                    .and_then(|m| m.modified())
-                    .ok()
-                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                    .map(|d| d.as_millis() as i64)
-                    .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
-
-                discovered.push(DiscoveredSkillRecord {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    tool: adapter.key.clone(),
-                    found_path: path_str,
-                    name_guess: Some(name),
-                    fingerprint,
-                    found_at,
-                    imported_skill_id: None,
-                });
             }
         }
     }

--- a/src-tauri/src/core/tool_adapters.rs
+++ b/src-tauri/src/core/tool_adapters.rs
@@ -18,6 +18,11 @@ pub struct ToolAdapter {
     /// Whether this is a user-defined custom agent (not built-in).
     #[serde(default)]
     pub is_custom: bool,
+    /// When true, scan the skills directory recursively for skill directories
+    /// (directories containing SKILL.md) instead of treating immediate children as skills.
+    /// Used by tools with nested category directories (e.g., Hermes Agent).
+    #[serde(default)]
+    pub recursive_scan: bool,
 }
 
 /// Serializable custom tool definition stored in settings.
@@ -107,6 +112,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "claude_code".into(),
@@ -119,6 +125,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             ],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "codex".into(),
@@ -128,6 +135,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "opencode".into(),
@@ -137,6 +145,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "antigravity".into(),
@@ -146,6 +155,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "amp".into(),
@@ -155,6 +165,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "kilo_code".into(),
@@ -164,6 +175,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "roo_code".into(),
@@ -173,6 +185,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "goose".into(),
@@ -182,6 +195,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "gemini_cli".into(),
@@ -191,6 +205,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "github_copilot".into(),
@@ -200,6 +215,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "openclaw".into(),
@@ -209,6 +225,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "droid".into(),
@@ -218,6 +235,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "windsurf".into(),
@@ -227,6 +245,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "trae".into(),
@@ -236,6 +255,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "cline".into(),
@@ -245,6 +265,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "deepagents".into(),
@@ -254,6 +275,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "firebender".into(),
@@ -263,6 +285,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "kimi".into(),
@@ -272,6 +295,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "replit".into(),
@@ -281,6 +305,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "warp".into(),
@@ -290,6 +315,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "augment".into(),
@@ -299,6 +325,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "bob".into(),
@@ -308,6 +335,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "codebuddy".into(),
@@ -317,6 +345,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "command_code".into(),
@@ -326,6 +355,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "continue".into(),
@@ -335,6 +365,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "cortex".into(),
@@ -344,6 +375,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "crush".into(),
@@ -353,6 +385,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "iflow".into(),
@@ -362,6 +395,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "junie".into(),
@@ -371,6 +405,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "kiro".into(),
@@ -380,6 +415,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "kode".into(),
@@ -389,6 +425,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "mcpjam".into(),
@@ -398,6 +435,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "mistral_vibe".into(),
@@ -407,6 +445,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "mux".into(),
@@ -416,6 +455,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "neovate".into(),
@@ -425,6 +465,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "openhands".into(),
@@ -434,6 +475,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "pi".into(),
@@ -443,6 +485,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "pochi".into(),
@@ -452,6 +495,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "qoder".into(),
@@ -461,6 +505,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "qwen_code".into(),
@@ -470,6 +515,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "trae_cn".into(),
@@ -479,6 +525,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "zencoder".into(),
@@ -488,6 +535,7 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
         },
         ToolAdapter {
             key: "adal".into(),
@@ -497,6 +545,17 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             is_custom: false,
+            recursive_scan: false,
+        },
+        ToolAdapter {
+            key: "hermes".into(),
+            display_name: "Hermes Agent".into(),
+            relative_skills_dir: ".hermes/skills".into(),
+            relative_detect_dir: ".hermes".into(),
+            additional_scan_dirs: vec![],
+            override_skills_dir: None,
+            is_custom: false,
+            recursive_scan: true,
         },
     ]
 }
@@ -545,6 +604,7 @@ pub fn all_tool_adapters(store: &crate::core::skill_store::SkillStore) -> Vec<To
             additional_scan_dirs: vec![],
             override_skills_dir: Some(ct.skills_dir),
             is_custom: true,
+            recursive_scan: false,
         });
     }
 
@@ -579,6 +639,7 @@ pub fn find_adapter_with_store(
             additional_scan_dirs: vec![],
             override_skills_dir: Some(ct.skills_dir),
             is_custom: true,
+            recursive_scan: false,
         })
 }
 


### PR DESCRIPTION
## Summary

Add support for [Hermes Agent](https://hermes-agent.nousresearch.com/) as a built-in tool, enabling skills-manager to discover, manage, and deploy skills for Hermes.

### Problem

Hermes Agent uses a **nested category directory** structure for skills:
```
~/.hermes/skills/devops/deploy-k8s/SKILL.md
~/.hermes/skills/software-development/super-dev/SKILL.md
```

The existing scanner only performs a flat (one-level) scan, treating each immediate child of the skills directory as a skill. This would incorrectly identify `devops/` and `software-development/` as skills instead of discovering the actual skill directories nested within them.

### Solution

1. **New field `recursive_scan`** on `ToolAdapter` — when `true`, the scanner recursively walks the directory tree and collects only directories that contain `SKILL.md`, skipping internal directories (, , `node_modules/`).

2. **Hermes adapter entry** with `recursive_scan: true`:
   - `key`: `hermes`
   - `skills_dir`: `~/.hermes/skills`
   - `detect_dir`: `~/.hermes`

3. **Backward compatible** — all existing tools retain `recursive_scan: false` (default), and their flat-scan behavior is completely unchanged.

### How to test

1. Create a mock Hermes skills directory:
   ```bash
   mkdir -p ~/.hermes/skills/devops/deploy-k8s
   echo -e '---\nname: deploy-k8s\n---\n# Deploy K8s' > ~/.hermes/skills/devops/deploy-k8s/SKILL.md
   mkdir -p ~/.hermes/skills/software-development/super-dev
   echo -e '---\nname: super-dev\n---\n# Super Dev' > ~/.hermes/skills/software-development/super-dev/SKILL.md
   ```

2. Open Skills Manager → the scanner should discover `deploy-k8s` and `super-dev` as individual skills under the Hermes tool, not `devops` or `software-development`.

3. Verify that existing tools (Cursor, Claude Code, etc.) continue to scan correctly with flat directory structures.

### Platforms tested

- macOS (development environment)
- Rust code compiles (verified struct construction correctness)
- Frontend is dynamic — no changes needed