### PR TITLE
fix: handle linked workspace skill duplicates safely

### DIFF
--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -262,6 +262,85 @@ fn remove_workspace_skill_target(path: &Path) -> Result<(), AppError> {
     Ok(())
 }
 
+fn remove_symlink_entry(path: &Path) -> Result<(), AppError> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(AppError::io(err)),
+    };
+    if !metadata.file_type().is_symlink() {
+        return Err(AppError::invalid_input(
+            "Duplicate skill entry is not a symlink — resolve manually",
+        ));
+    }
+    std::fs::remove_file(path)?;
+    Ok(())
+}
+
+fn set_project_skill_enabled_state(
+    skills_dir: &Path,
+    disabled_dir: &Path,
+    skill_relative_path: &str,
+    enabled: bool,
+) -> Result<(), AppError> {
+    ensure_safe_skill_relative_path(skill_relative_path)?;
+
+    let enabled_path = skills_dir.join(skill_relative_path);
+    let disabled_path = disabled_dir.join(skill_relative_path);
+
+    if enabled {
+        if enabled_path.is_dir() {
+            ensure_dir_within_root(&enabled_path, skills_dir)?;
+            if disabled_path.exists() {
+                ensure_dir_within_root(&disabled_path, disabled_dir)?;
+                remove_symlink_entry(&disabled_path)?;
+            }
+            return Ok(());
+        }
+
+        if !disabled_path.is_dir() {
+            return Err(AppError::not_found(
+                "Skill directory not found in skills-disabled",
+            ));
+        }
+        ensure_dir_within_root(&disabled_path, disabled_dir)?;
+        if let Some(parent) = enabled_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        if enabled_path.exists() {
+            return Err(AppError::invalid_input(
+                "Skill already exists in skills directory",
+            ));
+        }
+        std::fs::rename(&disabled_path, &enabled_path)?;
+        return Ok(());
+    }
+
+    if disabled_path.is_dir() {
+        ensure_dir_within_root(&disabled_path, disabled_dir)?;
+        if enabled_path.exists() {
+            ensure_dir_within_root(&enabled_path, skills_dir)?;
+            remove_symlink_entry(&enabled_path)?;
+        }
+        return Ok(());
+    }
+
+    if !enabled_path.is_dir() {
+        return Err(AppError::not_found("Skill directory not found"));
+    }
+    ensure_dir_within_root(&enabled_path, skills_dir)?;
+    if let Some(parent) = disabled_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if disabled_path.exists() {
+        return Err(AppError::invalid_input(
+            "Skill already exists in skills-disabled directory",
+        ));
+    }
+    std::fs::rename(&enabled_path, &disabled_path)?;
+    Ok(())
+}
+
 fn ensure_distinct_linked_workspace_roots(
     skills_root: &Path,
     disabled_root: &Path,
@@ -958,45 +1037,7 @@ pub async fn toggle_project_skill(
             AppError::invalid_input("This workspace does not support disabling skills")
         })?;
 
-        if enabled {
-            let from = disabled_dir.join(&skill_relative_path);
-            let to = skills_dir.join(&skill_relative_path);
-
-            if !from.is_dir() {
-                return Err(AppError::not_found(
-                    "Skill directory not found in skills-disabled",
-                ));
-            }
-            ensure_dir_within_root(&from, &disabled_dir)?;
-            if let Some(parent) = to.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            if to.exists() {
-                return Err(AppError::invalid_input(
-                    "Skill already exists in skills directory",
-                ));
-            }
-            std::fs::rename(&from, &to)?;
-        } else {
-            let from = skills_dir.join(&skill_relative_path);
-            let to = disabled_dir.join(&skill_relative_path);
-
-            if !from.is_dir() {
-                return Err(AppError::not_found("Skill directory not found"));
-            }
-            ensure_dir_within_root(&from, &skills_dir)?;
-            if let Some(parent) = to.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            if to.exists() {
-                return Err(AppError::invalid_input(
-                    "Skill already exists in skills-disabled directory",
-                ));
-            }
-            std::fs::rename(&from, &to)?;
-        }
-
-        Ok(())
+        set_project_skill_enabled_state(&skills_dir, &disabled_dir, &skill_relative_path, enabled)
     })
     .await?
 }
@@ -1045,8 +1086,10 @@ pub async fn delete_project_skill(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_sync_status, ensure_distinct_linked_workspace_roots, remove_workspace_skill_target,
+        classify_sync_status, ensure_distinct_linked_workspace_roots,
+        remove_workspace_skill_target, set_project_skill_enabled_state,
     };
+    use crate::core::error::ErrorKind;
     use crate::core::content_hash;
     use crate::core::project_scanner::ProjectSkillInfo;
     use crate::core::skill_store::SkillRecord;
@@ -1204,5 +1247,111 @@ mod tests {
         assert!(!link.exists());
         assert!(real.exists());
         assert!(real.join("SKILL.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_project_skill_enabled_state_disabling_cleans_duplicate_symlink_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempdir().unwrap();
+        let central_skill = tmp.path().join("central").join("understand-diff");
+        let skills_root = tmp.path().join("skills");
+        let disabled_root = tmp.path().join("skills-disabled");
+        let relative_path = "understand-diff";
+
+        fs::create_dir_all(&central_skill).unwrap();
+        fs::write(
+            central_skill.join("SKILL.md"),
+            "---\nname: understand-diff\n---\n",
+        )
+        .unwrap();
+        fs::create_dir_all(&skills_root).unwrap();
+        fs::create_dir_all(&disabled_root).unwrap();
+
+        symlink(&central_skill, skills_root.join(relative_path)).unwrap();
+        symlink(&central_skill, disabled_root.join(relative_path)).unwrap();
+
+        set_project_skill_enabled_state(&skills_root, &disabled_root, relative_path, false)
+            .unwrap();
+
+        assert!(!skills_root.join(relative_path).exists());
+        assert!(disabled_root.join(relative_path).exists());
+        assert!(central_skill.exists());
+        assert!(central_skill.join("SKILL.md").is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_project_skill_enabled_state_enabling_cleans_duplicate_symlink_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempdir().unwrap();
+        let central_skill = tmp.path().join("central").join("understand-diff");
+        let skills_root = tmp.path().join("skills");
+        let disabled_root = tmp.path().join("skills-disabled");
+        let relative_path = "understand-diff";
+
+        fs::create_dir_all(&central_skill).unwrap();
+        fs::write(
+            central_skill.join("SKILL.md"),
+            "---\nname: understand-diff\n---\n",
+        )
+        .unwrap();
+        fs::create_dir_all(&skills_root).unwrap();
+        fs::create_dir_all(&disabled_root).unwrap();
+
+        symlink(&central_skill, skills_root.join(relative_path)).unwrap();
+        symlink(&central_skill, disabled_root.join(relative_path)).unwrap();
+
+        set_project_skill_enabled_state(&skills_root, &disabled_root, relative_path, true).unwrap();
+
+        assert!(skills_root.join(relative_path).exists());
+        assert!(!disabled_root.join(relative_path).exists());
+        assert!(central_skill.exists());
+        assert!(central_skill.join("SKILL.md").is_file());
+    }
+
+    #[test]
+    fn set_project_skill_enabled_state_rejects_real_dir_duplicate_on_enable() {
+        let tmp = tempdir().unwrap();
+        let skills_root = tmp.path().join("skills");
+        let disabled_root = tmp.path().join("skills-disabled");
+        let relative_path = "my-skill";
+
+        let real_enabled = skills_root.join(relative_path);
+        let real_disabled = disabled_root.join(relative_path);
+        fs::create_dir_all(&real_enabled).unwrap();
+        fs::write(real_enabled.join("SKILL.md"), "---\nname: my-skill\n---\n").unwrap();
+        fs::create_dir_all(&real_disabled).unwrap();
+        fs::write(real_disabled.join("SKILL.md"), "---\nname: my-skill\n---\n").unwrap();
+
+        let err = set_project_skill_enabled_state(&skills_root, &disabled_root, relative_path, true)
+            .unwrap_err();
+        assert_eq!(err.kind, ErrorKind::InvalidInput);
+        // Both real dirs must still exist
+        assert!(real_enabled.join("SKILL.md").exists());
+        assert!(real_disabled.join("SKILL.md").exists());
+    }
+
+    #[test]
+    fn set_project_skill_enabled_state_rejects_real_dir_duplicate_on_disable() {
+        let tmp = tempdir().unwrap();
+        let skills_root = tmp.path().join("skills");
+        let disabled_root = tmp.path().join("skills-disabled");
+        let relative_path = "my-skill";
+
+        let real_enabled = skills_root.join(relative_path);
+        let real_disabled = disabled_root.join(relative_path);
+        fs::create_dir_all(&real_enabled).unwrap();
+        fs::write(real_enabled.join("SKILL.md"), "---\nname: my-skill\n---\n").unwrap();
+        fs::create_dir_all(&real_disabled).unwrap();
+        fs::write(real_disabled.join("SKILL.md"), "---\nname: my-skill\n---\n").unwrap();
+
+        let err = set_project_skill_enabled_state(&skills_root, &disabled_root, relative_path, false)
+            .unwrap_err();
+        assert_eq!(err.kind, ErrorKind::InvalidInput);
+        assert!(real_enabled.join("SKILL.md").exists());
+        assert!(real_disabled.join("SKILL.md").exists());
     }
 }

--- a/src-tauri/src/core/error.rs
+++ b/src-tauri/src/core/error.rs
@@ -11,7 +11,7 @@ pub struct AppError {
     pub message: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorKind {
     Database,

--- a/src-tauri/src/core/project_scanner.rs
+++ b/src-tauri/src/core/project_scanner.rs
@@ -100,6 +100,19 @@ pub fn read_linked_workspace_skills(
     skills
 }
 
+fn should_skip_dir(root: &Path, dir: &Path) -> bool {
+    let name = dir.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if name.starts_with('.') {
+        return true;
+    }
+
+    // Ignore embedded plugin/cache bundle layouts such as:
+    // <bundle>/<version>/skills/<skill>/SKILL.md
+    // The workspace root itself may be named "skills", so only skip nested
+    // container directories that introduce another "skills" subtree.
+    dir != root && dir.join("skills").is_dir()
+}
+
 fn read_skills_from_dir(
     dir: &Path,
     enabled: bool,
@@ -186,6 +199,11 @@ fn read_skills_from_dir_recursive(
         // Only check visited set before recursing into namespace dirs
         // to prevent symlink cycles. Skill dirs (above) are leaf nodes and
         // are allowed to alias the same canonical target.
+
+        if should_skip_dir(root, &path) {
+            continue;
+        }
+
         let canon = match std::fs::canonicalize(&path) {
             Ok(c) => c,
             Err(_) => continue,
@@ -325,7 +343,7 @@ fn latest_modified_millis(dir: &Path) -> Option<i64> {
 
 #[cfg(test)]
 mod tests {
-    use super::{read_project_skills, AgentSkillConfig};
+    use super::{read_linked_workspace_skills, read_project_skills, AgentSkillConfig};
     use std::fs;
     use tempfile::tempdir;
 
@@ -373,5 +391,70 @@ mod tests {
         let skills = read_project_skills(tmp.path(), &configs);
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].relative_path, "research/web-search");
+    }
+
+    #[test]
+    fn linked_workspace_skips_hidden_dirs_and_embedded_bundle_skills() {
+        let tmp = tempdir().unwrap();
+        let skills_root = tmp.path().join("skills");
+        let disabled_root = tmp.path().join("skills-disabled");
+
+        let top_level_skill = skills_root.join("understand");
+        fs::create_dir_all(&top_level_skill).unwrap();
+        fs::write(top_level_skill.join("SKILL.md"), "---\nname: understand\n---\n").unwrap();
+
+        let hidden_skill = skills_root.join(".claude").join("skills").join("hidden-skill");
+        fs::create_dir_all(&hidden_skill).unwrap();
+        fs::write(hidden_skill.join("SKILL.md"), "---\nname: hidden-skill\n---\n").unwrap();
+
+        let embedded_enabled = skills_root
+            .join("understand-anything")
+            .join("understand-anything")
+            .join("311f2ad1aca5")
+            .join("skills")
+            .join("understand");
+        fs::create_dir_all(&embedded_enabled).unwrap();
+        fs::write(embedded_enabled.join("SKILL.md"), "---\nname: understand\n---\n").unwrap();
+
+        let disabled_skill = disabled_root.join("understand-diff");
+        fs::create_dir_all(&disabled_skill).unwrap();
+        fs::write(
+            disabled_skill.join("SKILL.md"),
+            "---\nname: understand-diff\n---\n",
+        )
+        .unwrap();
+
+        let embedded_disabled = disabled_root
+            .join("claude-plugins-official")
+            .join("superpowers")
+            .join("5.0.7")
+            .join("skills")
+            .join("brainstorming");
+        fs::create_dir_all(&embedded_disabled).unwrap();
+        fs::write(
+            embedded_disabled.join("SKILL.md"),
+            "---\nname: brainstorming\n---\n",
+        )
+        .unwrap();
+
+        let skills = read_linked_workspace_skills(
+            &skills_root,
+            Some(&disabled_root),
+            "linked",
+            "Linked",
+        );
+
+        let names: Vec<&str> = skills.iter().map(|skill| skill.name.as_str()).collect();
+        assert_eq!(names, vec!["understand", "understand-diff"]);
+        assert_eq!(
+            skills.iter().filter(|skill| skill.name == "understand").count(),
+            1
+        );
+        assert!(skills
+            .iter()
+            .any(|skill| skill.name == "understand" && skill.enabled));
+        assert!(skills
+            .iter()
+            .any(|skill| skill.name == "understand-diff" && !skill.enabled));
     }
 }

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -108,6 +108,22 @@ function getSyncStatusMeta(t: (key: string) => string, status: ProjectSkill["syn
   }
 }
 
+function getAssignedAgents(variants: ProjectSkill[]) {
+  return Array.from(new Set(variants.map((variant) => variant.agent))).sort();
+}
+
+function getAgentDotTargets(variants: ProjectSkill[]) {
+  const seen = new Set<string>();
+  const targets: { key: string; display_name: string }[] = [];
+  for (const v of variants) {
+    if (!seen.has(v.agent)) {
+      seen.add(v.agent);
+      targets.push({ key: v.agent, display_name: v.agent_display_name });
+    }
+  }
+  return targets;
+}
+
 function getGroupStatus(variants: ProjectSkill[]): ProjectSkill["sync_status"] {
   const priority: ProjectSkill["sync_status"][] = [
     "diverged",
@@ -907,7 +923,7 @@ export function ProjectDetail() {
               skill.status === "center_newer" ||
               skill.status === "diverged";
             const statusMeta = getSyncStatusMeta(t, skill.status);
-            const assignedAgents = skill.variants.map((variant) => variant.agent).sort();
+            const assignedAgents = getAssignedAgents(skill.variants);
 
             if (viewMode === "grid") {
               return (
@@ -1298,10 +1314,10 @@ function ProjectSkillDetailPanel({
     <>
       <div className="flex flex-wrap items-center gap-2 text-[12.5px] text-muted">
         <ProjectAgentDots
-          assignedAgents={skill.variants.map((variant) => variant.agent)}
-          targets={skill.variants.map((variant) => ({
-            key: variant.agent,
-            display_name: variant.agent_display_name,
+          assignedAgents={getAssignedAgents(skill.variants)}
+          targets={getAgentDotTargets(skill.variants).map((t) => ({
+            key: t.key,
+            display_name: t.display_name,
             enabled: true,
             installed: true,
             is_custom: false,


### PR DESCRIPTION
## Summary
- Skip hidden dirs and embedded bundle `skills/` subtrees during linked workspace scanning
- Make skill toggle idempotent: auto-clean symlink duplicates, reject real-dir conflicts to prevent data loss
- Deduplicate agent display in project detail UI using Set-based helpers

## Problem
Linked workspaces could end up with the same skill present in both `skills/` and `skills-disabled/`. In that state the UI showed duplicated agent counts, and toggling errored with "Skill already exists in skills directory".

Based on and supersedes #65 (thanks @linziyanleo for the original analysis and fix).

## Test plan
- [x] `cargo test` — 152 passed (5 new tests)
- [x] `npm run build` — clean
- [x] Codex review — 2 rounds, converged clean