### PR TITLE
feat(install): cache cloned repos and show real-time clone progress

### DIFF
--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -416,11 +416,26 @@ pub async fn install_git(
 
         emit_progress("cloning");
         let parsed = git_fetcher::parse_git_source(&repo_url);
-        let temp_dir = git_fetcher::clone_repo_ref(
+        let app_for_progress = app_handle.clone();
+        let url_for_progress = repo_url.clone();
+        let progress_cb: git_fetcher::ProgressCallback = Box::new(move |msg: &str| {
+            app_for_progress
+                .emit(
+                    "install-progress",
+                    serde_json::json!({
+                        "skill_id": url_for_progress,
+                        "phase": "cloning",
+                        "detail": msg,
+                    }),
+                )
+                .ok();
+        });
+        let temp_dir = git_fetcher::clone_repo_ref_with_progress(
             &parsed.clone_url,
             parsed.branch.as_deref(),
             Some(&cancel),
             proxy_url.as_deref(),
+            Some(progress_cb),
         )
         .map_err(AppError::classify_git_error)?;
 
@@ -488,9 +503,28 @@ pub async fn install_from_skillssh(
 
         emit_progress("cloning");
         let repo_url = format!("https://github.com/{}.git", source);
-        let temp_dir =
-            git_fetcher::clone_repo_ref(&repo_url, None, Some(&cancel), proxy_url.as_deref())
-                .map_err(AppError::classify_git_error)?;
+        let app_for_progress = app_handle.clone();
+        let skill_key_for_progress = skill_key.clone();
+        let progress_cb: git_fetcher::ProgressCallback = Box::new(move |msg: &str| {
+            app_for_progress
+                .emit(
+                    "install-progress",
+                    serde_json::json!({
+                        "skill_id": skill_key_for_progress,
+                        "phase": "cloning",
+                        "detail": msg,
+                    }),
+                )
+                .ok();
+        });
+        let temp_dir = git_fetcher::clone_repo_ref_with_progress(
+            &repo_url,
+            None,
+            Some(&cancel),
+            proxy_url.as_deref(),
+            Some(progress_cb),
+        )
+        .map_err(AppError::classify_git_error)?;
 
         emit_progress("installing");
         let install_result =
@@ -560,11 +594,26 @@ pub async fn preview_git_install(
             .ok();
 
         let parsed = git_fetcher::parse_git_source(&repo_url);
-        let temp_dir = git_fetcher::clone_repo_ref(
+        let app_for_progress = app_handle.clone();
+        let url_for_progress = repo_url.clone();
+        let progress_cb: git_fetcher::ProgressCallback = Box::new(move |msg: &str| {
+            app_for_progress
+                .emit(
+                    "install-progress",
+                    serde_json::json!({
+                        "skill_id": url_for_progress,
+                        "phase": "cloning",
+                        "detail": msg,
+                    }),
+                )
+                .ok();
+        });
+        let temp_dir = git_fetcher::clone_repo_ref_with_progress(
             &parsed.clone_url,
             parsed.branch.as_deref(),
             Some(&cancel),
             proxy_url.as_deref(),
+            Some(progress_cb),
         )
         .map_err(AppError::classify_git_error)?;
 
@@ -1492,20 +1541,30 @@ fn validate_clone_temp_path(temp_dir: &str) -> Result<PathBuf, AppError> {
     let temp_path = raw_path
         .canonicalize()
         .map_err(|_| AppError::invalid_input("Invalid temp directory"))?;
+
+    // Allow paths inside the system temp dir (legacy random clone dirs).
     let expected_prefix = std::env::temp_dir()
         .canonicalize()
         .unwrap_or_else(|_| std::env::temp_dir());
-    if !temp_path.starts_with(&expected_prefix) {
-        return Err(AppError::invalid_input("Invalid temp directory"));
+    if temp_path.starts_with(&expected_prefix) {
+        let dir_name_str = temp_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if dir_name_str.starts_with("skills-manager-clone-") {
+            return Ok(temp_path);
+        }
     }
-    let dir_name_str = temp_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
-    if !dir_name_str.starts_with("skills-manager-clone-") {
-        return Err(AppError::invalid_input("Invalid temp directory"));
+
+    // Allow paths inside the repo cache dir.
+    let cache_repos = central_repo::cache_dir().join("repos");
+    if let Ok(cache_canon) = cache_repos.canonicalize() {
+        if temp_path.starts_with(&cache_canon) {
+            return Ok(temp_path);
+        }
     }
-    Ok(temp_path)
+
+    Err(AppError::invalid_input("Invalid temp directory"))
 }
 
 fn resolve_skill_dir(

--- a/src-tauri/src/core/git_fetcher.rs
+++ b/src-tauri/src/core/git_fetcher.rs
@@ -1,13 +1,18 @@
 use crate::core::skill_metadata;
+use crate::core::central_repo;
 use anyhow::{Context, Result};
 use git2::{Direction, Repository};
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-const CLONE_TIMEOUT_SECS: u64 = 120;
+const CLONE_TIMEOUT_SECS: u64 = 300;
+
+/// Callback type for reporting clone progress messages to the UI.
+pub type ProgressCallback = Box<dyn Fn(&str) + Send>;
 
 /// Create a `Command` for git that hides the console window on Windows.
 fn git_command() -> Command {
@@ -59,8 +64,6 @@ pub fn validate_git_url(url: &str) -> Result<()> {
     }
 
     // Allow GitHub/GitLab shorthand like "user/repo" or "user/repo.git"
-    // Must contain exactly one '/', no scheme separator, no backslash,
-    // and must not look like a Windows absolute path (e.g. "C:\repo").
     if !trimmed.contains("://")
         && !trimmed.contains('\\')
         && !trimmed.starts_with('/')
@@ -68,7 +71,6 @@ pub fn validate_git_url(url: &str) -> Result<()> {
         && !trimmed.starts_with('~')
         && trimmed.contains('/')
     {
-        // Reject Windows drive letters like "C:/repo"
         let bytes = trimmed.as_bytes();
         let is_windows_path =
             bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
@@ -80,17 +82,170 @@ pub fn validate_git_url(url: &str) -> Result<()> {
     anyhow::bail!("URL scheme not allowed: only https, http, ssh, and git@ are permitted");
 }
 
+/// Compute a stable cache directory name for a given clone URL.
+fn repo_cache_dir(url: &str) -> PathBuf {
+    let mut hasher = Sha256::new();
+    hasher.update(url.as_bytes());
+    let hash = format!("{:x}", hasher.finalize());
+    let short = &hash[..16];
+    central_repo::cache_dir().join("repos").join(short)
+}
+
+/// Try to update an existing cached repo via fetch + reset.
+/// Returns Ok(true) if the cache was reused, Ok(false) if it should be re-cloned.
+fn try_update_cached_repo(
+    cached: &Path,
+    url: &str,
+    branch: Option<&str>,
+    proxy_url: Option<&str>,
+    cancel: Option<&Arc<AtomicBool>>,
+    on_progress: &Option<ProgressCallback>,
+) -> Result<bool> {
+    if !cached.join(".git").exists() {
+        return Ok(false);
+    }
+
+    // Verify the remote URL still matches.
+    let current_remote = {
+        let mut cmd = git_command();
+        cmd.arg("-C").arg(cached).args(["remote", "get-url", "origin"]);
+        let output = cmd.output().ok();
+        output
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+    };
+    if current_remote.as_deref() != Some(url) {
+        // URL changed — discard cache.
+        let _ = std::fs::remove_dir_all(cached);
+        return Ok(false);
+    }
+
+    if let Some(cb) = on_progress {
+        cb("Updating cached repository…");
+    }
+
+    let mut fetch_cmd = git_command();
+    fetch_cmd.arg("-C").arg(cached).arg("fetch").arg("--depth").arg("1");
+    if let Some(proxy) = proxy_url.filter(|s| !s.is_empty()) {
+        fetch_cmd.arg("-c").arg(format!("http.proxy={proxy}"));
+        fetch_cmd.arg("-c").arg(format!("https.proxy={proxy}"));
+    }
+    fetch_cmd.arg("origin");
+    if let Some(branch) = branch {
+        fetch_cmd.arg(branch);
+    }
+    fetch_cmd
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped());
+
+    let child = fetch_cmd.spawn();
+    if let Ok(mut child) = child {
+        let deadline = Instant::now() + Duration::from_secs(CLONE_TIMEOUT_SECS);
+        loop {
+            if cancel.is_some_and(|c| c.load(Ordering::SeqCst)) {
+                let _ = child.kill();
+                anyhow::bail!("Installation cancelled");
+            }
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    if !status.success() {
+                        // Fetch failed — discard cache and re-clone.
+                        let _ = std::fs::remove_dir_all(cached);
+                        return Ok(false);
+                    }
+                    break;
+                }
+                Ok(None) => {
+                    if Instant::now() > deadline {
+                        let _ = child.kill();
+                        let _ = std::fs::remove_dir_all(cached);
+                        return Ok(false);
+                    }
+                    std::thread::sleep(Duration::from_millis(200));
+                }
+                Err(_) => {
+                    let _ = std::fs::remove_dir_all(cached);
+                    return Ok(false);
+                }
+            }
+        }
+    } else {
+        let _ = std::fs::remove_dir_all(cached);
+        return Ok(false);
+    }
+
+    // Reset to the fetched HEAD.
+    let target = branch
+        .map(|b| format!("origin/{b}"))
+        .unwrap_or_else(|| "origin/HEAD".to_string());
+    let reset_status = git_command()
+        .arg("-C")
+        .arg(cached)
+        .args(["reset", "--hard", &target])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    match reset_status {
+        Ok(s) if s.success() => Ok(true),
+        _ => {
+            let _ = std::fs::remove_dir_all(cached);
+            Ok(false)
+        }
+    }
+}
+
+/// Filter out SSH informational warnings from stderr lines.
+fn is_ssh_warning(line: &str) -> bool {
+    let trimmed = line.trim().trim_start_matches("** ");
+    trimmed.starts_with("WARNING:")
+        || trimmed.starts_with("This session may")
+        || trimmed.starts_with("The server may")
+        || trimmed.starts_with("See https://openssh.com")
+}
+
 pub fn clone_repo_ref(
     url: &str,
     branch: Option<&str>,
     cancel: Option<&Arc<AtomicBool>>,
     proxy_url: Option<&str>,
 ) -> Result<PathBuf> {
-    let temp_dir =
-        std::env::temp_dir().join(format!("skills-manager-clone-{}", uuid::Uuid::new_v4()));
-    let timeout = Duration::from_secs(CLONE_TIMEOUT_SECS);
+    clone_repo_ref_with_progress(url, branch, cancel, proxy_url, None)
+}
 
-    // Try system git first (faster, supports SSH)
+pub fn clone_repo_ref_with_progress(
+    url: &str,
+    branch: Option<&str>,
+    cancel: Option<&Arc<AtomicBool>>,
+    proxy_url: Option<&str>,
+    on_progress: Option<ProgressCallback>,
+) -> Result<PathBuf> {
+    // Try cached repo first.
+    let cached_dir = repo_cache_dir(url);
+    if cached_dir.exists() {
+        match try_update_cached_repo(&cached_dir, url, branch, proxy_url, cancel, &on_progress) {
+            Ok(true) => return Ok(cached_dir),
+            Ok(false) => { /* cache invalid, fall through to clone */ }
+            Err(e) => {
+                // Propagate cancellation.
+                if e.to_string().contains("cancelled") || e.to_string().contains("canceled") {
+                    return Err(e);
+                }
+                // Otherwise fall through to clone.
+            }
+        }
+    }
+
+    // Ensure cache parent exists.
+    if let Some(parent) = cached_dir.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    // Remove any leftover partial clone.
+    let _ = std::fs::remove_dir_all(&cached_dir);
+
+    let timeout = Duration::from_secs(CLONE_TIMEOUT_SECS);
+    let mut system_git_stderr: Option<String> = None;
+
+    // Try system git first (faster, supports SSH).
     let mut command = git_command();
     command.arg("clone").arg("--depth").arg("1");
     if let Some(proxy) = proxy_url.filter(|s| !s.is_empty()) {
@@ -100,32 +255,106 @@ pub fn clone_repo_ref(
     if let Some(branch) = branch {
         command.arg("--branch").arg(branch);
     }
+    command.arg("--progress"); // Force progress output to stderr.
     let child = command
         .arg(url)
-        .arg(&temp_dir)
+        .arg(&cached_dir)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
         .spawn();
 
     if let Ok(mut child) = child {
+        // Spawn a thread to read stderr and forward progress.
+        let stderr = child.stderr.take();
+        let on_progress_clone = on_progress.is_some();
+        let (stderr_tx, stderr_rx) = std::sync::mpsc::channel::<String>();
+        let progress_cb_for_thread: Option<Arc<dyn Fn(&str) + Send + Sync>> =
+            on_progress.as_ref().map(|_| {
+                // We can't move the Box across threads, so we use the channel.
+                Arc::new(|_: &str| {}) as Arc<dyn Fn(&str) + Send + Sync>
+            });
+        let _ = progress_cb_for_thread; // suppress unused warning
+
+        let stderr_thread = std::thread::spawn(move || {
+            let mut collected = String::new();
+            if let Some(stderr) = stderr {
+                let mut reader = std::io::BufReader::new(stderr);
+                let mut buf = Vec::new();
+                // Read byte-by-byte splitting on both \n and \r so we capture
+                // git's carriage-return progress lines (e.g. "Receiving objects: 45%\r").
+                loop {
+                    buf.clear();
+                    let mut byte = [0u8; 1];
+                    loop {
+                        match std::io::Read::read(&mut reader, &mut byte) {
+                            Ok(0) => break,  // EOF
+                            Ok(_) => {
+                                if byte[0] == b'\n' || byte[0] == b'\r' {
+                                    break;
+                                }
+                                buf.push(byte[0]);
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    if buf.is_empty() {
+                        // Check if we hit EOF (not just an empty line between \r\n).
+                        let mut peek = [0u8; 1];
+                        match std::io::Read::read(&mut reader, &mut peek) {
+                            Ok(0) => break,
+                            Ok(_) => {
+                                // Put it back by starting next iteration with it.
+                                buf.push(peek[0]);
+                                continue;
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    let line = String::from_utf8_lossy(&buf).to_string();
+                    if !is_ssh_warning(&line) {
+                        collected.push_str(&line);
+                        collected.push('\n');
+                    }
+                    if on_progress_clone {
+                        let _ = stderr_tx.send(line);
+                    }
+                }
+            }
+            collected
+        });
+
         let deadline = Instant::now() + timeout;
         loop {
             if cancel.is_some_and(|c| c.load(Ordering::SeqCst)) {
                 let _ = child.kill();
-                let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::remove_dir_all(&cached_dir);
                 anyhow::bail!("Installation cancelled");
             }
+
+            // Forward progress lines from stderr thread.
+            if let Some(ref cb) = on_progress {
+                while let Ok(line) = stderr_rx.try_recv() {
+                    if !is_ssh_warning(&line) && !line.trim().is_empty() {
+                        cb(&line);
+                    }
+                }
+            }
+
             match child.try_wait() {
                 Ok(Some(status)) => {
+                    let collected = stderr_thread.join().unwrap_or_default();
                     if status.success() {
-                        return Ok(temp_dir);
+                        return Ok(cached_dir);
                     }
+                    system_git_stderr = Some(collected);
+                    // Clean up failed clone.
+                    let _ = std::fs::remove_dir_all(&cached_dir);
                     break; // fall through to git2
                 }
                 Ok(None) => {
                     if Instant::now() > deadline {
                         let _ = child.kill();
-                        let _ = std::fs::remove_dir_all(&temp_dir);
+                        let _ = std::fs::remove_dir_all(&cached_dir);
                         anyhow::bail!(
                             "Git clone timed out after {}s — check your network connection",
                             CLONE_TIMEOUT_SECS
@@ -133,28 +362,58 @@ pub fn clone_repo_ref(
                     }
                     std::thread::sleep(Duration::from_millis(200));
                 }
-                Err(_) => break,
+                Err(_) => {
+                    let _ = std::fs::remove_dir_all(&cached_dir);
+                    break;
+                }
             }
         }
     }
 
-    // Fallback to git2
+    // Fallback to git2 with timeout and shallow clone.
+    if let Some(ref cb) = on_progress {
+        cb("Trying alternative clone method…");
+    }
+
     let mut builder = git2::build::RepoBuilder::new();
     if let Some(branch) = branch {
         builder.branch(branch);
     }
 
-    // git2: use transfer_progress callback for cancel checking
     let cancel_clone = cancel.cloned();
+    let clone_deadline = Instant::now() + Duration::from_secs(CLONE_TIMEOUT_SECS);
     let mut callbacks = git2::RemoteCallbacks::new();
-    callbacks.transfer_progress(move |_progress| {
+
+    let progress_for_cb: Option<Arc<std::sync::Mutex<ProgressCallback>>> =
+        on_progress.map(|cb| Arc::new(std::sync::Mutex::new(cb)));
+    let progress_for_transfer = progress_for_cb.clone();
+
+    callbacks.transfer_progress(move |stats| {
         if let Some(ref c) = cancel_clone {
-            return !c.load(Ordering::SeqCst);
+            if c.load(Ordering::SeqCst) {
+                return false;
+            }
+        }
+        if Instant::now() > clone_deadline {
+            return false;
+        }
+        if let Some(ref cb) = progress_for_transfer {
+            if let Ok(cb) = cb.lock() {
+                let msg = format!(
+                    "Receiving objects: {}/{} ({:.1} KB)",
+                    stats.received_objects(),
+                stats.total_objects(),
+                stats.received_bytes() as f64 / 1024.0
+            );
+            cb(&msg);
+            }
         }
         true
     });
+
     let mut fetch_opts = git2::FetchOptions::new();
     fetch_opts.remote_callbacks(callbacks);
+    fetch_opts.depth(1);
     if let Some(proxy) = proxy_url.filter(|s| !s.is_empty()) {
         let mut proxy_opts = git2::ProxyOptions::new();
         proxy_opts.url(proxy);
@@ -162,11 +421,18 @@ pub fn clone_repo_ref(
     }
     builder.fetch_options(fetch_opts);
 
-    builder
-        .clone(url, &temp_dir)
-        .with_context(|| format!("Failed to clone {}", url))?;
-
-    Ok(temp_dir)
+    match builder.clone(url, &cached_dir) {
+        Ok(_) => Ok(cached_dir),
+        Err(git2_err) => {
+            let _ = std::fs::remove_dir_all(&cached_dir);
+            // Include system git stderr in the error if available.
+            let detail = system_git_stderr
+                .filter(|s| !s.trim().is_empty())
+                .map(|s| format!(" (system git: {})", s.trim()))
+                .unwrap_or_default();
+            anyhow::bail!("Failed to clone {}: {}{}", url, git2_err, detail)
+        }
+    }
 }
 
 pub fn get_head_revision(repo_dir: &Path) -> Result<String> {
@@ -332,7 +598,13 @@ pub fn find_skill_dir(repo_dir: &Path, skill_id: Option<&str>) -> Result<PathBuf
     Ok(repo_dir.to_path_buf())
 }
 
+/// Clean up a temporary directory. Does NOT remove cached repo directories.
 pub fn cleanup_temp(path: &Path) {
+    // Don't delete if it's inside our repo cache.
+    let cache_repos = central_repo::cache_dir().join("repos");
+    if path.starts_with(&cache_repos) {
+        return;
+    }
     let _ = std::fs::remove_dir_all(path);
 }
 
@@ -441,8 +713,6 @@ mod tests {
         assert_eq!(parsed.clone_url, "something");
     }
 
-    // ── normalize_url (tested through parse_git_source) ──
-
     #[test]
     fn normalize_http_url_passthrough() {
         let parsed = parse_git_source("http://gitlab.example.com/repo.git");
@@ -456,7 +726,6 @@ mod tests {
     fn find_skill_dir_root_with_skill_md() {
         let tmp = tempdir().unwrap();
         fs::write(tmp.path().join("SKILL.md"), "---\nname: foo\n---").unwrap();
-
         let found = find_skill_dir(tmp.path(), None).unwrap();
         assert_eq!(found, tmp.path());
     }
@@ -465,7 +734,6 @@ mod tests {
     fn find_skill_dir_root_with_claude_md() {
         let tmp = tempdir().unwrap();
         fs::write(tmp.path().join("CLAUDE.md"), "# instructions").unwrap();
-
         let found = find_skill_dir(tmp.path(), None).unwrap();
         assert_eq!(found, tmp.path());
     }
@@ -474,7 +742,6 @@ mod tests {
     fn find_skill_dir_skills_subdirectory() {
         let tmp = tempdir().unwrap();
         fs::create_dir_all(tmp.path().join("skills")).unwrap();
-
         let found = find_skill_dir(tmp.path(), None).unwrap();
         assert_eq!(found, tmp.path().join("skills"));
     }
@@ -483,7 +750,6 @@ mod tests {
     fn find_skill_dir_skill_subdirectory() {
         let tmp = tempdir().unwrap();
         fs::create_dir_all(tmp.path().join("skill")).unwrap();
-
         let found = find_skill_dir(tmp.path(), None).unwrap();
         assert_eq!(found, tmp.path().join("skill"));
     }
@@ -494,7 +760,6 @@ mod tests {
         let skill = tmp.path().join("my-skill");
         fs::create_dir_all(&skill).unwrap();
         fs::write(skill.join("SKILL.md"), "content").unwrap();
-
         let found = find_skill_dir(tmp.path(), Some("my-skill")).unwrap();
         assert_eq!(found, skill);
     }
@@ -504,7 +769,6 @@ mod tests {
         let tmp = tempdir().unwrap();
         let skill = tmp.path().join("skills").join("my-skill");
         fs::create_dir_all(&skill).unwrap();
-
         let found = find_skill_dir(tmp.path(), Some("my-skill")).unwrap();
         assert_eq!(found, skill);
     }
@@ -512,7 +776,6 @@ mod tests {
     #[test]
     fn find_skill_dir_fallback_to_root() {
         let tmp = tempdir().unwrap();
-        // Empty dir — no markers, no skills/ subdir
         let found = find_skill_dir(tmp.path(), None).unwrap();
         assert_eq!(found, tmp.path());
     }
@@ -545,11 +808,8 @@ mod tests {
         assert_eq!(relative_subpath(&repo, &other), None);
     }
 
-    // ── parse_github_tree_url (private, tested through parse_git_source) ──
-
     #[test]
     fn parse_github_tree_url_with_dot_git_suffix() {
-        // URL with .git before /tree should still parse
         let parsed = parse_git_source("https://github.com/acme/skills.git/tree/main/sub");
         assert_eq!(parsed.clone_url, "https://github.com/acme/skills.git");
         assert_eq!(parsed.branch.as_deref(), Some("main"));
@@ -559,11 +819,38 @@ mod tests {
     #[test]
     fn parse_non_github_url_no_tree_extraction() {
         let parsed = parse_git_source("https://gitlab.com/acme/skills/tree/main/sub");
-        // Non-github — regex won't match, returned as-is
         assert_eq!(
             parsed.clone_url,
             "https://gitlab.com/acme/skills/tree/main/sub"
         );
         assert_eq!(parsed.branch, None);
+    }
+
+    // ── repo_cache_dir ──
+
+    #[test]
+    fn repo_cache_dir_is_deterministic() {
+        let a = repo_cache_dir("https://github.com/acme/skills.git");
+        let b = repo_cache_dir("https://github.com/acme/skills.git");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn repo_cache_dir_differs_for_different_urls() {
+        let a = repo_cache_dir("https://github.com/acme/skills.git");
+        let b = repo_cache_dir("https://github.com/acme/other.git");
+        assert_ne!(a, b);
+    }
+
+    // ── cleanup_temp ──
+
+    #[test]
+    fn cleanup_temp_removes_non_cache_dir() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path().join("some-temp");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("file.txt"), "data").unwrap();
+        cleanup_temp(&dir);
+        assert!(!dir.exists());
     }
 }

--- a/src/views/InstallSkills.tsx
+++ b/src/views/InstallSkills.tsx
@@ -401,12 +401,16 @@ export function InstallSkills() {
     let unlisten: (() => void) | null = null;
 
     try {
-      unlisten = await listen<{ skill_id: string; phase: string }>(
+      unlisten = await listen<{ skill_id: string; phase: string; detail?: string }>(
         "install-progress",
         (event) => {
           if (event.payload.skill_id !== cancelKey) return;
           if (event.payload.phase === "cloning") {
-            toast.loading(t("install.toast.cloning"), { id: toastId });
+            const detail = event.payload.detail?.trim();
+            const msg = detail
+              ? `${t("install.toast.cloning")}\n${detail}`
+              : t("install.toast.cloning");
+            toast.loading(msg, { id: toastId });
           } else if (event.payload.phase === "installing") {
             toast.loading(t("install.toast.installing", { name: displayName }), { id: toastId });
           }
@@ -449,12 +453,16 @@ export function InstallSkills() {
     let unlisten: (() => void) | null = null;
 
     try {
-      unlisten = await listen<{ skill_id: string; phase: string }>(
+      unlisten = await listen<{ skill_id: string; phase: string; detail?: string }>(
         "install-progress",
         (event) => {
           if (event.payload.skill_id !== url) return;
           if (event.payload.phase === "cloning") {
-            toast.loading(t("install.toast.cloning"), { id: toastId });
+            const detail = event.payload.detail?.trim();
+            const msg = detail
+              ? `${t("install.toast.cloning")}\n${detail}`
+              : t("install.toast.cloning");
+            toast.loading(msg, { id: toastId });
           }
         }
       );


### PR DESCRIPTION
## Summary

- Cache cloned repos for reuse, making repeat installs near-instant
- Add real-time clone progress display in install toast
- Add timeout and shallow clone to git2 fallback path

## Problem

1. **Slow installs**: Every install clones the full repo from scratch, even if the same repo was cloned minutes ago.
2. **No progress feedback**: Users see "Cloning repository..." with no indication of progress, appears frozen on slow networks.
3. **git2 fallback hangs**: When system git fails, git2 fallback has no timeout and no shallow clone.

## Changes

### Repo cache (`git_fetcher.rs`)
- Cache cloned repos in `~/.skills-manager/cache/repos/<url-sha256>`
- On cache hit: `git fetch --depth 1` + `git reset --hard` (seconds vs minutes)
- On cache miss or corruption: full clone as before
- `cleanup_temp()` skips cached repo directories

### git2 improvements
- Added 300s timeout via `transfer_progress` deadline check
- Added `depth(1)` for shallow clone
- System git stderr captured (was `Stdio::null()`) for better error diagnostics

### Clone progress (`InstallSkills.tsx`)
- New `ProgressCallback` type forwarded via `install-progress` event `detail` field
- stderr split on both `\r` and `\n` to capture git's carriage-return progress lines
- Toast shows latest progress line (e.g. "Receiving objects: 78% (1480/1896)")

### Security
- `validate_clone_temp_path()` updated to accept cached repo paths
