### PR TITLE
chore: add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tianliang Zhang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "skills-manager",
   "private": true,
   "version": "1.14.1",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Add standard MIT `LICENSE` file at repo root (`Copyright (c) 2026 Tianliang Zhang`)
- Add `"license": "MIT"` to `package.json`

Brings the three license declaration sites into agreement: `LICENSE` / `Cargo.toml` / `package.json` / `README.md` all now state MIT. Previously `Cargo.toml` and README claimed MIT while `package.json` had no license field and the root had no LICENSE file, which causes GitHub to tag the repo as "No license."

## Test plan

- [ ] GitHub's license detector on the repo page shows "MIT License"
- [ ] `npm install` / `cargo build` still work (no schema-level changes, just metadata)