### PR TITLE
Compensate root layout size for zoom-based text scaling

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -28,7 +28,7 @@ export function Layout() {
   }, [navigate]);
 
   return (
-    <div className="relative flex h-screen w-full overflow-hidden bg-background text-primary">
+    <div className="relative flex h-full w-full overflow-hidden bg-background text-primary">
       {/* Full-width top drag bar — spans sidebar + content, with bottom divider */}
       <div
         onMouseDown={onDrag}

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -4,6 +4,7 @@ import { listen } from "@tauri-apps/api/event";
 import type { ManagedSkill, Project, Scenario, ToolInfo } from "../lib/tauri";
 import * as api from "../lib/tauri";
 import i18n from "../i18n";
+import { applyTextSize } from "../lib/textScale";
 import { toast } from "sonner";
 
 interface AppState {
@@ -123,8 +124,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       // Apply saved text size on startup
       const savedSize = await api.getSettings("text_size").catch(() => null);
       if (savedSize) {
-        const zoomMap: Record<string, string> = { small: "0.9", default: "1", large: "1.1", xlarge: "1.2" };
-        document.documentElement.style.zoom = zoomMap[savedSize] || "1";
+        applyTextSize(savedSize);
       }
     }
     init();

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,7 @@
 @layer base {
   /* Light theme (default) */
   :root {
+    --app-scale: 1;
     --color-bg: #FAFAFA;
     --color-bg-secondary: #F4F4F5;
     --color-surface: #FFFFFF;
@@ -56,13 +57,16 @@
     }
   }
 
+  html,
+  body,
+  #root {
+    height: calc(100vh / var(--app-scale));
+    width: calc(100vw / var(--app-scale));
+  }
+
   body {
     @apply bg-background text-primary font-sans antialiased overflow-hidden;
     letter-spacing: -0.005em;
-  }
-
-  #root {
-    @apply h-screen;
   }
 }
 

--- a/src/lib/textScale.ts
+++ b/src/lib/textScale.ts
@@ -1,0 +1,12 @@
+export const TEXT_SIZE_SCALE_MAP: Record<string, string> = {
+  small: "0.9",
+  default: "1",
+  large: "1.1",
+  xlarge: "1.2",
+};
+
+export function applyTextSize(size: string) {
+  const scale = TEXT_SIZE_SCALE_MAP[size] || TEXT_SIZE_SCALE_MAP.default;
+  document.documentElement.style.zoom = scale;
+  document.documentElement.style.setProperty("--app-scale", scale);
+}

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -37,16 +37,11 @@ import { cn } from "../utils";
 import { useApp } from "../context/AppContext";
 import { useThemeContext } from "../context/ThemeContext";
 import * as api from "../lib/tauri";
+import { applyTextSize } from "../lib/textScale";
 import type { AppUpdateInfo } from "../lib/tauri";
 import type { Theme } from "../hooks/useTheme";
 
 const IS_WINDOWS = navigator.userAgent.includes("Windows");
-const TEXT_SIZE_ZOOM_MAP: Record<string, string> = {
-  small: "0.9",
-  default: "1",
-  large: "1.1",
-  xlarge: "1.2",
-};
 
 const MAINSTREAM_AGENT_KEYS = new Set([
   "claude_code",
@@ -60,10 +55,6 @@ const MAINSTREAM_AGENT_KEYS = new Set([
   "antigravity",
   "amp",
 ]);
-
-function applyTextSize(size: string) {
-  document.documentElement.style.zoom = TEXT_SIZE_ZOOM_MAP[size] || "1";
-}
 
 function compactHomePath(path: string) {
   return path


### PR DESCRIPTION
## Summary

- fix settings page scrolling when app text size is changed via the existing zoom-based text scale setting
- keep the current `zoom` implementation, but add a shared `--app-scale` CSS variable so the root container can compensate its width and height
- avoid introducing a transformed wrapper, so portaled overlays and existing `position: fixed` dialogs keep their current behavior

## Problem

The Settings page used the app-wide text size setting implemented through `document.documentElement.style.zoom`. When switching to a smaller text size, the page could show extra blank space near the bottom. When switching to a larger text size, the bottom portion of the Settings content could become unreachable.

This happened because the UI was visually scaled, but the root layout and scroll container sizing still assumed the unscaled viewport dimensions.

## Validation

<img width="1552" height="972" alt="截屏2026-04-21 16 39 14" src="https://github.com/user-attachments/assets/3dda2419-ac48-4c00-8747-9ee6f6c21179" />
<img width="1552" height="972" alt="截屏2026-04-21 16 39 18" src="https://github.com/user-attachments/assets/06f1bec8-899c-463f-89d7-00ca5a6bfb8d" />
<img width="1552" height="972" alt="截屏2026-04-21 16 39 21" src="https://github.com/user-attachments/assets/cc8ca0d3-aa2a-4c88-bab6-4fdb91896755" />

Closes #63
