### PR TITLE
feat: add CLI support for skills repo operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,52 @@ npm install
 npm run tauri:dev
 ```
 
+### CLI
+
+The repository now includes an agent-friendly CLI built on the same Rust shared core used by the desktop app. Repository bootstrap, tool resolution, scenario sync/apply logic, and metadata reindexing now live in reusable core modules instead of being reimplemented separately for CLI automation.
+
+```bash
+# Show the active repository paths and counts
+npm run cli -- repo status
+
+# List skills / inspect one skill
+npm run cli -- skills list
+npm run cli -- skills show db
+
+# Preview or apply a scenario using the shared Rust core
+npm run cli -- scenarios list
+npm run cli -- scenarios preview Default
+npm run cli -- scenarios apply Default
+
+# Export one skill to another agent workspace
+npm run cli -- skills export db --dest ~/.claude/skills/db
+
+# Inspect or sync the git-backed skills repo
+npm run cli -- git status
+npm run cli -- git pull
+npm run cli -- git commit -m "chore: update skills"
+```
+
+Available command groups:
+- `repo` — inspect or change the configured base directory
+- `tools` — list detected tool targets and paths
+- `skills` — list, inspect, and export skills
+- `scenarios` — list scenarios, preview sync targets, or apply one to default tool paths
+- `git` — operate on the git-backed `skills/` repository (`clone`, `pull`, `push`, `commit`, `versions`, `restore`)
+
+Extra flags:
+- `--skills-root <path>` — operate on a cloned/exported skills repo directly instead of the local app default
+- `--json` — machine-readable output for scripts/agents
+
+```bash
+npm run -s cli -- --skills-root /path/to/my-skills --json skills list
+```
+
 ### Build
 
 ```bash
 npm run tauri:build
+npm run cli:build
 ```
 
 ## Troubleshooting

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,10 +110,52 @@ npm install
 npm run tauri:dev
 ```
 
+### CLI
+
+仓库现在包含一个面向 agent 的 CLI，而且它是建立在与桌面应用共用的 Rust shared core 之上。也就是：repo 初始化、tool 解析、scenario 同步/应用逻辑，以及 metadata reindex，都被抽到了可复用 core 模块中，而不是另外在 CLI 里重写一份。
+
+```bash
+# 查看当前仓库路径和统计信息
+npm run cli -- repo status
+
+# 列出技能 / 查看单个技能
+npm run cli -- skills list
+npm run cli -- skills show db
+
+# 用 shared core 预览或应用某个 scenario
+npm run cli -- scenarios list
+npm run cli -- scenarios preview Default
+npm run cli -- scenarios apply Default
+
+# 导出单个技能到其他 agent 工作目录
+npm run cli -- skills export db --dest ~/.claude/skills/db
+
+# 查看或同步 git 管理的 skills 仓库
+npm run cli -- git status
+npm run cli -- git pull
+npm run cli -- git commit -m "chore: update skills"
+```
+
+可用命令分组：
+- `repo`：查看或修改当前 base directory
+- `tools`：列出已检测到的工具目标与路径
+- `skills`：列出、查看、导出技能
+- `scenarios`：列出 scenario、预览同步目标，或将某个 scenario 应用到默认工具路径
+- `git`：操作 git 管理的 `skills/` 仓库（`clone`、`pull`、`push`、`commit`、`versions`、`restore`）
+
+额外参数：
+- `--skills-root <path>`：直接针对某个已 clone / 已导出的 skills repo 操作，而不是本机 app 默认目录
+- `--json`：给脚本 / agent 使用的机器可读输出
+
+```bash
+npm run -s cli -- --skills-root /path/to/my-skills --json skills list
+```
+
 ### 构建
 
 ```bash
 npm run tauri:build
+npm run cli:build
 ```
 
 ## 常见问题

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "release:prepare": "node scripts/prepare-release.mjs",
     "tauri": "tauri",
     "tauri:dev": "tauri dev --config src-tauri/tauri.dev.conf.json",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "cli": "node scripts/run-rust-cli.mjs cli",
+    "cli:build": "node scripts/run-rust-cli.mjs build"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/run-rust-cli.mjs
+++ b/scripts/run-rust-cli.mjs
@@ -1,0 +1,64 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function canRun(command, args = ['--version']) {
+  const result = spawnSync(command, args, { stdio: 'ignore' });
+  return result.status === 0;
+}
+
+function resolveCargo() {
+  if (process.env.CARGO && existsSync(process.env.CARGO)) {
+    return process.env.CARGO;
+  }
+
+  if (canRun('cargo')) {
+    return 'cargo';
+  }
+
+  const rustupCheck = spawnSync('rustup', ['which', 'rustc'], { encoding: 'utf8' });
+  if (rustupCheck.status === 0) {
+    const rustcPath = rustupCheck.stdout.trim();
+    if (rustcPath) {
+      const cargoPath = join(dirname(rustcPath), 'cargo');
+      if (existsSync(cargoPath)) {
+        return cargoPath;
+      }
+    }
+  }
+
+  console.error('cargo not found. Install Rust or ensure cargo/rustup is on PATH.');
+  process.exit(127);
+}
+
+const mode = process.argv[2];
+const extraArgs = process.argv.slice(3);
+const cargo = resolveCargo();
+
+const baseArgs = ['--manifest-path', 'src-tauri/Cargo.toml', '--bin', 'skills-manager-cli'];
+const cargoArgs =
+  mode === 'cli'
+    ? ['run', '--quiet', ...baseArgs, '--', ...extraArgs]
+    : mode === 'build'
+      ? ['build', ...baseArgs]
+      : null;
+
+if (!cargoArgs) {
+  console.error(`unknown mode: ${mode}`);
+  process.exit(2);
+}
+
+const result = spawnSync(cargo, cargoArgs, {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    PATH: `${dirname(cargo)}:${process.env.PATH ?? ''}`,
+  },
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -117,6 +117,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +703,52 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2258,6 +2354,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,6 +3142,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -4520,6 +4628,7 @@ dependencies = [
  "anyhow",
  "caseless",
  "chrono",
+ "clap",
  "dirs 5.0.1",
  "fs2",
  "git2",
@@ -5756,6 +5865,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,3 +49,4 @@ aes-gcm = "0.10"
 rand = "0.8"
 image = { version = "0.25", default-features = false, features = ["png"] }
 notify = "6.1.1"
+clap = { version = "4.5", features = ["derive"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["tianliang"]
 license = "MIT"
 edition = "2021"
 rust-version = "1.77.2"
+default-run = "skills-manager"
 
 [lib]
 name = "app_lib"

--- a/src-tauri/src/bin/skills-manager-cli.rs
+++ b/src-tauri/src/bin/skills-manager-cli.rs
@@ -1,0 +1,420 @@
+use std::path::{Path, PathBuf};
+
+use app_lib::core::{
+    app_state, central_repo, git_backup, scenario_service, sync_engine, tool_service,
+};
+use clap::{Args, Parser, Subcommand};
+use serde::Serialize;
+
+#[derive(Parser, Debug)]
+#[command(name = "skills-manager-cli")]
+#[command(about = "Shared-core CLI for skills-manager", version)]
+struct Cli {
+    #[arg(long, global = true)]
+    json: bool,
+    #[arg(long, global = true)]
+    skills_root: Option<PathBuf>,
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    Repo(RepoArgs),
+    Tools(ToolsArgs),
+    Skills(SkillsArgs),
+    Scenarios(ScenarioArgs),
+    Git(GitArgs),
+}
+
+#[derive(Args, Debug)]
+struct RepoArgs {
+    #[command(subcommand)]
+    command: RepoCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum RepoCommand {
+    Status,
+    SetPath { path: String },
+    ResetPath,
+}
+
+#[derive(Args, Debug)]
+struct ToolsArgs {
+    #[command(subcommand)]
+    command: ToolsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ToolsCommand {
+    List,
+}
+
+#[derive(Args, Debug)]
+struct SkillsArgs {
+    #[command(subcommand)]
+    command: SkillsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum SkillsCommand {
+    List,
+    Show { reference: String },
+    Export { reference: String, #[arg(long)] dest: PathBuf },
+}
+
+#[derive(Args, Debug)]
+struct ScenarioArgs {
+    #[command(subcommand)]
+    command: ScenarioCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ScenarioCommand {
+    List,
+    Current,
+    Preview { reference: String },
+    Apply { reference: String },
+}
+
+#[derive(Args, Debug)]
+struct GitArgs {
+    #[command(subcommand)]
+    command: GitCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum GitCommand {
+    Status,
+    Init,
+    Clone { url: String },
+    SetRemote { url: String },
+    Pull,
+    Push,
+    Commit { #[arg(short, long)] message: String },
+    Versions { #[arg(long)] limit: Option<usize> },
+    Restore { tag: String },
+}
+
+#[derive(Debug, Serialize)]
+struct RepoStatus {
+    base_dir: String,
+    skills_dir: String,
+    db_path: String,
+    metadata_dir: String,
+    skill_count: usize,
+    scenario_count: usize,
+    active_scenario_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SkillSummary {
+    id: String,
+    name: String,
+    description: Option<String>,
+    path: String,
+    enabled: bool,
+    tags: Vec<String>,
+    source_type: String,
+    source_ref: Option<String>,
+    scenarios: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SkillDetail {
+    #[serde(flatten)]
+    summary: SkillSummary,
+    skill_file: String,
+    files: Vec<String>,
+    markdown: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioInfo {
+    id: String,
+    name: String,
+    description: Option<String>,
+    icon: Option<String>,
+    sort_order: i32,
+    skill_count: usize,
+    active: bool,
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("error: {err}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    if let Some(skills_root) = &cli.skills_root {
+        let base = skills_root
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("--skills-root requires a non-root path"))?
+            .to_path_buf();
+        central_repo::set_runtime_base_dir_override(Some(base));
+        central_repo::set_runtime_skills_dir_override(Some(skills_root.clone()));
+    }
+
+    let store = app_state::initialize_store()?;
+
+    match cli.command {
+        Commands::Repo(args) => match args.command {
+            RepoCommand::Status => print_json(&repo_status(&store), cli.json),
+            RepoCommand::SetPath { path } => {
+                central_repo::set_base_dir_override(Some(path))?;
+                let store = app_state::initialize_store()?;
+                print_json(&repo_status(&store), cli.json)
+            }
+            RepoCommand::ResetPath => {
+                central_repo::set_base_dir_override(None)?;
+                let store = app_state::initialize_store()?;
+                print_json(&repo_status(&store), cli.json)
+            }
+        },
+        Commands::Tools(args) => match args.command {
+            ToolsCommand::List => print_json(&tool_service::list_tool_info(&store), cli.json),
+        },
+        Commands::Skills(args) => match args.command {
+            SkillsCommand::List => print_json(&list_skills(&store)?, cli.json),
+            SkillsCommand::Show { reference } => print_json(&show_skill(&store, &reference)?, cli.json),
+            SkillsCommand::Export { reference, dest } => {
+                let result = export_skill(&store, &reference, &dest)?;
+                print_json(&serde_json::json!({"ok": true, "destination": result}), cli.json)
+            }
+        },
+        Commands::Scenarios(args) => match args.command {
+            ScenarioCommand::List => print_json(&list_scenarios(&store)?, cli.json),
+            ScenarioCommand::Current => print_json(&current_scenario(&store)?, cli.json),
+            ScenarioCommand::Preview { reference } => {
+                let scenario = resolve_scenario(&store, &reference)?;
+                let preview = scenario_service::preview_scenario_sync(&store, &scenario.id)
+                    .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+                print_json(&preview, cli.json)
+            }
+            ScenarioCommand::Apply { reference } => {
+                let scenario = resolve_scenario(&store, &reference)?;
+                scenario_service::apply_scenario_to_default(&store, &scenario.id)
+                    .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+                print_json(&current_scenario(&store)?, cli.json)
+            }
+        },
+        Commands::Git(args) => match args.command {
+            GitCommand::Status => print_json(&git_backup::get_status(&central_repo::skills_dir())?, cli.json),
+            GitCommand::Init => {
+                git_backup::init_repo(&central_repo::skills_dir())?;
+                print_json(&git_backup::get_status(&central_repo::skills_dir())?, cli.json)
+            }
+            GitCommand::Clone { url } => {
+                git_backup::clone_into(&central_repo::skills_dir(), &url)?;
+                print_json(&git_backup::get_status(&central_repo::skills_dir())?, cli.json)
+            }
+            GitCommand::SetRemote { url } => {
+                git_backup::set_remote(&central_repo::skills_dir(), &url)?;
+                print_json(&git_backup::get_status(&central_repo::skills_dir())?, cli.json)
+            }
+            GitCommand::Pull => {
+                git_backup::pull(&central_repo::skills_dir())?;
+                print_json(&git_backup::get_status(&central_repo::skills_dir())?, cli.json)
+            }
+            GitCommand::Push => {
+                git_backup::push(&central_repo::skills_dir())?;
+                print_json(&git_backup::get_status(&central_repo::skills_dir())?, cli.json)
+            }
+            GitCommand::Commit { message } => {
+                git_backup::commit_all(&central_repo::skills_dir(), &message)?;
+                let tag = git_backup::create_snapshot_tag(&central_repo::skills_dir())?;
+                print_json(&serde_json::json!({"ok": true, "tag": tag}), cli.json)
+            }
+            GitCommand::Versions { limit } => {
+                print_json(&git_backup::list_snapshot_versions(&central_repo::skills_dir(), limit)?, cli.json)
+            }
+            GitCommand::Restore { tag } => {
+                git_backup::restore_snapshot_version(&central_repo::skills_dir(), &tag)?;
+                print_json(&git_backup::get_status(&central_repo::skills_dir())?, cli.json)
+            }
+        },
+    }
+
+    Ok(())
+}
+
+fn repo_status(store: &app_lib::core::skill_store::SkillStore) -> RepoStatus {
+    RepoStatus {
+        base_dir: central_repo::base_dir().to_string_lossy().to_string(),
+        skills_dir: central_repo::skills_dir().to_string_lossy().to_string(),
+        db_path: central_repo::db_path().to_string_lossy().to_string(),
+        metadata_dir: app_lib::core::sync_metadata::metadata_dir().to_string_lossy().to_string(),
+        skill_count: store.get_all_skills().unwrap_or_default().len(),
+        scenario_count: store.get_all_scenarios().unwrap_or_default().len(),
+        active_scenario_id: store.get_active_scenario_id().unwrap_or(None),
+    }
+}
+
+fn list_skills(store: &app_lib::core::skill_store::SkillStore) -> anyhow::Result<Vec<SkillSummary>> {
+    let tags_map = store.get_tags_map()?;
+    let scenarios = store.get_all_scenarios()?;
+    let scenario_lookup: std::collections::HashMap<String, String> = scenarios
+        .into_iter()
+        .map(|s| (s.id, s.name))
+        .collect();
+
+    let mut items = Vec::new();
+    for skill in store.get_all_skills()? {
+        let scenario_names = store
+            .get_scenarios_for_skill(&skill.id)?
+            .into_iter()
+            .filter_map(|id| scenario_lookup.get(&id).cloned())
+            .collect();
+        items.push(SkillSummary {
+            id: skill.id.clone(),
+            name: skill.name.clone(),
+            description: skill.description.clone(),
+            path: skill.central_path.clone(),
+            enabled: skill.enabled,
+            tags: tags_map.get(&skill.id).cloned().unwrap_or_default(),
+            source_type: skill.source_type.clone(),
+            source_ref: skill.source_ref.clone(),
+            scenarios: scenario_names,
+        });
+    }
+    Ok(items)
+}
+
+fn show_skill(store: &app_lib::core::skill_store::SkillStore, reference: &str) -> anyhow::Result<SkillDetail> {
+    let skill = resolve_skill(store, reference)?;
+
+    let summary = list_skills(store)?
+        .into_iter()
+        .find(|item| item.id == skill.id)
+        .ok_or_else(|| anyhow::anyhow!("skill summary missing"))?;
+
+    let skill_dir = PathBuf::from(&skill.central_path);
+    let skill_file = [skill_dir.join("SKILL.md"), skill_dir.join("skill.md")]
+        .into_iter()
+        .find(|path| path.is_file())
+        .ok_or_else(|| anyhow::anyhow!("no SKILL.md found for {}", skill.name))?;
+    let markdown = std::fs::read_to_string(&skill_file)?;
+
+    Ok(SkillDetail {
+        summary,
+        skill_file: skill_file.to_string_lossy().to_string(),
+        files: collect_files(&skill_dir)?,
+        markdown,
+    })
+}
+
+fn export_skill(
+    store: &app_lib::core::skill_store::SkillStore,
+    reference: &str,
+    dest: &Path,
+) -> anyhow::Result<String> {
+    let skill = resolve_skill(store, reference)?;
+    sync_engine::sync_skill(Path::new(&skill.central_path), dest, sync_engine::SyncMode::Copy)?;
+    Ok(dest.to_string_lossy().to_string())
+}
+
+fn resolve_skill(
+    store: &app_lib::core::skill_store::SkillStore,
+    reference: &str,
+) -> anyhow::Result<app_lib::core::skill_store::SkillRecord> {
+    let matches: Vec<_> = store
+        .get_all_skills()?
+        .into_iter()
+        .filter(|skill| {
+            skill.id == reference
+                || skill.name == reference
+                || skill.central_path == reference
+                || Path::new(&skill.central_path)
+                    .file_name()
+                    .and_then(|value| value.to_str())
+                    == Some(reference)
+        })
+        .collect();
+
+    match matches.len() {
+        1 => Ok(matches.into_iter().next().unwrap()),
+        0 => Err(anyhow::anyhow!("skill not found: {reference}")),
+        _ => Err(anyhow::anyhow!("skill reference is ambiguous: {reference}")),
+    }
+}
+
+fn list_scenarios(store: &app_lib::core::skill_store::SkillStore) -> anyhow::Result<Vec<ScenarioInfo>> {
+    let active = store.get_active_scenario_id()?;
+    let scenarios = store.get_all_scenarios()?;
+    Ok(scenarios
+        .into_iter()
+        .map(|scenario| ScenarioInfo {
+            skill_count: store.get_skill_ids_for_scenario(&scenario.id).unwrap_or_default().len(),
+            active: active.as_deref() == Some(scenario.id.as_str()),
+            id: scenario.id,
+            name: scenario.name,
+            description: scenario.description,
+            icon: scenario.icon,
+            sort_order: scenario.sort_order,
+        })
+        .collect())
+}
+
+fn current_scenario(store: &app_lib::core::skill_store::SkillStore) -> anyhow::Result<Option<ScenarioInfo>> {
+    let scenarios = list_scenarios(store)?;
+    Ok(scenarios.into_iter().find(|scenario| scenario.active))
+}
+
+fn resolve_scenario(
+    store: &app_lib::core::skill_store::SkillStore,
+    reference: &str,
+) -> anyhow::Result<app_lib::core::skill_store::ScenarioRecord> {
+    let scenarios = store.get_all_scenarios()?;
+    if reference == "current" {
+        let active = store
+            .get_active_scenario_id()?
+            .ok_or_else(|| anyhow::anyhow!("no active scenario"))?;
+        return scenarios
+            .into_iter()
+            .find(|scenario| scenario.id == active)
+            .ok_or_else(|| anyhow::anyhow!("active scenario not found"));
+    }
+    let matches: Vec<_> = scenarios
+        .into_iter()
+        .filter(|scenario| scenario.id == reference || scenario.name == reference)
+        .collect();
+    match matches.len() {
+        1 => Ok(matches.into_iter().next().unwrap()),
+        0 => Err(anyhow::anyhow!("scenario not found: {reference}")),
+        _ => Err(anyhow::anyhow!("scenario reference is ambiguous: {reference}")),
+    }
+}
+
+fn collect_files(root: &Path) -> anyhow::Result<Vec<String>> {
+    let mut out = Vec::new();
+    collect_files_inner(root, root, &mut out)?;
+    out.sort();
+    Ok(out)
+}
+
+fn collect_files_inner(root: &Path, current: &Path, out: &mut Vec<String>) -> anyhow::Result<()> {
+    for entry in std::fs::read_dir(current)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_files_inner(root, &path, out)?;
+        } else {
+            out.push(path.strip_prefix(root)?.to_string_lossy().to_string());
+        }
+    }
+    Ok(())
+}
+
+fn print_json<T: Serialize>(value: &T, json: bool) {
+    let rendered = if json {
+        serde_json::to_string(value).unwrap()
+    } else {
+        serde_json::to_string_pretty(value).unwrap()
+    };
+    println!("{rendered}");
+}

--- a/src-tauri/src/commands/scenarios.rs
+++ b/src-tauri/src/commands/scenarios.rs
@@ -5,10 +5,10 @@ use tauri::State;
 
 use crate::core::{
     error::AppError,
-    skill_store::{ScenarioRecord, SkillStore, SkillTargetRecord},
-    sync_engine, sync_metadata, tool_adapters,
+    scenario_service,
+    skill_store::{ScenarioRecord, SkillStore},
+    sync_engine, sync_metadata,
 };
-use std::collections::{HashMap, HashSet};
 
 fn refresh_tray_menu_best_effort(app: &tauri::AppHandle) {
     if let Err(err) = crate::refresh_tray_menu(app) {
@@ -23,104 +23,7 @@ pub(crate) fn sync_skill_to_active_scenario(
     scenario_id: &str,
     skill_id: &str,
 ) -> Result<(), AppError> {
-    if let Ok(Some(active_id)) = store.get_active_scenario_id() {
-        if active_id == scenario_id {
-            let adapters =
-                enabled_installed_adapters_for_scenario_skill(store, scenario_id, skill_id)?;
-            let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
-            let Ok(Some(skill)) = store.get_skill_by_id(skill_id) else {
-                return Ok(());
-            };
-            let source = PathBuf::from(&skill.central_path);
-            let target_name = sync_engine::target_dir_name(&source, &skill.name);
-            let old_targets = store.get_targets_for_skill(skill_id).unwrap_or_default();
-            for adapter in &adapters {
-                // Remove stale target from a previous sync if the skill name changed
-                if let Some(old) = old_targets.iter().find(|t| t.tool == adapter.key) {
-                    let old_path = PathBuf::from(&old.target_path);
-                    if old_path != adapter.skills_dir().join(&target_name) {
-                        if let Err(e) = sync_engine::remove_target(&old_path) {
-                            log::warn!("Failed to remove stale target {}: {e}", old_path.display());
-                        }
-                        let _ = store.delete_target(skill_id, &adapter.key);
-                    }
-                }
-
-                let target = adapter.skills_dir().join(&target_name);
-                let mode =
-                    sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
-                match sync_engine::sync_skill(&source, &target, mode) {
-                    Ok(actual_mode) => {
-                        let now = chrono::Utc::now().timestamp_millis();
-                        let target_record = crate::core::skill_store::SkillTargetRecord {
-                            id: uuid::Uuid::new_v4().to_string(),
-                            skill_id: skill_id.to_string(),
-                            tool: adapter.key.clone(),
-                            target_path: target.to_string_lossy().to_string(),
-                            mode: actual_mode.as_str().to_string(),
-                            status: "ok".to_string(),
-                            synced_at: Some(now),
-                            last_error: None,
-                        };
-                        if let Err(e) = store.insert_target(&target_record) {
-                            log::warn!("Failed to insert sync target for skill {skill_id}: {e}");
-                        }
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "Failed to sync skill {skill_id} to {}: {e}",
-                            target.display()
-                        );
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-fn ensure_scenario_exists(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
-    let exists = store
-        .get_all_scenarios()
-        .map_err(AppError::db)?
-        .iter()
-        .any(|s| s.id == scenario_id);
-    if !exists {
-        return Err(AppError::not_found("Scenario not found"));
-    }
-    Ok(())
-}
-
-pub(crate) fn enabled_installed_adapters_for_scenario_skill(
-    store: &SkillStore,
-    scenario_id: &str,
-    skill_id: &str,
-) -> Result<Vec<tool_adapters::ToolAdapter>, AppError> {
-    let adapters = tool_adapters::enabled_installed_adapters(store);
-    let adapter_keys: Vec<String> = adapters.iter().map(|a| a.key.clone()).collect();
-
-    store
-        .ensure_scenario_skill_tool_defaults(scenario_id, skill_id, &adapter_keys)
-        .map_err(AppError::db)?;
-
-    let enabled = store
-        .get_enabled_tools_for_scenario_skill(scenario_id, skill_id)
-        .map_err(AppError::db)?;
-    let enabled_set: HashSet<String> = enabled.into_iter().collect();
-
-    Ok(adapters
-        .into_iter()
-        .filter(|adapter| enabled_set.contains(&adapter.key))
-        .collect())
-}
-
-#[derive(Debug, Clone)]
-struct ScenarioSyncTarget {
-    skill_id: String,
-    tool: String,
-    source: PathBuf,
-    target: PathBuf,
-    mode: sync_engine::SyncMode,
+    scenario_service::sync_skill_to_active_scenario(store, scenario_id, skill_id)
 }
 
 #[derive(Debug, Serialize)]
@@ -342,23 +245,7 @@ async fn apply_scenario_to_default_impl(
     store: Arc<SkillStore>,
 ) -> Result<(), AppError> {
     let result = tauri::async_runtime::spawn_blocking(move || {
-        ensure_scenario_exists(&store, &id)?;
-        let desired_targets = collect_scenario_sync_targets(&store, &id)?;
-
-        // Remove only targets that are not also needed by the new scenario.
-        if let Ok(Some(old_id)) = store.get_active_scenario_id() {
-            if old_id != id {
-                unsync_obsolete_scenario_targets(&store, &old_id, &desired_targets)?;
-            }
-        }
-
-        // Mark this scenario as the one currently applied to default targets.
-        store.set_active_scenario(&id).map_err(AppError::db)?;
-
-        // Sync missing or stale targets for the new scenario.
-        sync_desired_targets(&store, &desired_targets)?;
-
-        Ok(())
+        scenario_service::apply_scenario_to_default(&store, &id)
     })
     .await?;
     if result.is_ok() {
@@ -491,185 +378,24 @@ pub async fn reorder_scenario_skills(
 // ── Internal helpers ──
 
 pub(crate) fn sync_scenario_skills(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
-    let desired_targets = collect_scenario_sync_targets(store, scenario_id)?;
-    sync_desired_targets(store, &desired_targets)
-}
-
-fn collect_scenario_sync_targets(
-    store: &SkillStore,
-    scenario_id: &str,
-) -> Result<Vec<ScenarioSyncTarget>, AppError> {
-    let skills = store
-        .get_skills_for_scenario(scenario_id)
-        .map_err(AppError::db)?;
-    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
-    let mut targets = Vec::new();
-
-    for skill in &skills {
-        let source = PathBuf::from(&skill.central_path);
-        let target_name = sync_engine::target_dir_name(&source, &skill.name);
-        let adapters =
-            enabled_installed_adapters_for_scenario_skill(store, scenario_id, &skill.id)?;
-        for adapter in &adapters {
-            let target = adapter.skills_dir().join(&target_name);
-            let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
-            targets.push(ScenarioSyncTarget {
-                skill_id: skill.id.clone(),
-                tool: adapter.key.clone(),
-                source: source.clone(),
-                target,
-                mode,
-            });
-        }
-    }
-
-    Ok(targets)
-}
-
-fn sync_desired_targets(
-    store: &SkillStore,
-    desired_targets: &[ScenarioSyncTarget],
-) -> Result<(), AppError> {
-    let existing_targets: HashMap<(String, String), SkillTargetRecord> = store
-        .get_all_targets()
-        .map_err(AppError::db)?
-        .into_iter()
-        .map(|target| ((target.skill_id.clone(), target.tool.clone()), target))
-        .collect();
-
-    for desired in desired_targets {
-        let key = (desired.skill_id.clone(), desired.tool.clone());
-        if let Some(existing) = existing_targets.get(&key) {
-            let target_path = PathBuf::from(&existing.target_path);
-            if target_path != desired.target {
-                if let Err(e) = sync_engine::remove_target(&target_path) {
-                    log::warn!(
-                        "Failed to remove stale target {}: {e}",
-                        target_path.display()
-                    );
-                }
-                if let Err(e) = store.delete_target(&desired.skill_id, &desired.tool) {
-                    log::warn!(
-                        "Failed to delete stale target record for skill {}, tool {}: {e}",
-                        desired.skill_id,
-                        desired.tool
-                    );
-                }
-            } else if existing.mode == desired.mode.as_str()
-                && existing.status == "ok"
-                && sync_engine::is_target_current(&desired.source, &desired.target, desired.mode)
-            {
-                continue;
-            }
-        }
-
-        match sync_engine::sync_skill(&desired.source, &desired.target, desired.mode) {
-            Ok(actual_mode) => {
-                let now = chrono::Utc::now().timestamp_millis();
-                let target_record = SkillTargetRecord {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    skill_id: desired.skill_id.clone(),
-                    tool: desired.tool.clone(),
-                    target_path: desired.target.to_string_lossy().to_string(),
-                    mode: actual_mode.as_str().to_string(),
-                    status: "ok".to_string(),
-                    synced_at: Some(now),
-                    last_error: None,
-                };
-                if let Err(e) = store.insert_target(&target_record) {
-                    log::warn!(
-                        "Failed to insert sync target for skill {}: {e}",
-                        desired.skill_id
-                    );
-                }
-            }
-            Err(e) => {
-                log::warn!(
-                    "Failed to sync skill {} to {}: {e}",
-                    desired.skill_id,
-                    desired.target.display()
-                );
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn unsync_obsolete_scenario_targets(
-    store: &SkillStore,
-    old_scenario_id: &str,
-    desired_targets: &[ScenarioSyncTarget],
-) -> Result<(), AppError> {
-    let desired_paths: HashMap<(String, String), PathBuf> = desired_targets
-        .iter()
-        .map(|target| {
-            (
-                (target.skill_id.clone(), target.tool.clone()),
-                target.target.clone(),
-            )
-        })
-        .collect();
-
-    let old_skill_ids = store
-        .get_skill_ids_for_scenario(old_scenario_id)
-        .map_err(AppError::db)?;
-    for skill_id in &old_skill_ids {
-        let targets = store.get_targets_for_skill(skill_id).unwrap_or_default();
-        for target in &targets {
-            let path = PathBuf::from(&target.target_path);
-            let key = (skill_id.clone(), target.tool.clone());
-            if desired_paths.get(&key) == Some(&path) {
-                continue;
-            }
-
-            if let Err(e) = sync_engine::remove_target(&path) {
-                log::warn!("Failed to remove sync target {}: {e}", path.display());
-            }
-            if let Err(e) = store.delete_target(skill_id, &target.tool) {
-                log::warn!(
-                    "Failed to delete target record for skill {skill_id}, tool {}: {e}",
-                    target.tool
-                );
-            }
-        }
-    }
-
-    Ok(())
+    scenario_service::sync_scenario_skills(store, scenario_id)
 }
 
 pub(crate) fn unsync_scenario_skills(
     store: &SkillStore,
     scenario_id: &str,
 ) -> Result<(), AppError> {
-    let skill_ids = store
-        .get_skill_ids_for_scenario(scenario_id)
-        .map_err(AppError::db)?;
-
-    for skill_id in &skill_ids {
-        let targets = store.get_targets_for_skill(skill_id).unwrap_or_default();
-        for target in &targets {
-            let path = PathBuf::from(&target.target_path);
-            if let Err(e) = sync_engine::remove_target(&path) {
-                log::warn!("Failed to remove sync target {}: {e}", path.display());
-            }
-            if let Err(e) = store.delete_target(skill_id, &target.tool) {
-                log::warn!(
-                    "Failed to delete target record for skill {skill_id}, tool {}: {e}",
-                    target.tool
-                );
-            }
-        }
-    }
-
-    Ok(())
+    scenario_service::unsync_scenario_skills(store, scenario_id)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::scenario_service::{
+        collect_scenario_sync_targets, sync_desired_targets, unsync_obsolete_scenario_targets,
+    };
     use crate::core::skill_store::SkillRecord;
-    use crate::core::tool_adapters::CustomToolDef;
+    use crate::core::tool_adapters::{self, CustomToolDef};
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -4,8 +4,10 @@ use tauri::State;
 
 use crate::core::{
     error::AppError,
-    skill_store::{SkillStore, SkillTargetRecord},
+    scenario_service,
+    skill_store::SkillStore,
     sync_engine, sync_metadata, tool_adapters,
+    tool_service,
 };
 use serde::Serialize;
 
@@ -19,12 +21,7 @@ pub struct SkillToolToggleDto {
 }
 
 fn disabled_tools(store: &SkillStore) -> Vec<String> {
-    store
-        .get_setting("disabled_tools")
-        .ok()
-        .flatten()
-        .and_then(|v| serde_json::from_str::<Vec<String>>(&v).ok())
-        .unwrap_or_default()
+    tool_service::get_disabled_tools(store)
 }
 
 fn sync_skill_to_tool_internal(
@@ -32,50 +29,7 @@ fn sync_skill_to_tool_internal(
     skill_id: &str,
     tool: &str,
 ) -> Result<(), AppError> {
-    let adapter = tool_adapters::find_adapter_with_store(store, tool)
-        .ok_or_else(|| AppError::not_found(format!("Unknown tool: {}", tool)))?;
-
-    if !adapter.is_installed() {
-        return Err(AppError::not_found(format!(
-            "{} is not installed",
-            adapter.display_name
-        )));
-    }
-
-    if disabled_tools(store).contains(&tool.to_string()) {
-        return Err(AppError::invalid_input(format!(
-            "{} is disabled",
-            adapter.display_name
-        )));
-    }
-
-    let skill = store
-        .get_skill_by_id(skill_id)
-        .map_err(AppError::db)?
-        .ok_or_else(|| AppError::not_found("Skill not found"))?;
-
-    let source = PathBuf::from(&skill.central_path);
-    let target = adapter
-        .skills_dir()
-        .join(sync_engine::target_dir_name(&source, &skill.name));
-    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
-    let mode = sync_engine::sync_mode_for_tool(tool, configured_mode.as_deref());
-    let actual_mode = sync_engine::sync_skill(&source, &target, mode).map_err(AppError::io)?;
-
-    let now = chrono::Utc::now().timestamp_millis();
-    let target_record = SkillTargetRecord {
-        id: uuid::Uuid::new_v4().to_string(),
-        skill_id: skill_id.to_string(),
-        tool: tool.to_string(),
-        target_path: target.to_string_lossy().to_string(),
-        mode: actual_mode.as_str().to_string(),
-        status: "ok".to_string(),
-        synced_at: Some(now),
-        last_error: None,
-    };
-
-    store.insert_target(&target_record).map_err(AppError::db)?;
-    Ok(())
+    scenario_service::sync_single_skill_to_tool(store, skill_id, tool)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/tools.rs
+++ b/src-tauri/src/commands/tools.rs
@@ -1,15 +1,19 @@
 use serde::Serialize;
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tauri::State;
 
 use crate::core::error::AppError;
-use crate::core::skill_store::{SkillStore, SkillTargetRecord};
+use crate::core::scenario_service;
+use crate::core::scenario_service::sync_scenario_skills;
+use crate::core::skill_store::SkillStore;
 use crate::core::sync_engine;
 use crate::core::tool_adapters::{self, CustomToolDef};
-
-use super::scenarios::{enabled_installed_adapters_for_scenario_skill, sync_scenario_skills};
+use crate::core::tool_service::{
+    self, ToolInfo, get_custom_tool_paths, get_custom_tools, get_disabled_tools,
+    normalize_project_relative_skills_dir_input, normalize_skills_dir_input, set_custom_tool_paths,
+    set_custom_tools, set_disabled_tools,
+};
 
 #[derive(Debug, Serialize)]
 pub struct ToolInfoDto {
@@ -23,157 +27,9 @@ pub struct ToolInfoDto {
     pub project_relative_skills_dir: Option<String>,
 }
 
-fn get_disabled_tools(store: &SkillStore) -> Vec<String> {
-    store
-        .get_setting("disabled_tools")
-        .ok()
-        .flatten()
-        .and_then(|v| serde_json::from_str::<Vec<String>>(&v).ok())
-        .unwrap_or_default()
-}
-
-fn set_disabled_tools(store: &SkillStore, disabled: &[String]) -> Result<(), AppError> {
-    let json = serde_json::to_string(disabled)
-        .map_err(|e| AppError::internal(format!("Failed to serialize: {e}")))?;
-    store
-        .set_setting("disabled_tools", &json)
-        .map_err(AppError::db)
-}
-
-fn get_custom_tool_paths(store: &SkillStore) -> HashMap<String, String> {
-    tool_adapters::custom_tool_paths(store)
-}
-
-fn set_custom_tool_paths(
-    store: &SkillStore,
-    paths: &HashMap<String, String>,
-) -> Result<(), AppError> {
-    let json = serde_json::to_string(paths)
-        .map_err(|e| AppError::internal(format!("Failed to serialize: {e}")))?;
-    store
-        .set_setting("custom_tool_paths", &json)
-        .map_err(AppError::db)
-}
-
-fn get_custom_tools(store: &SkillStore) -> Vec<CustomToolDef> {
-    tool_adapters::custom_tools(store)
-}
-
-fn set_custom_tools(store: &SkillStore, custom_tools: &[CustomToolDef]) -> Result<(), AppError> {
-    let json = serde_json::to_string(custom_tools)
-        .map_err(|e| AppError::internal(format!("Failed to serialize: {e}")))?;
-    store
-        .set_setting("custom_tools", &json)
-        .map_err(AppError::db)
-}
-
-fn normalize_skills_dir_input(path: &str) -> Result<String, AppError> {
-    let raw = path.trim();
-    if raw.is_empty() {
-        return Err(AppError::invalid_input("Path is required"));
-    }
-
-    let expanded = if raw == "~" {
-        dirs::home_dir()
-            .ok_or_else(|| AppError::internal("Cannot determine home directory"))?
-            .to_string_lossy()
-            .to_string()
-    } else if let Some(rest) = raw.strip_prefix("~/") {
-        dirs::home_dir()
-            .ok_or_else(|| AppError::internal("Cannot determine home directory"))?
-            .join(rest)
-            .to_string_lossy()
-            .to_string()
-    } else if !std::path::Path::new(raw).is_absolute() {
-        return Err(AppError::invalid_input(
-            "Skills path must be absolute (or start with ~/)",
-        ));
-    } else {
-        raw.to_string()
-    };
-
-    Ok(expanded)
-}
-
-fn normalize_project_relative_skills_dir_input(path: &str) -> Result<Option<String>, AppError> {
-    let trimmed = path.trim();
-    if trimmed.is_empty() {
-        return Ok(None);
-    }
-    let candidate = std::path::Path::new(trimmed);
-    if candidate.is_absolute() {
-        return Err(AppError::invalid_input(
-            "Project skills path must be relative to the project root",
-        ));
-    }
-    if candidate
-        .components()
-        .any(|component| matches!(component, std::path::Component::ParentDir))
-    {
-        return Err(AppError::invalid_input(
-            "Project skills path cannot contain parent directory segments",
-        ));
-    }
-    Ok(Some(trimmed.trim_matches('/').to_string()))
-}
-
 /// Sync active scenario skills to a single tool.
 fn sync_active_scenario_to_tool(store: &SkillStore, tool_key: &str) {
-    let active_id = match store.get_active_scenario_id() {
-        Ok(Some(id)) => id,
-        _ => return,
-    };
-    let skills = match store.get_skills_for_scenario(&active_id) {
-        Ok(s) => s,
-        _ => return,
-    };
-    let adapter = match tool_adapters::find_adapter_with_store(store, tool_key) {
-        Some(a) if a.is_installed() => a,
-        _ => return,
-    };
-    let configured_mode = store.get_setting("sync_mode").ok().flatten();
-    for skill in &skills {
-        let allowed_adapters =
-            match enabled_installed_adapters_for_scenario_skill(store, &active_id, &skill.id) {
-                Ok(adapters) => adapters,
-                Err(_) => continue,
-            };
-        if !allowed_adapters
-            .iter()
-            .any(|adapter| adapter.key == tool_key)
-        {
-            continue;
-        }
-        let source = PathBuf::from(&skill.central_path);
-        let target = adapter
-            .skills_dir()
-            .join(sync_engine::target_dir_name(&source, &skill.name));
-        let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
-        match sync_engine::sync_skill(&source, &target, mode) {
-            Ok(actual_mode) => {
-                let now = chrono::Utc::now().timestamp_millis();
-                let target_record = SkillTargetRecord {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    skill_id: skill.id.clone(),
-                    tool: adapter.key.clone(),
-                    target_path: target.to_string_lossy().to_string(),
-                    mode: actual_mode.as_str().to_string(),
-                    status: "ok".to_string(),
-                    synced_at: Some(now),
-                    last_error: None,
-                };
-                store.insert_target(&target_record).ok();
-            }
-            Err(e) => {
-                log::warn!(
-                    "Failed to sync skill {} to {} for tool {}: {e}",
-                    skill.id,
-                    target.display(),
-                    adapter.key
-                );
-            }
-        }
-    }
+    scenario_service::sync_active_scenario_to_tool(store, tool_key)
 }
 
 /// Remove all synced skill files and target records for a given tool.
@@ -200,23 +56,17 @@ pub async fn get_tool_status(
 ) -> Result<Vec<ToolInfoDto>, AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        let adapters = tool_adapters::all_tool_adapters(&store);
-        let disabled = get_disabled_tools(&store);
-        let result: Vec<ToolInfoDto> = adapters
+        let result: Vec<ToolInfoDto> = tool_service::list_tool_info(&store)
             .into_iter()
-            .map(|a| ToolInfoDto {
-                key: a.key.clone(),
-                display_name: a.display_name.clone(),
-                installed: a.is_installed(),
-                skills_dir: a.skills_dir().to_string_lossy().to_string(),
-                enabled: !disabled.contains(&a.key),
-                is_custom: a.is_custom,
-                has_path_override: a.has_path_override(),
-                project_relative_skills_dir: if a.relative_skills_dir.is_empty() {
-                    None
-                } else {
-                    Some(a.relative_skills_dir.clone())
-                },
+            .map(|info: ToolInfo| ToolInfoDto {
+                key: info.key,
+                display_name: info.display_name,
+                installed: info.installed,
+                skills_dir: info.skills_dir,
+                enabled: info.enabled,
+                is_custom: info.is_custom,
+                has_path_override: info.has_path_override,
+                project_relative_skills_dir: info.project_relative_skills_dir,
             })
             .collect();
         Ok(result)
@@ -438,97 +288,7 @@ pub async fn remove_custom_tool(
 }
 
 pub fn migrate_legacy_tool_keys(store: &SkillStore) -> Result<(), AppError> {
-    const OLD_KEY: &str = "clawdbot";
-    const NEW_KEY: &str = "openclaw";
-
-    let mut changed = false;
-
-    let mut disabled = get_disabled_tools(store);
-    if disabled.iter().any(|k| k == OLD_KEY) {
-        for key in &mut disabled {
-            if key == OLD_KEY {
-                *key = NEW_KEY.to_string();
-            }
-        }
-        disabled.sort();
-        disabled.dedup();
-        set_disabled_tools(store, &disabled)?;
-        changed = true;
-    }
-
-    let mut custom_paths = get_custom_tool_paths(store);
-    if let Some(old_path) = custom_paths.remove(OLD_KEY) {
-        custom_paths.entry(NEW_KEY.to_string()).or_insert(old_path);
-        set_custom_tool_paths(store, &custom_paths)?;
-        changed = true;
-    }
-
-    // Backward compatibility: normalize any persisted "~" path forms.
-    let mut normalized_path_changed = false;
-    for value in custom_paths.values_mut() {
-        if let Ok(normalized) = normalize_skills_dir_input(value) {
-            if *value != normalized {
-                *value = normalized;
-                normalized_path_changed = true;
-            }
-        }
-    }
-    if normalized_path_changed {
-        set_custom_tool_paths(store, &custom_paths)?;
-        changed = true;
-    }
-
-    let custom_tools = get_custom_tools(store);
-    let mut custom_tools_changed = false;
-    let custom_tools = if custom_tools.iter().any(|c| c.key == OLD_KEY) {
-        let has_new = custom_tools.iter().any(|c| c.key == NEW_KEY);
-        let mut migrated = Vec::with_capacity(custom_tools.len());
-        let mut seen_keys = std::collections::HashSet::new();
-        for mut custom in custom_tools {
-            if custom.key == OLD_KEY {
-                if has_new {
-                    continue;
-                }
-                custom.key = NEW_KEY.to_string();
-            }
-            if seen_keys.insert(custom.key.clone()) {
-                migrated.push(custom);
-            }
-        }
-        custom_tools_changed = true;
-        changed = true;
-        migrated
-    } else {
-        custom_tools
-    };
-
-    let mut normalized_customs = custom_tools;
-    for custom in &mut normalized_customs {
-        if let Ok(normalized) = normalize_skills_dir_input(&custom.skills_dir) {
-            if custom.skills_dir != normalized {
-                custom.skills_dir = normalized;
-                custom_tools_changed = true;
-            }
-        }
-    }
-    if custom_tools_changed {
-        set_custom_tools(store, &normalized_customs)?;
-    }
-
-    if changed
-        || store
-            .has_tool_key_references(OLD_KEY)
-            .map_err(AppError::db)?
-    {
-        // Migrate historical per-tool records in DB tables only when needed.
-        store
-            .remap_tool_key_references(OLD_KEY, NEW_KEY)
-            .map_err(AppError::db)?;
-    }
-    if changed {
-        log::info!("Migrated legacy tool key {OLD_KEY} -> {NEW_KEY}");
-    }
-    Ok(())
+    tool_service::migrate_legacy_tool_keys(store)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/core/app_state.rs
+++ b/src-tauri/src/core/app_state.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+
+use super::{central_repo, scenario_service, skill_store::SkillStore, sync_metadata, tool_service};
+
+pub fn initialize_store() -> Result<Arc<SkillStore>> {
+    central_repo::ensure_central_repo().context("Failed to create central repo")?;
+
+    let db_path = central_repo::db_path();
+    let store = Arc::new(SkillStore::new(&db_path).context("Failed to initialize database")?);
+    tool_service::migrate_legacy_tool_keys(&store)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))
+        .context("Failed to migrate legacy tool keys")?;
+    if sync_metadata::metadata_exists() {
+        sync_metadata::reindex_from_metadata(&store)
+            .context("Failed to reindex from sync metadata")?;
+    }
+    scenario_service::ensure_default_startup_scenario(&store)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))
+        .context("Failed to initialize startup scenario")?;
+    Ok(store)
+}

--- a/src-tauri/src/core/central_repo.rs
+++ b/src-tauri/src/core/central_repo.rs
@@ -2,14 +2,13 @@ use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-#[cfg(test)]
 use std::sync::{Mutex, OnceLock};
 use walkdir::WalkDir;
 
 const CONFIG_FILE_NAME: &str = "repo-config.json";
 
-#[cfg(test)]
-static TEST_BASE_DIR_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+static BASE_DIR_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+static SKILLS_DIR_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct RepoPathConfig {
@@ -89,8 +88,7 @@ pub fn configured_base_dir() -> Option<PathBuf> {
 }
 
 pub fn base_dir() -> PathBuf {
-    #[cfg(test)]
-    if let Some(path) = TEST_BASE_DIR_OVERRIDE
+    if let Some(path) = BASE_DIR_OVERRIDE
         .get_or_init(|| Mutex::new(None))
         .lock()
         .unwrap()
@@ -102,15 +100,35 @@ pub fn base_dir() -> PathBuf {
     configured_base_dir().unwrap_or_else(default_base_dir)
 }
 
-#[cfg(test)]
-pub(crate) fn set_test_base_dir_override(path: Option<PathBuf>) {
-    *TEST_BASE_DIR_OVERRIDE
+pub fn set_runtime_base_dir_override(path: Option<PathBuf>) {
+    *BASE_DIR_OVERRIDE
         .get_or_init(|| Mutex::new(None))
         .lock()
         .unwrap() = path;
 }
 
+pub fn set_runtime_skills_dir_override(path: Option<PathBuf>) {
+    *SKILLS_DIR_OVERRIDE
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap() = path;
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_base_dir_override(path: Option<PathBuf>) {
+    set_runtime_base_dir_override(path);
+    set_runtime_skills_dir_override(None);
+}
+
 pub fn skills_dir() -> PathBuf {
+    if let Some(path) = SKILLS_DIR_OVERRIDE
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap()
+        .clone()
+    {
+        return path;
+    }
     base_dir().join("skills")
 }
 

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod app_state;
 pub mod central_repo;
 pub mod content_hash;
 pub mod crypto;
@@ -11,6 +12,7 @@ pub mod migrations;
 pub mod project_scanner;
 pub mod repo_lock;
 pub mod scanner;
+pub mod scenario_service;
 pub mod skill_metadata;
 pub mod skill_store;
 pub mod skillsmp_api;
@@ -18,3 +20,4 @@ pub mod skillssh_api;
 pub mod sync_engine;
 pub mod sync_metadata;
 pub mod tool_adapters;
+pub mod tool_service;

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -1,0 +1,434 @@
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+
+use super::{
+    error::AppError,
+    skill_store::{ScenarioRecord, SkillStore, SkillTargetRecord},
+    sync_engine, tool_adapters,
+    tool_service,
+};
+
+#[derive(Debug, Clone)]
+pub struct ScenarioSyncTarget {
+    pub skill_id: String,
+    pub skill_name: String,
+    pub tool: String,
+    pub source: PathBuf,
+    pub target: PathBuf,
+    pub mode: sync_engine::SyncMode,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyncPreviewTarget {
+    pub skill_id: String,
+    pub skill_name: String,
+    pub tool: String,
+    pub target_path: String,
+    pub mode: String,
+}
+
+pub fn ensure_scenario_exists(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
+    let exists = store
+        .get_all_scenarios()
+        .map_err(AppError::db)?
+        .iter()
+        .any(|s| s.id == scenario_id);
+    if !exists {
+        return Err(AppError::not_found("Scenario not found"));
+    }
+    Ok(())
+}
+
+pub fn enabled_installed_adapters_for_scenario_skill(
+    store: &SkillStore,
+    scenario_id: &str,
+    skill_id: &str,
+) -> Result<Vec<tool_adapters::ToolAdapter>, AppError> {
+    let adapters = tool_adapters::enabled_installed_adapters(store);
+    let adapter_keys: Vec<String> = adapters.iter().map(|a| a.key.clone()).collect();
+
+    store
+        .ensure_scenario_skill_tool_defaults(scenario_id, skill_id, &adapter_keys)
+        .map_err(AppError::db)?;
+
+    let enabled = store
+        .get_enabled_tools_for_scenario_skill(scenario_id, skill_id)
+        .map_err(AppError::db)?;
+    let enabled_set: HashSet<String> = enabled.into_iter().collect();
+
+    Ok(adapters
+        .into_iter()
+        .filter(|adapter| enabled_set.contains(&adapter.key))
+        .collect())
+}
+
+pub fn collect_scenario_sync_targets(
+    store: &SkillStore,
+    scenario_id: &str,
+) -> Result<Vec<ScenarioSyncTarget>, AppError> {
+    let skills = store
+        .get_skills_for_scenario(scenario_id)
+        .map_err(AppError::db)?;
+    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+    let mut targets = Vec::new();
+
+    for skill in &skills {
+        let source = PathBuf::from(&skill.central_path);
+        let target_name = sync_engine::target_dir_name(&source, &skill.name);
+        let adapters = enabled_installed_adapters_for_scenario_skill(store, scenario_id, &skill.id)?;
+        for adapter in &adapters {
+            let target = adapter.skills_dir().join(&target_name);
+            let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
+            targets.push(ScenarioSyncTarget {
+                skill_id: skill.id.clone(),
+                skill_name: skill.name.clone(),
+                tool: adapter.key.clone(),
+                source: source.clone(),
+                target,
+                mode,
+            });
+        }
+    }
+
+    Ok(targets)
+}
+
+pub fn preview_scenario_sync(
+    store: &SkillStore,
+    scenario_id: &str,
+) -> Result<Vec<SyncPreviewTarget>, AppError> {
+    collect_scenario_sync_targets(store, scenario_id).map(|targets| {
+        targets
+            .into_iter()
+            .map(|target| SyncPreviewTarget {
+                skill_id: target.skill_id,
+                skill_name: target.skill_name,
+                tool: target.tool,
+                target_path: target.target.to_string_lossy().to_string(),
+                mode: target.mode.as_str().to_string(),
+            })
+            .collect()
+    })
+}
+
+pub fn sync_desired_targets(
+    store: &SkillStore,
+    desired_targets: &[ScenarioSyncTarget],
+) -> Result<(), AppError> {
+    let existing_targets: HashMap<(String, String), SkillTargetRecord> = store
+        .get_all_targets()
+        .map_err(AppError::db)?
+        .into_iter()
+        .map(|target| ((target.skill_id.clone(), target.tool.clone()), target))
+        .collect();
+
+    for desired in desired_targets {
+        let key = (desired.skill_id.clone(), desired.tool.clone());
+        if let Some(existing) = existing_targets.get(&key) {
+            let target_path = PathBuf::from(&existing.target_path);
+            if target_path != desired.target {
+                if let Err(e) = sync_engine::remove_target(&target_path) {
+                    log::warn!(
+                        "Failed to remove stale target {}: {e}",
+                        target_path.display()
+                    );
+                }
+                if let Err(e) = store.delete_target(&desired.skill_id, &desired.tool) {
+                    log::warn!(
+                        "Failed to delete stale target record for skill {}, tool {}: {e}",
+                        desired.skill_id,
+                        desired.tool
+                    );
+                }
+            } else if existing.mode == desired.mode.as_str()
+                && existing.status == "ok"
+                && sync_engine::is_target_current(&desired.source, &desired.target, desired.mode)
+            {
+                continue;
+            }
+        }
+
+        match sync_engine::sync_skill(&desired.source, &desired.target, desired.mode) {
+            Ok(actual_mode) => {
+                let now = chrono::Utc::now().timestamp_millis();
+                let target_record = SkillTargetRecord {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    skill_id: desired.skill_id.clone(),
+                    tool: desired.tool.clone(),
+                    target_path: desired.target.to_string_lossy().to_string(),
+                    mode: actual_mode.as_str().to_string(),
+                    status: "ok".to_string(),
+                    synced_at: Some(now),
+                    last_error: None,
+                };
+                if let Err(e) = store.insert_target(&target_record) {
+                    log::warn!(
+                        "Failed to insert sync target for skill {}: {e}",
+                        desired.skill_id
+                    );
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to sync skill {} to {}: {e}",
+                    desired.skill_id,
+                    desired.target.display()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn unsync_obsolete_scenario_targets(
+    store: &SkillStore,
+    old_scenario_id: &str,
+    desired_targets: &[ScenarioSyncTarget],
+) -> Result<(), AppError> {
+    let desired_paths: HashMap<(String, String), PathBuf> = desired_targets
+        .iter()
+        .map(|target| {
+            (
+                (target.skill_id.clone(), target.tool.clone()),
+                target.target.clone(),
+            )
+        })
+        .collect();
+
+    let old_skill_ids = store
+        .get_skill_ids_for_scenario(old_scenario_id)
+        .map_err(AppError::db)?;
+    for skill_id in &old_skill_ids {
+        let targets = store.get_targets_for_skill(skill_id).unwrap_or_default();
+        for target in &targets {
+            let path = PathBuf::from(&target.target_path);
+            let key = (skill_id.clone(), target.tool.clone());
+            if desired_paths.get(&key) == Some(&path) {
+                continue;
+            }
+
+            if let Err(e) = sync_engine::remove_target(&path) {
+                log::warn!("Failed to remove sync target {}: {e}", path.display());
+            }
+            if let Err(e) = store.delete_target(skill_id, &target.tool) {
+                log::warn!(
+                    "Failed to delete target record for skill {skill_id}, tool {}: {e}",
+                    target.tool
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn unsync_scenario_skills(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
+    let skill_ids = store
+        .get_skill_ids_for_scenario(scenario_id)
+        .map_err(AppError::db)?;
+
+    for skill_id in &skill_ids {
+        let targets = store.get_targets_for_skill(skill_id).unwrap_or_default();
+        for target in &targets {
+            let path = PathBuf::from(&target.target_path);
+            if let Err(e) = sync_engine::remove_target(&path) {
+                log::warn!("Failed to remove sync target {}: {e}", path.display());
+            }
+            if let Err(e) = store.delete_target(skill_id, &target.tool) {
+                log::warn!(
+                    "Failed to delete target record for skill {skill_id}, tool {}: {e}",
+                    target.tool
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn sync_scenario_skills(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
+    let desired_targets = collect_scenario_sync_targets(store, scenario_id)?;
+    sync_desired_targets(store, &desired_targets)
+}
+
+pub fn apply_scenario_to_default(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
+    ensure_scenario_exists(store, scenario_id)?;
+    let desired_targets = collect_scenario_sync_targets(store, scenario_id)?;
+
+    if let Ok(Some(old_id)) = store.get_active_scenario_id() {
+        if old_id != scenario_id {
+            unsync_obsolete_scenario_targets(store, &old_id, &desired_targets)?;
+        }
+    }
+
+    store.set_active_scenario(scenario_id).map_err(AppError::db)?;
+    sync_desired_targets(store, &desired_targets)
+}
+
+pub fn sync_skill_to_active_scenario(
+    store: &SkillStore,
+    scenario_id: &str,
+    skill_id: &str,
+) -> Result<(), AppError> {
+    if let Ok(Some(active_id)) = store.get_active_scenario_id() {
+        if active_id == scenario_id {
+            let adapters = enabled_installed_adapters_for_scenario_skill(store, scenario_id, skill_id)?;
+            let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+            let Ok(Some(skill)) = store.get_skill_by_id(skill_id) else {
+                return Ok(());
+            };
+            let source = PathBuf::from(&skill.central_path);
+            let target_name = sync_engine::target_dir_name(&source, &skill.name);
+            let old_targets = store.get_targets_for_skill(skill_id).unwrap_or_default();
+            for adapter in &adapters {
+                if let Some(old) = old_targets.iter().find(|t| t.tool == adapter.key) {
+                    let old_path = PathBuf::from(&old.target_path);
+                    if old_path != adapter.skills_dir().join(&target_name) {
+                        if let Err(e) = sync_engine::remove_target(&old_path) {
+                            log::warn!("Failed to remove stale target {}: {e}", old_path.display());
+                        }
+                        let _ = store.delete_target(skill_id, &adapter.key);
+                    }
+                }
+
+                let target = adapter.skills_dir().join(&target_name);
+                let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
+                match sync_engine::sync_skill(&source, &target, mode) {
+                    Ok(actual_mode) => {
+                        let now = chrono::Utc::now().timestamp_millis();
+                        let target_record = super::skill_store::SkillTargetRecord {
+                            id: uuid::Uuid::new_v4().to_string(),
+                            skill_id: skill_id.to_string(),
+                            tool: adapter.key.clone(),
+                            target_path: target.to_string_lossy().to_string(),
+                            mode: actual_mode.as_str().to_string(),
+                            status: "ok".to_string(),
+                            synced_at: Some(now),
+                            last_error: None,
+                        };
+                        if let Err(e) = store.insert_target(&target_record) {
+                            log::warn!("Failed to insert sync target for skill {skill_id}: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to sync skill {skill_id} to {}: {e}",
+                            target.display()
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn ensure_default_startup_scenario(store: &SkillStore) -> Result<(), AppError> {
+    let mut scenarios = store.get_all_scenarios().map_err(AppError::db)?;
+    if scenarios.is_empty() {
+        let now = chrono::Utc::now().timestamp_millis();
+        let default_scenario = ScenarioRecord {
+            id: uuid::Uuid::new_v4().to_string(),
+            name: "Default".to_string(),
+            description: Some("Default startup scenario".to_string()),
+            icon: None,
+            sort_order: 0,
+            created_at: now,
+            updated_at: now,
+        };
+        store.insert_scenario(&default_scenario).map_err(AppError::db)?;
+        scenarios.push(default_scenario);
+    }
+
+    let current_active = store.get_active_scenario_id().map_err(AppError::db)?;
+    let preferred_default = store.get_setting("default_scenario").ok().flatten();
+
+    let desired_active = preferred_default
+        .filter(|id| scenarios.iter().any(|scenario| scenario.id == *id))
+        .or_else(|| {
+            current_active
+                .clone()
+                .filter(|id| scenarios.iter().any(|scenario| scenario.id == *id))
+        })
+        .unwrap_or_else(|| scenarios[0].id.clone());
+
+    if current_active.as_deref() != Some(desired_active.as_str()) {
+        if let Some(old_active) = current_active.as_deref() {
+            unsync_scenario_skills(store, old_active)?;
+        }
+        store
+            .set_active_scenario(&desired_active)
+            .map_err(AppError::db)?;
+    }
+
+    sync_scenario_skills(store, &desired_active)
+}
+
+pub fn sync_active_scenario_to_tool(store: &SkillStore, tool_key: &str) {
+    if let Ok(Some(active_id)) = store.get_active_scenario_id() {
+        let Ok(skill_ids) = store.get_skill_ids_for_scenario(&active_id) else {
+            return;
+        };
+        for skill_id in skill_ids {
+            if let Ok(adapters) = enabled_installed_adapters_for_scenario_skill(store, &active_id, &skill_id)
+            {
+                if adapters.iter().any(|adapter| adapter.key == tool_key) {
+                    let _ = sync_skill_to_active_scenario(store, &active_id, &skill_id);
+                }
+            }
+        }
+    }
+}
+
+pub fn sync_single_skill_to_tool(
+    store: &SkillStore,
+    skill_id: &str,
+    tool: &str,
+) -> Result<(), AppError> {
+    let adapter = tool_adapters::find_adapter_with_store(store, tool)
+        .ok_or_else(|| AppError::not_found(format!("Unknown tool: {}", tool)))?;
+
+    if !adapter.is_installed() {
+        return Err(AppError::not_found(format!(
+            "{} is not installed",
+            adapter.display_name
+        )));
+    }
+
+    if tool_service::get_disabled_tools(store).contains(&tool.to_string()) {
+        return Err(AppError::invalid_input(format!(
+            "{} is disabled",
+            adapter.display_name
+        )));
+    }
+
+    let skill = store
+        .get_skill_by_id(skill_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Skill not found"))?;
+
+    let source = PathBuf::from(&skill.central_path);
+    let target = adapter
+        .skills_dir()
+        .join(sync_engine::target_dir_name(&source, &skill.name));
+    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+    let mode = sync_engine::sync_mode_for_tool(tool, configured_mode.as_deref());
+    let actual_mode = sync_engine::sync_skill(&source, &target, mode).map_err(AppError::io)?;
+
+    let now = chrono::Utc::now().timestamp_millis();
+    let target_record = SkillTargetRecord {
+        id: uuid::Uuid::new_v4().to_string(),
+        skill_id: skill_id.to_string(),
+        tool: tool.to_string(),
+        target_path: target.to_string_lossy().to_string(),
+        mode: actual_mode.as_str().to_string(),
+        status: "ok".to_string(),
+        synced_at: Some(now),
+        last_error: None,
+    };
+
+    store.insert_target(&target_record).map_err(AppError::db)?;
+    Ok(())
+}

--- a/src-tauri/src/core/tool_service.rs
+++ b/src-tauri/src/core/tool_service.rs
@@ -1,0 +1,227 @@
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+
+use super::{
+    error::AppError,
+    skill_store::SkillStore,
+    tool_adapters::{self, CustomToolDef},
+};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolInfo {
+    pub key: String,
+    pub display_name: String,
+    pub installed: bool,
+    pub skills_dir: String,
+    pub enabled: bool,
+    pub is_custom: bool,
+    pub has_path_override: bool,
+    pub project_relative_skills_dir: Option<String>,
+}
+
+pub fn get_disabled_tools(store: &SkillStore) -> Vec<String> {
+    store
+        .get_setting("disabled_tools")
+        .ok()
+        .flatten()
+        .and_then(|v| serde_json::from_str::<Vec<String>>(&v).ok())
+        .unwrap_or_default()
+}
+
+pub fn disabled_tools_set(store: &SkillStore) -> HashSet<String> {
+    get_disabled_tools(store).into_iter().collect()
+}
+
+pub fn set_disabled_tools(store: &SkillStore, disabled: &[String]) -> Result<(), AppError> {
+    let json = serde_json::to_string(disabled)
+        .map_err(|e| AppError::internal(format!("Failed to serialize: {e}")))?;
+    store
+        .set_setting("disabled_tools", &json)
+        .map_err(AppError::db)
+}
+
+pub fn get_custom_tool_paths(store: &SkillStore) -> HashMap<String, String> {
+    tool_adapters::custom_tool_paths(store)
+}
+
+pub fn set_custom_tool_paths(
+    store: &SkillStore,
+    paths: &HashMap<String, String>,
+) -> Result<(), AppError> {
+    let json = serde_json::to_string(paths)
+        .map_err(|e| AppError::internal(format!("Failed to serialize: {e}")))?;
+    store
+        .set_setting("custom_tool_paths", &json)
+        .map_err(AppError::db)
+}
+
+pub fn get_custom_tools(store: &SkillStore) -> Vec<CustomToolDef> {
+    tool_adapters::custom_tools(store)
+}
+
+pub fn set_custom_tools(store: &SkillStore, custom_tools: &[CustomToolDef]) -> Result<(), AppError> {
+    let json = serde_json::to_string(custom_tools)
+        .map_err(|e| AppError::internal(format!("Failed to serialize: {e}")))?;
+    store
+        .set_setting("custom_tools", &json)
+        .map_err(AppError::db)
+}
+
+pub fn normalize_skills_dir_input(path: &str) -> Result<String, AppError> {
+    let raw = path.trim();
+    if raw.is_empty() {
+        return Err(AppError::invalid_input("Path is required"));
+    }
+
+    let expanded = if raw == "~" {
+        dirs::home_dir()
+            .ok_or_else(|| AppError::internal("Cannot determine home directory"))?
+            .to_string_lossy()
+            .to_string()
+    } else if let Some(rest) = raw.strip_prefix("~/") {
+        dirs::home_dir()
+            .ok_or_else(|| AppError::internal("Cannot determine home directory"))?
+            .join(rest)
+            .to_string_lossy()
+            .to_string()
+    } else if !std::path::Path::new(raw).is_absolute() {
+        return Err(AppError::invalid_input(
+            "Skills path must be absolute (or start with ~/)",
+        ));
+    } else {
+        raw.to_string()
+    };
+
+    Ok(expanded)
+}
+
+pub fn normalize_project_relative_skills_dir_input(path: &str) -> Result<Option<String>, AppError> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let candidate = std::path::Path::new(trimmed);
+    if candidate.is_absolute() {
+        return Err(AppError::invalid_input(
+            "Project skills path must be relative to the project root",
+        ));
+    }
+    if candidate
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(AppError::invalid_input(
+            "Project skills path cannot contain parent directory segments",
+        ));
+    }
+    Ok(Some(trimmed.trim_matches('/').to_string()))
+}
+
+pub fn list_tool_info(store: &SkillStore) -> Vec<ToolInfo> {
+    let disabled = disabled_tools_set(store);
+    tool_adapters::all_tool_adapters(store)
+        .into_iter()
+        .map(|adapter| ToolInfo {
+            key: adapter.key.clone(),
+            display_name: adapter.display_name.clone(),
+            installed: adapter.is_installed(),
+            skills_dir: adapter.skills_dir().to_string_lossy().to_string(),
+            enabled: !disabled.contains(&adapter.key),
+            is_custom: adapter.is_custom,
+            has_path_override: adapter.has_path_override(),
+            project_relative_skills_dir: if adapter.relative_skills_dir.is_empty() {
+                None
+            } else {
+                Some(adapter.relative_skills_dir.clone())
+            },
+        })
+        .collect()
+}
+
+pub fn migrate_legacy_tool_keys(store: &SkillStore) -> Result<(), AppError> {
+    const OLD_KEY: &str = "clawdbot";
+    const NEW_KEY: &str = "openclaw";
+
+    let mut changed = false;
+
+    let mut disabled = get_disabled_tools(store);
+    if disabled.iter().any(|k| k == OLD_KEY) {
+        for key in &mut disabled {
+            if key == OLD_KEY {
+                *key = NEW_KEY.to_string();
+            }
+        }
+        disabled.sort();
+        disabled.dedup();
+        set_disabled_tools(store, &disabled)?;
+        changed = true;
+    }
+
+    let mut custom_paths = get_custom_tool_paths(store);
+    if let Some(old_path) = custom_paths.remove(OLD_KEY) {
+        custom_paths.entry(NEW_KEY.to_string()).or_insert(old_path);
+        set_custom_tool_paths(store, &custom_paths)?;
+        changed = true;
+    }
+
+    let mut normalized_path_changed = false;
+    for value in custom_paths.values_mut() {
+        if let Ok(normalized) = normalize_skills_dir_input(value) {
+            if *value != normalized {
+                *value = normalized;
+                normalized_path_changed = true;
+            }
+        }
+    }
+    if normalized_path_changed {
+        set_custom_tool_paths(store, &custom_paths)?;
+        changed = true;
+    }
+
+    let custom_tools = get_custom_tools(store);
+    let mut custom_tools_changed = false;
+    let custom_tools = if custom_tools.iter().any(|c| c.key == OLD_KEY) {
+        let has_new = custom_tools.iter().any(|c| c.key == NEW_KEY);
+        let mut migrated = Vec::with_capacity(custom_tools.len());
+        let mut seen_keys = std::collections::HashSet::new();
+        for mut custom in custom_tools {
+            if custom.key == OLD_KEY {
+                if has_new {
+                    continue;
+                }
+                custom.key = NEW_KEY.to_string();
+            }
+            if seen_keys.insert(custom.key.clone()) {
+                migrated.push(custom);
+            }
+        }
+        custom_tools_changed = true;
+        changed = true;
+        migrated
+    } else {
+        custom_tools
+    };
+
+    let mut normalized_customs = custom_tools;
+    for custom in &mut normalized_customs {
+        if let Ok(normalized) = normalize_skills_dir_input(&custom.skills_dir) {
+            if custom.skills_dir != normalized {
+                custom.skills_dir = normalized;
+                custom_tools_changed = true;
+            }
+        }
+    }
+    if custom_tools_changed {
+        set_custom_tools(store, &normalized_customs)?;
+    }
+
+    if changed || store.has_tool_key_references(OLD_KEY).map_err(AppError::db)? {
+        store
+            .remap_tool_key_references(OLD_KEY, NEW_KEY)
+            .map_err(AppError::db)?;
+    }
+    if changed {
+        log::info!("Migrated legacy tool key {OLD_KEY} -> {NEW_KEY}");
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,8 +2,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{Emitter, Manager};
 
-mod commands;
-mod core;
+pub mod commands;
+pub mod core;
 
 /// Shared flag: when true, CloseRequested should NOT be prevented.
 pub static QUITTING: AtomicBool = AtomicBool::new(false);
@@ -334,17 +334,8 @@ pub fn quit_app(app: &tauri::AppHandle) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Ensure central repo exists
-    core::central_repo::ensure_central_repo().expect("Failed to create central repo");
-
-    // Initialize database
-    let db_path = core::central_repo::db_path();
-    let store = Arc::new(
-        core::skill_store::SkillStore::new(&db_path).expect("Failed to initialize database"),
-    );
-    commands::tools::migrate_legacy_tool_keys(&store).expect("Failed to migrate legacy tool keys");
+    let store = core::app_state::initialize_store().expect("Failed to initialize app state");
     let store_for_setup = store.clone();
-    initialize_startup_scenario(&store).expect("Failed to initialize startup scenario");
 
     let cancel_registry = Arc::new(core::install_cancel::InstallCancelRegistry::new());
 
@@ -494,48 +485,3 @@ pub fn run() {
         .expect("error while running tauri application");
 }
 
-fn initialize_startup_scenario(store: &Arc<core::skill_store::SkillStore>) -> Result<(), String> {
-    let mut scenarios = store.get_all_scenarios().map_err(|e| e.to_string())?;
-    if scenarios.is_empty() {
-        let now = chrono::Utc::now().timestamp_millis();
-        let default_scenario = core::skill_store::ScenarioRecord {
-            id: uuid::Uuid::new_v4().to_string(),
-            name: "Default".to_string(),
-            description: Some("Default startup scenario".to_string()),
-            icon: None,
-            sort_order: 0,
-            created_at: now,
-            updated_at: now,
-        };
-        store
-            .insert_scenario(&default_scenario)
-            .map_err(|e| e.to_string())?;
-        scenarios.push(default_scenario);
-    }
-
-    let current_active = store.get_active_scenario_id().map_err(|e| e.to_string())?;
-    let preferred_default = store.get_setting("default_scenario").ok().flatten();
-
-    let desired_active = preferred_default
-        .filter(|id| scenarios.iter().any(|scenario| scenario.id == *id))
-        .or_else(|| {
-            current_active
-                .clone()
-                .filter(|id| scenarios.iter().any(|scenario| scenario.id == *id))
-        })
-        .unwrap_or_else(|| scenarios[0].id.clone());
-
-    if current_active.as_deref() != Some(desired_active.as_str()) {
-        if let Some(old_active) = current_active.as_deref() {
-            commands::scenarios::unsync_scenario_skills(store, old_active)
-                .map_err(|e| e.to_string())?;
-        }
-
-        store
-            .set_active_scenario(&desired_active)
-            .map_err(|e| e.to_string())?;
-    }
-
-    commands::scenarios::sync_scenario_skills(store, &desired_active).map_err(|e| e.to_string())?;
-    Ok(())
-}


### PR DESCRIPTION
## Why
This project already manages a central skills repo, scenarios, and per-tool sync targets in the desktop app, but it is still hard for coding agents or scripts to operate on that repo directly.

The concrete gap is automation:
- agents need a non-GUI entry point
- cloned skills repos should be operable without opening the app first
- CLI behavior should stay aligned with the same repo/config/metadata rules the GUI already uses

So this PR starts from the CLI need first: make `skills-manager` usable for agent-driven workflows on a skills repo such as `my-skills`, without duplicating a separate product model.

## What this PR adds
- a new Rust CLI binary for repository-oriented operations
- support for operating against an explicit skills repo via `--skills-root`
- agent-friendly commands for:
  - repo status
  - tool listing
  - skill listing / inspection / export
  - scenario listing / preview / apply
  - git-backed skills repo operations

Examples:
```bash
npm run -s cli -- repo status
npm run -s cli -- skills list
npm run -s cli -- scenarios preview Default
npm run -s cli -- --skills-root /path/to/my-skills --json skills list
```

## Why the implementation looks like a refactor
To keep the new CLI trustworthy, it should not reimplement core repo behavior in a separate stack.

Because of that, this PR extracts shared Rust services so both GUI and CLI use the same implementation for:
- repository bootstrap
- metadata reindex
- tool resolution / tool settings
- scenario sync planning
- scenario apply / active-scenario sync

So the refactor here is in service of the CLI requirement, not the other way around.

## Main changes
### New shared Rust core modules
- `src-tauri/src/core/app_state.rs`
- `src-tauri/src/core/tool_service.rs`
- `src-tauri/src/core/scenario_service.rs`

### New CLI entry point
- `src-tauri/src/bin/skills-manager-cli.rs`
- `scripts/run-rust-cli.mjs` launcher so `npm run cli` also works when Cargo is only reachable via `rustup`

### CLI polish
- `--json` now emits compact machine-readable JSON
- ambiguous skill references now fail explicitly instead of silently picking the first match
- `default-run = "skills-manager"` fixes local `tauri dev` after adding the extra CLI binary

## Verification
Passed locally:
- `npm run build`
- `npm run cli:build`
- `npm run -s cli -- repo status`
- `npm run -s cli -- --json repo status`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- local `npm run tauri:dev` smoke test after setting `default-run`

Additional manual verification:
- cloned `danie1Lin/my-skills`
- verified `--skills-root` with:
  - `repo status`
  - `skills list`
  - `scenarios list`
  - `scenarios preview Default`

Note:
- `cargo clippy --all-targets -- -D warnings` still reports pre-existing repository-wide warnings outside the scope of this PR.
