### PR TITLE
Fix project skill workspace interactions

### DIFF
--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -214,6 +214,121 @@ fn project_to_dto(
     }
 }
 
+fn default_workspace_name(path: &Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn add_linked_workspace_impl(
+    store: &SkillStore,
+    name: String,
+    path: String,
+    disabled_path: Option<String>,
+) -> Result<ProjectDto, AppError> {
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return Err(AppError::invalid_input("Workspace name is required"));
+    }
+
+    let skills_root = PathBuf::from(path.trim());
+    if !skills_root.is_dir() {
+        return Err(AppError::invalid_input("Skills directory does not exist"));
+    }
+
+    let disabled_path = disabled_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let disabled_path = if let Some(disabled) = disabled_path {
+        let disabled_root = PathBuf::from(&disabled);
+        if !disabled_root.is_dir() {
+            return Err(AppError::invalid_input(
+                "Disabled skills directory does not exist",
+            ));
+        }
+        ensure_distinct_linked_workspace_roots(&skills_root, &disabled_root)?;
+        Some(disabled)
+    } else {
+        let mut disabled_root = skills_root.clone();
+        let derived = disabled_root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|name| format!("{}-disabled", name));
+        match derived {
+            Some(name) => {
+                disabled_root.set_file_name(name);
+                match std::fs::create_dir_all(&disabled_root) {
+                    Ok(()) => {
+                        ensure_distinct_linked_workspace_roots(&skills_root, &disabled_root)?;
+                        Some(disabled_root.to_string_lossy().to_string())
+                    }
+                    Err(_) => None,
+                }
+            }
+            None => None,
+        }
+    };
+
+    let now = chrono::Utc::now().timestamp_millis();
+    let record = ProjectRecord {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: name.clone(),
+        path: skills_root.to_string_lossy().to_string(),
+        workspace_type: "linked".to_string(),
+        linked_agent_key: Some(slugify_skill_dir_name(&name)),
+        linked_agent_name: Some(name),
+        disabled_path,
+        sort_order: 0,
+        created_at: now,
+        updated_at: now,
+    };
+
+    store.insert_project(&record).map_err(AppError::db)?;
+    let all_managed = store.get_all_skills().map_err(AppError::db)?;
+    let configs = agent_skill_configs(store);
+    Ok(project_to_dto(&record, &all_managed, &configs))
+}
+
+fn add_project_impl(store: &SkillStore, path: String) -> Result<ProjectDto, AppError> {
+    let project_path = Path::new(&path);
+    if !project_path.is_dir() {
+        return Err(AppError::invalid_input("Directory does not exist"));
+    }
+
+    if project_scanner::is_standalone_skills_root(project_path) {
+        return add_linked_workspace_impl(store, default_workspace_name(project_path), path, None);
+    }
+
+    let claude_dir = project_path.join(".claude");
+    let skills_dir = claude_dir.join("skills");
+    let disabled_dir = claude_dir.join("skills-disabled");
+
+    // Support initializing an empty project directory as a managed project.
+    std::fs::create_dir_all(&skills_dir)?;
+    std::fs::create_dir_all(&disabled_dir)?;
+
+    let now = chrono::Utc::now().timestamp_millis();
+    let record = ProjectRecord {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: default_workspace_name(project_path),
+        path: path.clone(),
+        workspace_type: "project".to_string(),
+        linked_agent_key: None,
+        linked_agent_name: None,
+        disabled_path: None,
+        sort_order: 0,
+        created_at: now,
+        updated_at: now,
+    };
+
+    store.insert_project(&record).map_err(AppError::db)?;
+    let all_managed = store.get_all_skills().map_err(AppError::db)?;
+    let configs = agent_skill_configs(store);
+    Ok(project_to_dto(&record, &all_managed, &configs))
+}
+
 fn ensure_safe_skill_relative_path(skill_relative_path: &str) -> Result<(), AppError> {
     if skill_relative_path.trim().is_empty() {
         return Err(AppError::invalid_input("Invalid skill directory path"));
@@ -515,43 +630,7 @@ pub async fn add_project(
     path: String,
 ) -> Result<ProjectDto, AppError> {
     let store = store.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        let project_path = Path::new(&path);
-        if !project_path.is_dir() {
-            return Err(AppError::invalid_input("Directory does not exist"));
-        }
-        let claude_dir = project_path.join(".claude");
-        let skills_dir = claude_dir.join("skills");
-        let disabled_dir = claude_dir.join("skills-disabled");
-
-        // Support initializing an empty project directory as a managed project.
-        std::fs::create_dir_all(&skills_dir)?;
-        std::fs::create_dir_all(&disabled_dir)?;
-
-        let name = project_path
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "unknown".to_string());
-
-        let now = chrono::Utc::now().timestamp_millis();
-        let record = ProjectRecord {
-            id: uuid::Uuid::new_v4().to_string(),
-            name,
-            path: path.clone(),
-            workspace_type: "project".to_string(),
-            linked_agent_key: None,
-            linked_agent_name: None,
-            disabled_path: None,
-            sort_order: 0,
-            created_at: now,
-            updated_at: now,
-        };
-
-        store.insert_project(&record).map_err(AppError::db)?;
-        let all_managed = store.get_all_skills().map_err(AppError::db)?;
-        let configs = agent_skill_configs(&store);
-        Ok(project_to_dto(&record, &all_managed, &configs))
-    })
+    tauri::async_runtime::spawn_blocking(move || add_project_impl(&store, path))
     .await?
 }
 
@@ -564,69 +643,7 @@ pub async fn add_linked_workspace(
 ) -> Result<ProjectDto, AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        let name = name.trim().to_string();
-        if name.is_empty() {
-            return Err(AppError::invalid_input("Workspace name is required"));
-        }
-
-        let skills_root = PathBuf::from(path.trim());
-        if !skills_root.is_dir() {
-            return Err(AppError::invalid_input("Skills directory does not exist"));
-        }
-
-        let disabled_path = disabled_path
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string);
-        let disabled_path = if let Some(disabled) = disabled_path {
-            let disabled_root = PathBuf::from(&disabled);
-            if !disabled_root.is_dir() {
-                return Err(AppError::invalid_input(
-                    "Disabled skills directory does not exist",
-                ));
-            }
-            ensure_distinct_linked_workspace_roots(&skills_root, &disabled_root)?;
-            Some(disabled)
-        } else {
-            let mut disabled_root = skills_root.clone();
-            let derived = disabled_root
-                .file_name()
-                .and_then(|n| n.to_str())
-                .map(|name| format!("{}-disabled", name));
-            match derived {
-                Some(name) => {
-                    disabled_root.set_file_name(name);
-                    match std::fs::create_dir_all(&disabled_root) {
-                        Ok(()) => {
-                            ensure_distinct_linked_workspace_roots(&skills_root, &disabled_root)?;
-                            Some(disabled_root.to_string_lossy().to_string())
-                        }
-                        Err(_) => None,
-                    }
-                }
-                None => None,
-            }
-        };
-
-        let now = chrono::Utc::now().timestamp_millis();
-        let record = ProjectRecord {
-            id: uuid::Uuid::new_v4().to_string(),
-            name: name.clone(),
-            path: skills_root.to_string_lossy().to_string(),
-            workspace_type: "linked".to_string(),
-            linked_agent_key: Some(slugify_skill_dir_name(&name)),
-            linked_agent_name: Some(name),
-            disabled_path,
-            sort_order: 0,
-            created_at: now,
-            updated_at: now,
-        };
-
-        store.insert_project(&record).map_err(AppError::db)?;
-        let all_managed = store.get_all_skills().map_err(AppError::db)?;
-        let configs = agent_skill_configs(&store);
-        Ok(project_to_dto(&record, &all_managed, &configs))
+        add_linked_workspace_impl(&store, name, path, disabled_path)
     })
     .await?
 }
@@ -1112,13 +1129,13 @@ pub async fn delete_project_skill(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_sync_status, ensure_distinct_linked_workspace_roots,
+        add_project_impl, classify_sync_status, ensure_distinct_linked_workspace_roots,
         remove_workspace_skill_target, set_project_skill_enabled_state,
     };
     use crate::core::content_hash;
     use crate::core::error::ErrorKind;
     use crate::core::project_scanner::ProjectSkillInfo;
-    use crate::core::skill_store::SkillRecord;
+    use crate::core::skill_store::{SkillRecord, SkillStore};
     use std::fs;
     use tempfile::tempdir;
 
@@ -1256,6 +1273,62 @@ mod tests {
         fs::create_dir_all(&disabled).unwrap();
 
         ensure_distinct_linked_workspace_roots(&root, &disabled).unwrap();
+    }
+
+    fn temp_store() -> (tempfile::TempDir, SkillStore) {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let store = SkillStore::new(&db_path).unwrap();
+        (tmp, store)
+    }
+
+    #[test]
+    fn add_project_treats_standalone_skills_root_as_linked_workspace() {
+        let (_store_tmp, store) = temp_store();
+        let skills_root_tmp = tempdir().unwrap();
+        let skill = skills_root_tmp.path().join("example-skill");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "# Example").unwrap();
+
+        let dto = add_project_impl(&store, skills_root_tmp.path().to_string_lossy().to_string())
+            .unwrap();
+
+        assert_eq!(dto.workspace_type, "linked");
+        assert_eq!(dto.path, skills_root_tmp.path().to_string_lossy().to_string());
+        assert!(!skills_root_tmp.path().join(".claude").exists());
+
+        let mut disabled_root = skills_root_tmp.path().to_path_buf();
+        let dir_name = skills_root_tmp
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap();
+        disabled_root.set_file_name(format!("{dir_name}-disabled"));
+        assert!(disabled_root.is_dir());
+    }
+
+    #[test]
+    fn add_project_keeps_project_mode_for_actual_project_root() {
+        let (_store_tmp, store) = temp_store();
+        let project_root = tempdir().unwrap();
+        let existing_skill = project_root
+            .path()
+            .join(".claude")
+            .join("skills")
+            .join("example-skill");
+        fs::create_dir_all(&existing_skill).unwrap();
+        fs::write(existing_skill.join("SKILL.md"), "# Example").unwrap();
+
+        let dto = add_project_impl(&store, project_root.path().to_string_lossy().to_string())
+            .unwrap();
+
+        assert_eq!(dto.workspace_type, "project");
+        assert!(project_root.path().join(".claude").join("skills").is_dir());
+        assert!(project_root
+            .path()
+            .join(".claude")
+            .join("skills-disabled")
+            .is_dir());
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -398,18 +398,27 @@ fn cleanup_empty_dirs_up_to(start: &Path, root: &Path) {
     }
 }
 
-fn remove_symlink_entry(path: &Path) -> Result<(), AppError> {
-    let metadata = match std::fs::symlink_metadata(path) {
+fn remove_duplicate_symlink_entry(kept_path: &Path, duplicate_path: &Path) -> Result<(), AppError> {
+    let metadata = match std::fs::symlink_metadata(duplicate_path) {
         Ok(m) => m,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(err) => return Err(AppError::io(err)),
     };
     if !metadata.file_type().is_symlink() {
         return Err(AppError::invalid_input(
-            "Duplicate skill entry is not a symlink — resolve manually",
+            "Duplicate skill entry is not a symlink - resolve manually",
         ));
     }
-    sync_engine::remove_target(path).map_err(AppError::io)
+
+    let kept_canonical = std::fs::canonicalize(kept_path).map_err(AppError::io)?;
+    let duplicate_canonical = std::fs::canonicalize(duplicate_path).map_err(AppError::io)?;
+    if kept_canonical != duplicate_canonical {
+        return Err(AppError::invalid_input(
+            "Duplicate skill entries point to different targets - resolve manually",
+        ));
+    }
+
+    sync_engine::remove_target(duplicate_path).map_err(AppError::io)
 }
 
 fn set_project_skill_enabled_state(
@@ -428,7 +437,7 @@ fn set_project_skill_enabled_state(
             ensure_dir_within_root(&enabled_path, skills_dir)?;
             if disabled_path.exists() {
                 ensure_dir_within_root(&disabled_path, disabled_dir)?;
-                remove_symlink_entry(&disabled_path)?;
+                remove_duplicate_symlink_entry(&enabled_path, &disabled_path)?;
                 if let Some(parent) = disabled_path.parent() {
                     cleanup_empty_dirs_up_to(parent, disabled_dir);
                 }
@@ -461,7 +470,7 @@ fn set_project_skill_enabled_state(
         ensure_dir_within_root(&disabled_path, disabled_dir)?;
         if enabled_path.exists() {
             ensure_dir_within_root(&enabled_path, skills_dir)?;
-            remove_symlink_entry(&enabled_path)?;
+            remove_duplicate_symlink_entry(&disabled_path, &enabled_path)?;
         }
         return Ok(());
     }
@@ -630,8 +639,7 @@ pub async fn add_project(
     path: String,
 ) -> Result<ProjectDto, AppError> {
     let store = store.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || add_project_impl(&store, path))
-    .await?
+    tauri::async_runtime::spawn_blocking(move || add_project_impl(&store, path)).await?
 }
 
 #[tauri::command]
@@ -1290,11 +1298,14 @@ mod tests {
         fs::create_dir_all(&skill).unwrap();
         fs::write(skill.join("SKILL.md"), "# Example").unwrap();
 
-        let dto = add_project_impl(&store, skills_root_tmp.path().to_string_lossy().to_string())
-            .unwrap();
+        let dto =
+            add_project_impl(&store, skills_root_tmp.path().to_string_lossy().to_string()).unwrap();
 
         assert_eq!(dto.workspace_type, "linked");
-        assert_eq!(dto.path, skills_root_tmp.path().to_string_lossy().to_string());
+        assert_eq!(
+            dto.path,
+            skills_root_tmp.path().to_string_lossy().to_string()
+        );
         assert!(!skills_root_tmp.path().join(".claude").exists());
 
         let mut disabled_root = skills_root_tmp.path().to_path_buf();
@@ -1319,16 +1330,18 @@ mod tests {
         fs::create_dir_all(&existing_skill).unwrap();
         fs::write(existing_skill.join("SKILL.md"), "# Example").unwrap();
 
-        let dto = add_project_impl(&store, project_root.path().to_string_lossy().to_string())
-            .unwrap();
+        let dto =
+            add_project_impl(&store, project_root.path().to_string_lossy().to_string()).unwrap();
 
         assert_eq!(dto.workspace_type, "project");
         assert!(project_root.path().join(".claude").join("skills").is_dir());
-        assert!(project_root
-            .path()
-            .join(".claude")
-            .join("skills-disabled")
-            .is_dir());
+        assert!(
+            project_root
+                .path()
+                .join(".claude")
+                .join("skills-disabled")
+                .is_dir()
+        );
     }
 
     #[cfg(unix)]
@@ -1427,6 +1440,88 @@ mod tests {
         assert!(!disabled_root.join(relative_path).exists());
         assert!(central_skill.exists());
         assert!(central_skill.join("SKILL.md").is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_project_skill_enabled_state_enabling_rejects_duplicate_symlink_to_different_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempdir().unwrap();
+        let enabled_target = tmp.path().join("central").join("enabled-skill");
+        let disabled_target = tmp.path().join("central").join("disabled-skill");
+        let skills_root = tmp.path().join("skills");
+        let disabled_root = tmp.path().join("skills-disabled");
+        let relative_path = "understand-diff";
+
+        fs::create_dir_all(&enabled_target).unwrap();
+        fs::write(
+            enabled_target.join("SKILL.md"),
+            "---\nname: enabled-skill\n---\n",
+        )
+        .unwrap();
+        fs::create_dir_all(&disabled_target).unwrap();
+        fs::write(
+            disabled_target.join("SKILL.md"),
+            "---\nname: disabled-skill\n---\n",
+        )
+        .unwrap();
+        fs::create_dir_all(&skills_root).unwrap();
+        fs::create_dir_all(&disabled_root).unwrap();
+
+        symlink(&enabled_target, skills_root.join(relative_path)).unwrap();
+        symlink(&disabled_target, disabled_root.join(relative_path)).unwrap();
+
+        let err =
+            set_project_skill_enabled_state(&skills_root, &disabled_root, relative_path, true)
+                .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::InvalidInput);
+        assert!(skills_root.join(relative_path).exists());
+        assert!(disabled_root.join(relative_path).exists());
+        assert!(enabled_target.join("SKILL.md").is_file());
+        assert!(disabled_target.join("SKILL.md").is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_project_skill_enabled_state_disabling_rejects_duplicate_symlink_to_different_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempdir().unwrap();
+        let enabled_target = tmp.path().join("central").join("enabled-skill");
+        let disabled_target = tmp.path().join("central").join("disabled-skill");
+        let skills_root = tmp.path().join("skills");
+        let disabled_root = tmp.path().join("skills-disabled");
+        let relative_path = "understand-diff";
+
+        fs::create_dir_all(&enabled_target).unwrap();
+        fs::write(
+            enabled_target.join("SKILL.md"),
+            "---\nname: enabled-skill\n---\n",
+        )
+        .unwrap();
+        fs::create_dir_all(&disabled_target).unwrap();
+        fs::write(
+            disabled_target.join("SKILL.md"),
+            "---\nname: disabled-skill\n---\n",
+        )
+        .unwrap();
+        fs::create_dir_all(&skills_root).unwrap();
+        fs::create_dir_all(&disabled_root).unwrap();
+
+        symlink(&enabled_target, skills_root.join(relative_path)).unwrap();
+        symlink(&disabled_target, disabled_root.join(relative_path)).unwrap();
+
+        let err =
+            set_project_skill_enabled_state(&skills_root, &disabled_root, relative_path, false)
+                .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::InvalidInput);
+        assert!(skills_root.join(relative_path).exists());
+        assert!(disabled_root.join(relative_path).exists());
+        assert!(enabled_target.join("SKILL.md").is_file());
+        assert!(disabled_target.join("SKILL.md").is_file());
     }
 
     #[test]

--- a/src-tauri/src/core/project_scanner.rs
+++ b/src-tauri/src/core/project_scanner.rs
@@ -113,6 +113,64 @@ fn should_skip_dir(root: &Path, dir: &Path) -> bool {
     dir != root && dir.join("skills").is_dir()
 }
 
+pub fn is_standalone_skills_root(root: &Path) -> bool {
+    if !root.is_dir() {
+        return false;
+    }
+
+    if root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.ends_with("-disabled"))
+        .unwrap_or(false)
+    {
+        return false;
+    }
+
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return false;
+    };
+
+    let mut visited = std::collections::HashSet::new();
+    if let Ok(canon) = std::fs::canonicalize(root) {
+        visited.insert(canon);
+    }
+
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if name.starts_with('.') {
+            continue;
+        }
+
+        if skill_metadata::is_valid_skill_dir(&path) {
+            return true;
+        }
+
+        if name == "skills" || name.ends_with("-disabled") {
+            continue;
+        }
+
+        let canon = match std::fs::canonicalize(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if !visited.insert(canon) {
+            continue;
+        }
+
+        if contains_skill_dir_recursive(&path, &mut visited, 1) {
+            return true;
+        }
+    }
+
+    false
+}
+
 fn read_skills_from_dir(
     dir: &Path,
     enabled: bool,
@@ -223,6 +281,45 @@ fn read_skills_from_dir_recursive(
     }
 }
 
+fn contains_skill_dir_recursive(
+    current: &Path,
+    visited: &mut std::collections::HashSet<PathBuf>,
+    remaining_depth: usize,
+) -> bool {
+    if remaining_depth == 0 {
+        return false;
+    }
+
+    let Ok(entries) = std::fs::read_dir(current) else {
+        return false;
+    };
+
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        if skill_metadata::is_valid_skill_dir(&path) {
+            return true;
+        }
+
+        let canon = match std::fs::canonicalize(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if !visited.insert(canon) {
+            continue;
+        }
+
+        if contains_skill_dir_recursive(&path, visited, remaining_depth - 1) {
+            return true;
+        }
+    }
+
+    false
+}
+
 /// Scan a root directory for projects containing any agent's skills directory.
 pub fn scan_projects_in_dir(
     root: &Path,
@@ -239,6 +336,7 @@ fn has_any_agent_skills(dir: &Path, agent_configs: &[AgentSkillConfig]) -> bool 
     agent_configs
         .iter()
         .any(|config| dir.join(&config.relative_skills_dir).is_dir())
+        || is_standalone_skills_root(dir)
 }
 
 fn scan_recursive(
@@ -343,7 +441,10 @@ fn latest_modified_millis(dir: &Path) -> Option<i64> {
 
 #[cfg(test)]
 mod tests {
-    use super::{read_linked_workspace_skills, read_project_skills, AgentSkillConfig};
+    use super::{
+        is_standalone_skills_root, read_linked_workspace_skills, read_project_skills,
+        scan_projects_in_dir, AgentSkillConfig,
+    };
     use std::fs;
     use tempfile::tempdir;
 
@@ -391,6 +492,58 @@ mod tests {
         let skills = read_project_skills(tmp.path(), &configs);
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].relative_path, "research/web-search");
+    }
+
+    #[test]
+    fn scan_projects_includes_standalone_skills_root() {
+        let tmp = tempdir().unwrap();
+        let skills_root = tmp.path().join("workspace").join("skills");
+        let nested_skill = skills_root.join("research").join("web-search");
+        fs::create_dir_all(&nested_skill).unwrap();
+        fs::write(nested_skill.join("SKILL.md"), "# Nested").unwrap();
+
+        let results = scan_projects_in_dir(tmp.path(), 4, &[]);
+
+        assert_eq!(results, vec![skills_root.to_string_lossy().to_string()]);
+    }
+
+    #[test]
+    fn scan_projects_matches_scan_root_when_it_is_a_standalone_skills_root() {
+        let tmp = tempdir().unwrap();
+        let skill = tmp.path().join("example-skill");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "# Example").unwrap();
+
+        let results = scan_projects_in_dir(tmp.path(), 0, &[]);
+
+        assert_eq!(results, vec![tmp.path().to_string_lossy().to_string()]);
+    }
+
+    #[test]
+    fn standalone_skills_root_ignores_hidden_agent_dirs() {
+        let tmp = tempdir().unwrap();
+        let hidden_skill = tmp.path().join(".claude").join("skills").join("example-skill");
+        fs::create_dir_all(&hidden_skill).unwrap();
+        fs::write(hidden_skill.join("SKILL.md"), "# Example").unwrap();
+
+        assert!(!is_standalone_skills_root(tmp.path()));
+    }
+
+    #[test]
+    fn standalone_skills_root_does_not_match_parent_of_skills_dir() {
+        let tmp = tempdir().unwrap();
+        let nested_skill = tmp
+            .path()
+            .join("workspace")
+            .join("skills")
+            .join("example-skill");
+        fs::create_dir_all(&nested_skill).unwrap();
+        fs::write(nested_skill.join("SKILL.md"), "# Example").unwrap();
+
+        assert!(!is_standalone_skills_root(&tmp.path().join("workspace")));
+        assert!(is_standalone_skills_root(
+            &tmp.path().join("workspace").join("skills")
+        ));
     }
 
     #[test]

--- a/src/views/InstallSkills.tsx
+++ b/src/views/InstallSkills.tsx
@@ -194,8 +194,11 @@ export function InstallSkills() {
     setSearchParams({ tab });
   };
 
-  const runScan = useCallback(async () => {
-    setScanLoading(true);
+  const runScan = useCallback(async (options?: { background?: boolean }) => {
+    const background = options?.background ?? false;
+    if (!background) {
+      setScanLoading(true);
+    }
     setLocalError(null);
     try {
       const result = await api.scanLocalSkills();
@@ -206,9 +209,23 @@ export function InstallSkills() {
       setLocalError(message);
       toast.error(message);
     } finally {
-      setScanLoading(false);
+      if (!background) {
+        setScanLoading(false);
+      }
     }
   }, [t]);
+
+  const markScanGroupsImported = useCallback((shouldMark: (group: ScanResult["groups"][number]) => boolean) => {
+    setScanResult((current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        groups: current.groups.map((group) =>
+          shouldMark(group) ? { ...group, imported: true } : group
+        ),
+      };
+    });
+  }, []);
 
   useEffect(() => {
     if (activeTab !== "market") return;
@@ -287,7 +304,10 @@ export function InstallSkills() {
     try {
       await api.installLocal(sourcePath);
       await Promise.all([refreshScenarios(), refreshManagedSkills()]);
-      await runScan();
+      markScanGroupsImported((group) =>
+        group.locations.some((location) => location.found_path === sourcePath)
+      );
+      runScan({ background: true });
       toast.success(t("install.toast.success", { name }), {
         id: toastId,
         action: {
@@ -382,7 +402,7 @@ export function InstallSkills() {
       }
 
       await Promise.all([refreshScenarios(), refreshManagedSkills()]);
-      runScan();
+      runScan({ background: true });
     } catch (error: unknown) {
       const message = getErrorMessage(error, t("common.error"));
       setLocalError(message);
@@ -530,8 +550,11 @@ export function InstallSkills() {
     try {
       await api.importExistingSkill(sourcePath, name);
       toast.success(t("install.scan.importedOne", { name }));
+      markScanGroupsImported((group) =>
+        group.locations.some((location) => location.found_path === sourcePath)
+      );
       await Promise.all([refreshScenarios(), refreshManagedSkills()]);
-      await runScan();
+      runScan({ background: true });
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
     } finally {
@@ -548,8 +571,9 @@ export function InstallSkills() {
     try {
       await api.importAllDiscovered();
       toast.success(t("install.scan.importedAll"));
+      markScanGroupsImported(() => true);
       await Promise.all([refreshScenarios(), refreshManagedSkills()]);
-      await runScan();
+      runScan({ background: true });
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
     } finally {
@@ -1242,7 +1266,7 @@ export function InstallSkills() {
               title={t("common.requestFailed")}
               description={localError}
               actionLabel={t("common.retry")}
-              onAction={runScan}
+              onAction={() => runScan()}
               tone="danger"
             />
           ) : null}
@@ -1263,7 +1287,7 @@ export function InstallSkills() {
 
               <div className="flex items-center gap-2">
                 <button
-                  onClick={runScan}
+                  onClick={() => runScan()}
                   disabled={scanLoading}
                   className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-surface-hover px-3 py-2 text-[13px] font-medium text-secondary transition-colors hover:bg-surface-active disabled:opacity-50"
                 >

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -38,6 +38,7 @@ import { cn } from "../utils";
 import * as api from "../lib/tauri";
 import type { ProjectSkill, ManagedSkill, ProjectAgentTarget } from "../lib/tauri";
 import { getErrorMessage } from "../lib/error";
+import { applyProjectSkillEnabledState } from "./projectSkillState";
 
 const PROJECT_DEFAULT_EXPORT_AGENTS_KEY = "project_default_export_agents";
 const PROJECT_EXPORT_AGENT_PRIORITY = ["claude_code", "codex", "cursor", "gemini_cli", "github_copilot"];
@@ -125,6 +126,10 @@ function getAgentDotTargets(variants: ProjectSkill[]) {
   return targets;
 }
 
+function isGroupEnabled(skill: Pick<ProjectSkillGroup, "enabledCount">) {
+  return skill.enabledCount > 0;
+}
+
 function getGroupStatus(variants: ProjectSkill[]): ProjectSkill["sync_status"] {
   const priority: ProjectSkill["sync_status"][] = [
     "diverged",
@@ -150,6 +155,7 @@ export function ProjectDetail() {
   const [projectAgentTargets, setProjectAgentTargets] = useState<ProjectAgentTarget[]>([]);
   const [selectedExportAgents, setSelectedExportAgents] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [filterMode, setFilterMode] = useState<"all" | "enabled" | "disabled">("all");
   const [search, setSearch] = useState("");
@@ -191,16 +197,25 @@ export function ProjectDetail() {
     return skill.id;
   }, []);
 
-  const loadSkills = useCallback(async () => {
+  const loadSkills = useCallback(async (options?: { background?: boolean }) => {
     if (!id) return;
-    setLoading(true);
+    const background = options?.background ?? false;
+    if (background) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
     try {
       const result = await api.getProjectSkills(id);
       setSkills(result);
     } catch (e) {
       console.error("Failed to load project skills:", e);
     } finally {
-      setLoading(false);
+      if (background) {
+        setRefreshing(false);
+      } else {
+        setLoading(false);
+      }
     }
   }, [id]);
 
@@ -317,7 +332,7 @@ export function ProjectDetail() {
     items: groupedSkills,
     filtered,
     getKey: getSkillKey,
-    isItemActive: (s) => s.enabledCount === s.totalCount,
+    isItemActive: isGroupEnabled,
   });
 
   const exportTargets = useMemo(() => {
@@ -422,7 +437,11 @@ export function ProjectDetail() {
     try {
       await api.updateProjectSkillToCenter(id, skill.primaryVariant.relative_path, skill.primaryVariant.agent);
       toast.success(t("project.updateCenterSuccess", { name: skill.name }));
-      await Promise.all([refreshManagedSkills(), refreshScenarios(), loadSkills()]);
+      await Promise.all([
+        refreshManagedSkills(),
+        refreshScenarios(),
+        loadSkills({ background: true }),
+      ]);
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
     } finally {
@@ -444,7 +463,7 @@ export function ProjectDetail() {
       } else {
         toast.success(t("project.updateProjectSuccess", { name: skill.name }));
       }
-      await Promise.all([loadSkills(), refreshProjects()]);
+      await Promise.all([loadSkills({ background: true }), refreshProjects()]);
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
     } finally {
@@ -456,18 +475,20 @@ export function ProjectDetail() {
     if (!id) return;
     setTogglingSkill(getSkillKey(skill));
     try {
-      const nextEnabled = skill.enabledCount !== skill.totalCount;
+      const nextEnabled = !isGroupEnabled(skill);
       await Promise.all(
         skill.variants.map((variant) =>
           api.toggleProjectSkill(id, variant.relative_path, variant.agent, nextEnabled)
         )
       );
-      if (skill.enabledCount === skill.totalCount) {
-        toast.success(t("project.skillDisabled", { name: skill.name }));
-      } else {
+      setSkills((current) =>
+        applyProjectSkillEnabledState(current, skill.variants, nextEnabled)
+      );
+      if (nextEnabled) {
         toast.success(t("project.skillEnabled", { name: skill.name }));
+      } else {
+        toast.success(t("project.skillDisabled", { name: skill.name }));
       }
-      await loadSkills();
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
     } finally {
@@ -496,7 +517,7 @@ export function ProjectDetail() {
         await api.deleteProjectSkill(id, existingVariant.relative_path, agentKey);
         toast.success(t("project.agentRemoved", { agent: displayName, name: skill.name }));
       }
-      await Promise.all([loadSkills(), refreshProjects()]);
+      await Promise.all([loadSkills({ background: true }), refreshProjects()]);
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
     } finally {
@@ -517,7 +538,7 @@ export function ProjectDetail() {
         count: selectedExportAgents.length,
       }));
       setShowExportDialog(false);
-      await Promise.all([loadSkills(), refreshProjects()]);
+      await Promise.all([loadSkills({ background: true }), refreshProjects()]);
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
     }
@@ -549,7 +570,7 @@ export function ProjectDetail() {
     if (imported > 0) {
       setShowExportDialog(false);
     }
-    await Promise.all([loadSkills(), refreshProjects()]);
+    await Promise.all([loadSkills({ background: true }), refreshProjects()]);
   };
 
   const handleDeleteSkill = async () => {
@@ -561,7 +582,7 @@ export function ProjectDetail() {
         )
       );
       toast.success(t("project.skillDeleted", { name: deleteTarget.name }));
-      await Promise.all([loadSkills(), refreshProjects()]);
+      await Promise.all([loadSkills({ background: true }), refreshProjects()]);
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
     }
@@ -592,7 +613,7 @@ export function ProjectDetail() {
     }
     exitMultiSelect();
     setBatchDeleteConfirm(false);
-    await Promise.all([loadSkills(), refreshProjects()]);
+    await Promise.all([loadSkills({ background: true }), refreshProjects()]);
   };
 
   const handleBatchToggleProject = async () => {
@@ -600,27 +621,35 @@ export function ProjectDetail() {
     const enabling = anyDisabled;
     let count = 0;
     let failed = 0;
+    const updatedVariants: Pick<ProjectSkill, "agent" | "relative_path">[] = [];
     for (const skill of selectedSkills) {
       try {
-        if (enabling && skill.enabledCount !== skill.totalCount) {
+        if (enabling && !isGroupEnabled(skill)) {
           await Promise.all(
             skill.variants.map((variant) =>
               api.toggleProjectSkill(id, variant.relative_path, variant.agent, true)
             )
           );
+          updatedVariants.push(...skill.variants);
           count++;
-        } else if (!enabling && skill.enabledCount > 0) {
+        } else if (!enabling && isGroupEnabled(skill)) {
           await Promise.all(
             skill.variants.map((variant) =>
               api.toggleProjectSkill(id, variant.relative_path, variant.agent, false)
             )
           );
+          updatedVariants.push(...skill.variants);
           count++;
         }
       } catch {
         failed++;
         // continue with remaining
       }
+    }
+    if (updatedVariants.length > 0) {
+      setSkills((current) =>
+        applyProjectSkillEnabledState(current, updatedVariants, enabling)
+      );
     }
     if (count > 0) {
       toast.success(enabling
@@ -630,7 +659,6 @@ export function ProjectDetail() {
     if (failed > 0) {
       toast.error(t("project.batchToggleFailed", { count: failed }));
     }
-    await loadSkills();
   };
 
   const handleBatchUpdateCenter = async () => {
@@ -658,7 +686,11 @@ export function ProjectDetail() {
       if (failed > 0) {
         toast.error(t("project.batchUpdateCenterFailed", { count: failed }));
       }
-      await Promise.all([refreshManagedSkills(), refreshScenarios(), loadSkills()]);
+      await Promise.all([
+        refreshManagedSkills(),
+        refreshScenarios(),
+        loadSkills({ background: true }),
+      ]);
     } finally {
       setBatchUpdatingCenter(false);
     }
@@ -693,7 +725,7 @@ export function ProjectDetail() {
       if (failed > 0) {
         toast.error(t("project.batchUpdateProjectFailed", { count: failed }));
       }
-      await Promise.all([loadSkills(), refreshProjects()]);
+      await Promise.all([loadSkills({ background: true }), refreshProjects()]);
     } finally {
       setBatchUpdatingProject(false);
     }
@@ -732,7 +764,7 @@ export function ProjectDetail() {
     if (failed > 0) {
       toast.error(t("project.batchTagsFailed", { count: failed }));
     }
-    await Promise.all([refreshManagedSkills(), loadSkills()]);
+    await Promise.all([refreshManagedSkills(), loadSkills({ background: true })]);
   };
 
   if (!project) return null;
@@ -813,11 +845,12 @@ export function ProjectDetail() {
 
         <div className="app-segmented">
           <button
-            onClick={loadSkills}
+            onClick={() => loadSkills({ background: true })}
             className="mr-2 inline-flex items-center gap-1 rounded-md px-3 py-2 text-[13px] font-medium text-muted transition-colors hover:bg-surface-hover hover:text-secondary"
+            disabled={refreshing}
             title={t("common.refresh")}
           >
-            <RefreshCw className={cn("h-3.5 w-3.5", loading && "animate-spin")} />
+            <RefreshCw className={cn("h-3.5 w-3.5", (loading || refreshing) && "animate-spin")} />
           </button>
           <button
             onClick={() => setViewMode("grid")}
@@ -1096,7 +1129,7 @@ export function ProjectDetail() {
                           >
                             {isToggling ? (
                               <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                            ) : skill.enabledCount === skill.totalCount ? (
+                            ) : isGroupEnabled(skill) ? (
                               t("project.enabled")
                             ) : (
                               t("project.enableSkill")
@@ -1236,7 +1269,7 @@ export function ProjectDetail() {
                       >
                         {isToggling ? (
                           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                        ) : skill.enabledCount === skill.totalCount ? (
+                        ) : isGroupEnabled(skill) ? (
                           t("project.enabled")
                         ) : (
                           t("project.enableSkill")

--- a/src/views/projectSkillState.test.mjs
+++ b/src/views/projectSkillState.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import ts from "typescript";
+
+async function importTypeScriptModule(moduleUrl) {
+  const source = await readFile(moduleUrl, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+    },
+  });
+
+  return import(`data:text/javascript;base64,${Buffer.from(outputText).toString("base64")}`);
+}
+
+const { applyProjectSkillEnabledState, getProjectSkillVariantKey } = await importTypeScriptModule(
+  new URL("./projectSkillState.ts", import.meta.url)
+);
+
+test("getProjectSkillVariantKey normalizes relative path casing", () => {
+  assert.equal(
+    getProjectSkillVariantKey({ agent: "claude_code", relative_path: "Foo/Bar" }),
+    "claude_code::foo/bar"
+  );
+});
+
+test("applyProjectSkillEnabledState updates only matching skill variants", () => {
+  const skills = [
+    { agent: "claude_code", relative_path: "foo/bar", enabled: true, marker: "keep-enabled" },
+    { agent: "codex", relative_path: "foo/bar", enabled: true, marker: "disable-me" },
+    { agent: "cursor", relative_path: "foo/baz", enabled: false, marker: "keep-disabled" },
+  ];
+
+  const next = applyProjectSkillEnabledState(
+    skills,
+    [{ agent: "codex", relative_path: "Foo/Bar" }],
+    false
+  );
+
+  assert.deepEqual(
+    next.map((skill) => ({ marker: skill.marker, enabled: skill.enabled })),
+    [
+      { marker: "keep-enabled", enabled: true },
+      { marker: "disable-me", enabled: false },
+      { marker: "keep-disabled", enabled: false },
+    ]
+  );
+});

--- a/src/views/projectSkillState.ts
+++ b/src/views/projectSkillState.ts
@@ -1,0 +1,18 @@
+import type { ProjectSkill } from "../lib/tauri";
+
+export function getProjectSkillVariantKey(variant: Pick<ProjectSkill, "agent" | "relative_path">) {
+  return `${variant.agent}::${variant.relative_path.toLowerCase()}`;
+}
+
+export function applyProjectSkillEnabledState(
+  allSkills: ProjectSkill[],
+  variants: Pick<ProjectSkill, "agent" | "relative_path">[],
+  enabled: boolean,
+) {
+  const variantKeys = new Set(variants.map(getProjectSkillVariantKey));
+  return allSkills.map((skill) =>
+    variantKeys.has(getProjectSkillVariantKey(skill))
+      ? { ...skill, enabled }
+      : skill
+  );
+}


### PR DESCRIPTION
## Summary

- Treat standalone skill roots as linked workspaces while preserving normal project detection.
- Keep Project Detail skill toggles local and variant-aware so enabling/disabling skills does not force a full page refresh.
- Mark newly imported skills on the Install Skills page without refreshing the whole view.

## Why

Project skill actions were causing avoidable UI refreshes, and standalone skill roots could be classified through the wrong project path. The UI now updates the affected skill state in place, and backend project detection covers standalone skill workspace roots directly.

## Validation

- `npm run build`
- `npm run lint`
- `node --test src/views/projectSkillState.test.mjs`
- `cargo test`
- `git diff --check upstream/main...HEAD`

Note: `cargo fmt --check` could not run locally because this toolchain is missing `cargo-fmt`; install with `rustup component add rustfmt`.
