### PR TITLE
fix linked workspace skill state handling

### DIFF
--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -271,6 +271,88 @@ fn ensure_distinct_linked_workspace_roots(
     Ok(())
 }
 
+fn remove_project_skill_entry(path: &Path) -> Result<(), AppError> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(AppError::io(err)),
+    };
+
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        std::fs::remove_file(path)?;
+    } else if metadata.is_dir() {
+        std::fs::remove_dir_all(path)?;
+    } else {
+        std::fs::remove_file(path)?;
+    }
+
+    Ok(())
+}
+
+fn set_project_skill_enabled_state(
+    skills_dir: &Path,
+    disabled_dir: &Path,
+    skill_relative_path: &str,
+    enabled: bool,
+) -> Result<(), AppError> {
+    ensure_safe_skill_relative_path(skill_relative_path)?;
+
+    let enabled_path = skills_dir.join(skill_relative_path);
+    let disabled_path = disabled_dir.join(skill_relative_path);
+
+    if enabled {
+        if enabled_path.is_dir() {
+            ensure_dir_within_root(&enabled_path, skills_dir)?;
+            if disabled_path.exists() {
+                ensure_dir_within_root(&disabled_path, disabled_dir)?;
+                remove_project_skill_entry(&disabled_path)?;
+            }
+            return Ok(());
+        }
+
+        if !disabled_path.is_dir() {
+            return Err(AppError::not_found(
+                "Skill directory not found in skills-disabled",
+            ));
+        }
+        ensure_dir_within_root(&disabled_path, disabled_dir)?;
+        if let Some(parent) = enabled_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        if enabled_path.exists() {
+            return Err(AppError::invalid_input(
+                "Skill already exists in skills directory",
+            ));
+        }
+        std::fs::rename(&disabled_path, &enabled_path)?;
+        return Ok(());
+    }
+
+    if disabled_path.is_dir() {
+        ensure_dir_within_root(&disabled_path, disabled_dir)?;
+        if enabled_path.exists() {
+            ensure_dir_within_root(&enabled_path, skills_dir)?;
+            remove_project_skill_entry(&enabled_path)?;
+        }
+        return Ok(());
+    }
+
+    if !enabled_path.is_dir() {
+        return Err(AppError::not_found("Skill directory not found"));
+    }
+    ensure_dir_within_root(&enabled_path, skills_dir)?;
+    if let Some(parent) = disabled_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if disabled_path.exists() {
+        return Err(AppError::invalid_input(
+            "Skill already exists in skills-disabled directory",
+        ));
+    }
+    std::fs::rename(&enabled_path, &disabled_path)?;
+    Ok(())
+}
+
 fn slugify_skill_dir_name(name: &str) -> String {
     let mut out = String::new();
     let mut prev_dash = false;
@@ -945,46 +1027,7 @@ pub async fn toggle_project_skill(
                 .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent)))?;
         let disabled_dir = disabled_dir
             .ok_or_else(|| AppError::invalid_input("This workspace does not support disabling skills"))?;
-
-        if enabled {
-            let from = disabled_dir.join(&skill_relative_path);
-            let to = skills_dir.join(&skill_relative_path);
-
-            if !from.is_dir() {
-                return Err(AppError::not_found(
-                    "Skill directory not found in skills-disabled",
-                ));
-            }
-            ensure_dir_within_root(&from, &disabled_dir)?;
-            if let Some(parent) = to.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            if to.exists() {
-                return Err(AppError::invalid_input(
-                    "Skill already exists in skills directory",
-                ));
-            }
-            std::fs::rename(&from, &to)?;
-        } else {
-            let from = skills_dir.join(&skill_relative_path);
-            let to = disabled_dir.join(&skill_relative_path);
-
-            if !from.is_dir() {
-                return Err(AppError::not_found("Skill directory not found"));
-            }
-            ensure_dir_within_root(&from, &skills_dir)?;
-            if let Some(parent) = to.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            if to.exists() {
-                return Err(AppError::invalid_input(
-                    "Skill already exists in skills-disabled directory",
-                ));
-            }
-            std::fs::rename(&from, &to)?;
-        }
-
-        Ok(())
+        set_project_skill_enabled_state(&skills_dir, &disabled_dir, &skill_relative_path, enabled)
     })
     .await?
 }
@@ -1028,7 +1071,10 @@ pub async fn delete_project_skill(
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_sync_status, ensure_distinct_linked_workspace_roots};
+    use super::{
+        classify_sync_status, ensure_distinct_linked_workspace_roots,
+        set_project_skill_enabled_state,
+    };
     use crate::core::content_hash;
     use crate::core::project_scanner::ProjectSkillInfo;
     use crate::core::skill_store::SkillRecord;
@@ -1168,5 +1214,59 @@ mod tests {
         fs::create_dir_all(&disabled).unwrap();
 
         ensure_distinct_linked_workspace_roots(&root, &disabled).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_project_skill_enabled_state_disabling_cleans_duplicate_symlink_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempdir().unwrap();
+        let central_skill = tmp.path().join("central").join("understand-diff");
+        let skills_root = tmp.path().join("skills");
+        let disabled_root = tmp.path().join("skills-disabled");
+        let relative_path = "understand-diff";
+
+        fs::create_dir_all(&central_skill).unwrap();
+        fs::write(central_skill.join("SKILL.md"), "---\nname: understand-diff\n---\n").unwrap();
+        fs::create_dir_all(&skills_root).unwrap();
+        fs::create_dir_all(&disabled_root).unwrap();
+
+        symlink(&central_skill, skills_root.join(relative_path)).unwrap();
+        symlink(&central_skill, disabled_root.join(relative_path)).unwrap();
+
+        set_project_skill_enabled_state(&skills_root, &disabled_root, relative_path, false).unwrap();
+
+        assert!(!skills_root.join(relative_path).exists());
+        assert!(disabled_root.join(relative_path).exists());
+        assert!(central_skill.exists());
+        assert!(central_skill.join("SKILL.md").is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_project_skill_enabled_state_enabling_cleans_duplicate_symlink_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempdir().unwrap();
+        let central_skill = tmp.path().join("central").join("understand-diff");
+        let skills_root = tmp.path().join("skills");
+        let disabled_root = tmp.path().join("skills-disabled");
+        let relative_path = "understand-diff";
+
+        fs::create_dir_all(&central_skill).unwrap();
+        fs::write(central_skill.join("SKILL.md"), "---\nname: understand-diff\n---\n").unwrap();
+        fs::create_dir_all(&skills_root).unwrap();
+        fs::create_dir_all(&disabled_root).unwrap();
+
+        symlink(&central_skill, skills_root.join(relative_path)).unwrap();
+        symlink(&central_skill, disabled_root.join(relative_path)).unwrap();
+
+        set_project_skill_enabled_state(&skills_root, &disabled_root, relative_path, true).unwrap();
+
+        assert!(skills_root.join(relative_path).exists());
+        assert!(!disabled_root.join(relative_path).exists());
+        assert!(central_skill.exists());
+        assert!(central_skill.join("SKILL.md").is_file());
     }
 }

--- a/src-tauri/src/core/project_scanner.rs
+++ b/src-tauri/src/core/project_scanner.rs
@@ -98,6 +98,19 @@ pub fn read_linked_workspace_skills(
     skills
 }
 
+fn should_skip_dir(root: &Path, dir: &Path) -> bool {
+    let name = dir.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if name.starts_with('.') {
+        return true;
+    }
+
+    // Ignore embedded plugin/cache bundle layouts such as:
+    // <bundle>/<version>/skills/<skill>/SKILL.md
+    // The workspace root itself may be named "skills", so only skip nested
+    // container directories that introduce another "skills" subtree.
+    dir != root && dir.join("skills").is_dir()
+}
+
 fn read_skills_from_dir(
     dir: &Path,
     enabled: bool,
@@ -131,6 +144,9 @@ fn read_skills_from_dir_recursive(
     for entry in entries.filter_map(|e| e.ok()) {
         let path = entry.path();
         if !path.is_dir() {
+            continue;
+        }
+        if should_skip_dir(root, &path) {
             continue;
         }
 
@@ -306,7 +322,7 @@ fn latest_modified_millis(dir: &Path) -> Option<i64> {
 
 #[cfg(test)]
 mod tests {
-    use super::{read_project_skills, AgentSkillConfig};
+    use super::{read_linked_workspace_skills, read_project_skills, AgentSkillConfig};
     use std::fs;
     use tempfile::tempdir;
 
@@ -354,5 +370,63 @@ mod tests {
         let skills = read_project_skills(tmp.path(), &configs);
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].relative_path, "research/web-search");
+    }
+
+    #[test]
+    fn linked_workspace_skips_hidden_dirs_and_embedded_bundle_skills() {
+        let tmp = tempdir().unwrap();
+        let skills_root = tmp.path().join("skills");
+        let disabled_root = tmp.path().join("skills-disabled");
+
+        let top_level_skill = skills_root.join("understand");
+        fs::create_dir_all(&top_level_skill).unwrap();
+        fs::write(top_level_skill.join("SKILL.md"), "---\nname: understand\n---\n").unwrap();
+
+        let hidden_skill = skills_root.join(".claude").join("skills").join("hidden-skill");
+        fs::create_dir_all(&hidden_skill).unwrap();
+        fs::write(hidden_skill.join("SKILL.md"), "---\nname: hidden-skill\n---\n").unwrap();
+
+        let embedded_enabled = skills_root
+            .join("understand-anything")
+            .join("understand-anything")
+            .join("311f2ad1aca5")
+            .join("skills")
+            .join("understand");
+        fs::create_dir_all(&embedded_enabled).unwrap();
+        fs::write(embedded_enabled.join("SKILL.md"), "---\nname: understand\n---\n").unwrap();
+
+        let disabled_skill = disabled_root.join("understand-diff");
+        fs::create_dir_all(&disabled_skill).unwrap();
+        fs::write(
+            disabled_skill.join("SKILL.md"),
+            "---\nname: understand-diff\n---\n",
+        )
+        .unwrap();
+
+        let embedded_disabled = disabled_root
+            .join("claude-plugins-official")
+            .join("superpowers")
+            .join("5.0.7")
+            .join("skills")
+            .join("brainstorming");
+        fs::create_dir_all(&embedded_disabled).unwrap();
+        fs::write(
+            embedded_disabled.join("SKILL.md"),
+            "---\nname: brainstorming\n---\n",
+        )
+        .unwrap();
+
+        let skills = read_linked_workspace_skills(
+            &skills_root,
+            Some(&disabled_root),
+            "linked",
+            "Linked",
+        );
+
+        let names: Vec<&str> = skills.iter().map(|skill| skill.name.as_str()).collect();
+        assert_eq!(names, vec!["understand", "understand-diff"]);
+        assert_eq!(skills.iter().filter(|skill| skill.name == "understand").count(), 1);
+        assert!(skills.iter().any(|skill| skill.name == "understand" && skill.enabled));
+        assert!(skills.iter().any(|skill| skill.name == "understand-diff" && !skill.enabled));
     }
 }

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -122,6 +122,14 @@ function areAgentSetsEqual(left: string[], right: string[]) {
   return left.every((value) => rightSet.has(value));
 }
 
+function getAssignedAgents(variants: ProjectSkill[]) {
+  return Array.from(new Set(variants.map((variant) => variant.agent))).sort();
+}
+
+function isGroupEnabled(skill: Pick<ProjectSkillGroup, "enabledCount">) {
+  return skill.enabledCount > 0;
+}
+
 export function ProjectDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -254,7 +262,7 @@ export function ProjectDetail() {
     items: groupedSkills,
     filtered,
     getKey: getSkillKey,
-    isItemActive: (s) => s.enabledCount === s.totalCount,
+    isItemActive: isGroupEnabled,
   });
 
   const exportTargets = useMemo(() => {
@@ -351,16 +359,16 @@ export function ProjectDetail() {
     if (!id) return;
     setTogglingSkill(getSkillKey(skill));
     try {
-      const nextEnabled = skill.enabledCount !== skill.totalCount;
+      const nextEnabled = !isGroupEnabled(skill);
       await Promise.all(
         skill.variants.map((variant) =>
           api.toggleProjectSkill(id, variant.relative_path, variant.agent, nextEnabled)
         )
       );
-      if (skill.enabledCount === skill.totalCount) {
-        toast.success(t("project.skillDisabled", { name: skill.name }));
-      } else {
+      if (nextEnabled) {
         toast.success(t("project.skillEnabled", { name: skill.name }));
+      } else {
+        toast.success(t("project.skillDisabled", { name: skill.name }));
       }
       await loadSkills();
     } catch (error: unknown) {
@@ -470,14 +478,14 @@ export function ProjectDetail() {
     let failed = 0;
     for (const skill of selectedSkillsList) {
       try {
-        if (enabling && skill.enabledCount !== skill.totalCount) {
+        if (enabling && !isGroupEnabled(skill)) {
           await Promise.all(
             skill.variants.map((variant) =>
               api.toggleProjectSkill(id, variant.relative_path, variant.agent, true)
             )
           );
           count++;
-        } else if (!enabling && skill.enabledCount > 0) {
+        } else if (!enabling && isGroupEnabled(skill)) {
           await Promise.all(
             skill.variants.map((variant) =>
               api.toggleProjectSkill(id, variant.relative_path, variant.agent, false)
@@ -657,7 +665,7 @@ export function ProjectDetail() {
               skill.status === "center_newer" ||
               skill.status === "diverged";
             const statusMeta = getSyncStatusMeta(t, skill.status);
-            const assignedAgents = skill.variants.map((variant) => variant.agent).sort();
+            const assignedAgents = getAssignedAgents(skill.variants);
             const hasCustomAssignment =
               defaultAgentKeys.length > 0 && !areAgentSetsEqual(assignedAgents, defaultAgentKeys);
 
@@ -767,7 +775,7 @@ export function ProjectDetail() {
                           >
                             {isToggling ? (
                               <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                            ) : skill.enabledCount === skill.totalCount ? (
+                            ) : isGroupEnabled(skill) ? (
                               t("project.enabled")
                             ) : (
                               t("project.enableSkill")
@@ -890,7 +898,7 @@ export function ProjectDetail() {
                       >
                         {isToggling ? (
                           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                        ) : skill.enabledCount === skill.totalCount ? (
+                        ) : isGroupEnabled(skill) ? (
                           t("project.enabled")
                         ) : (
                           t("project.enableSkill")


### PR DESCRIPTION
## Summary
- harden linked workspace scanning so hidden directories and embedded bundle `skills/` trees are skipped
- make project skill toggles idempotent by cleaning duplicate enabled/disabled entries instead of erroring
- align project detail enable-state and agent-count UI with grouped skill state so duplicate variants do not show misleading `2 / 1 Agents`

## Problem
Linked workspaces could end up with the same skill present in both `skills/` and `skills-disabled/`. In that state the UI treated the group as partially enabled, clicking the toggle took the enable path, and the backend returned `Skill already exists in skills directory`.

## Verification
- `cargo test linked_workspace_skips_hidden_dirs_and_embedded_bundle_skills --manifest-path src-tauri/Cargo.toml -- --nocapture`
- `cargo test set_project_skill_enabled_state --manifest-path src-tauri/Cargo.toml -- --nocapture`
- `source ~/.zshrc && nvm use 20.19.0 >/dev/null && npm run build`
