### PR TITLE
fix(git): fix pull failing with 'Cannot rebase onto multiple branches'

### DIFF
--- a/src-tauri/src/core/git_backup.rs
+++ b/src-tauri/src/core/git_backup.rs
@@ -53,6 +53,24 @@ pub struct GitBackupVersion {
     pub committed_at: String,
 }
 
+/// Fetch from the remote without modifying the working tree.
+/// Silently succeeds when there is no remote or the network is unreachable,
+/// so callers can use it as a best-effort refresh before reading status.
+pub fn fetch_remote(skills_dir: &Path) -> Result<()> {
+    if !skills_dir.join(".git").exists() {
+        return Ok(());
+    }
+    // Only attempt fetch when a remote is configured.
+    if run_git(skills_dir, &["remote", "get-url", "origin"]).is_err() {
+        return Ok(());
+    }
+    let branch = run_git(skills_dir, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .unwrap_or_else(|_| "main".to_string());
+    // Best-effort: ignore network errors so the UI still works offline.
+    let _ = run_git(skills_dir, &["fetch", "--quiet", "origin", &branch]);
+    Ok(())
+}
+
 /// Get the current git status of the skills directory.
 pub fn get_status(skills_dir: &Path) -> Result<GitBackupStatus> {
     if !skills_dir.join(".git").exists() {
@@ -280,7 +298,14 @@ pub fn pull(skills_dir: &Path) -> Result<()> {
 pub(crate) fn pull_unlocked(skills_dir: &Path) -> Result<()> {
     ensure_repo(skills_dir)?;
     ensure_no_interrupted_git_operation(skills_dir)?;
-    run_git_checked(skills_dir, &["pull", "--no-rebase"])?;
+    let branch = run_git(skills_dir, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .unwrap_or_else(|_| "main".to_string());
+
+    // Use explicit fetch + merge instead of `git pull` to avoid
+    // "Cannot rebase onto multiple branches" when the remote tracking
+    // configuration references more than one merge target.
+    run_git_checked(skills_dir, &["fetch", "origin", &branch])?;
+    run_git_checked(skills_dir, &["merge", &format!("origin/{}", branch)])?;
     Ok(())
 }
 
@@ -568,8 +593,27 @@ fn run_git(dir: &Path, args: &[&str]) -> Result<String> {
     if output.status.success() {
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        anyhow::bail!("git command failed: {}", redact_urls_in_text(&stderr))
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Strip SSH informational warnings (e.g. post-quantum key exchange)
+        // so the user only sees the actual git error.
+        let filtered: String = stderr
+            .lines()
+            .filter(|line| {
+                let trimmed = line.trim().trim_start_matches("** ");
+                !trimmed.starts_with("WARNING:")
+                    && !trimmed.starts_with("This session may")
+                    && !trimmed.starts_with("The server may")
+                    && !trimmed.starts_with("See https://openssh.com")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let msg = filtered.trim();
+        let msg = if msg.is_empty() {
+            stderr.trim().to_string()
+        } else {
+            msg.to_string()
+        };
+        anyhow::bail!("git command failed: {}", redact_urls_in_text(&msg))
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix `git pull` failing with `fatal: Cannot rebase onto multiple branches` when the remote tracking configuration references more than one merge target
- Replace `git pull --no-rebase` with explicit `git fetch origin <branch>` + `git merge origin/<branch>` to avoid ambiguity
- Filter SSH post-quantum key exchange warnings from git stderr so users only see actual git errors
- Add `fetch_remote()` helper for best-effort remote status refresh without modifying the working tree

## Problem

When a user's git config has multiple merge refs configured for a branch (e.g. from previous `git fetch origin` pulling all branches), `git pull` fails with:

```
fatal: Cannot rebase onto multiple branches.
```

Additionally, SSH connections to servers without post-quantum key exchange show noisy warnings that get included in error messages shown to users.

## Changes

- `src-tauri/src/core/git_backup.rs`:
  - `pull_unlocked()`: replaced `git pull --no-rebase` with `fetch origin <branch>` + `merge origin/<branch>`
  - `run_git()`: filter `** WARNING:` lines from SSH stderr before displaying errors
  - Added `fetch_remote()` function for lightweight remote status checks