### PR TITLE
fix(cli): isolate --skills-root state, document install path & GUI caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,28 @@ Available command groups:
 - `git` — operate on the git-backed `skills/` repository (`clone`, `pull`, `push`, `commit`, `versions`, `restore`)
 
 Extra flags:
-- `--skills-root <path>` — operate on a cloned/exported skills repo directly instead of the local app default
+- `--skills-root <path>` — operate on a cloned/exported skills repo directly instead of the local app default. The manager's state (DB, scenarios, cache, logs) lives in `~/.skills-manager/external/<name>-<hash>/`, namespaced by the canonical path of the skills root, so the external checkout itself stays clean.
 - `--json` — machine-readable output for scripts/agents
 
 ```bash
 npm run -s cli -- --skills-root /path/to/my-skills --json skills list
 ```
+
+#### Install the binary on PATH
+
+Agents and scripts that invoke `skills-manager-cli` directly (without `npm run`) need the binary on PATH. Install it with:
+
+```bash
+npm run cli:install
+# equivalent to:
+# cargo install --path src-tauri --bin skills-manager-cli --locked --force
+```
+
+This drops the binary at `~/.cargo/bin/skills-manager-cli`. Re-run after pulling updates to refresh it.
+
+#### Concurrent use with the desktop app
+
+The CLI and desktop app share the same SQLite database. SQLite serializes writes safely, but the running app does not auto-refresh its in-memory caches when the CLI mutates state — restart or trigger a manual refresh in the app after `scenarios apply`, `git pull`, or other CLI write operations.
 
 ### Build
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -144,12 +144,28 @@ npm run cli -- git commit -m "chore: update skills"
 - `git`：操作 git 管理的 `skills/` 仓库（`clone`、`pull`、`push`、`commit`、`versions`、`restore`）
 
 额外参数：
-- `--skills-root <path>`：直接针对某个已 clone / 已导出的 skills repo 操作，而不是本机 app 默认目录
+- `--skills-root <path>`：直接针对某个已 clone / 已导出的 skills repo 操作，而不是本机 app 默认目录。manager 的状态（DB、scenarios、cache、logs）会落在 `~/.skills-manager/external/<name>-<hash>/`，按 skills root 的规范化路径分目录隔离，外部仓库本身保持干净。
 - `--json`：给脚本 / agent 使用的机器可读输出
 
 ```bash
 npm run -s cli -- --skills-root /path/to/my-skills --json skills list
 ```
+
+#### 把 CLI 二进制安装到 PATH
+
+如果 agent / 脚本直接调用 `skills-manager-cli`（而不是 `npm run`），需要先把二进制放到 PATH 上：
+
+```bash
+npm run cli:install
+# 等价于：
+# cargo install --path src-tauri --bin skills-manager-cli --locked --force
+```
+
+二进制会装到 `~/.cargo/bin/skills-manager-cli`。代码更新后再跑一次即可刷新。
+
+#### 与桌面应用并发使用
+
+CLI 和桌面应用共享同一个 SQLite 数据库。SQLite 会串行化写入，所以数据是安全的，但运行中的应用不会自动刷新它的内存缓存 —— 在 CLI 跑完 `scenarios apply`、`git pull` 等会改状态的命令后，重启应用或手动刷新一次。
 
 ### 构建
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "tauri:dev": "tauri dev --config src-tauri/tauri.dev.conf.json",
     "tauri:build": "tauri build",
     "cli": "node scripts/run-rust-cli.mjs cli",
-    "cli:build": "node scripts/run-rust-cli.mjs build"
+    "cli:build": "node scripts/run-rust-cli.mjs build",
+    "cli:install": "node scripts/run-rust-cli.mjs install"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/run-rust-cli.mjs
+++ b/scripts/run-rust-cli.mjs
@@ -41,7 +41,9 @@ const cargoArgs =
     ? ['run', '--quiet', ...baseArgs, '--', ...extraArgs]
     : mode === 'build'
       ? ['build', ...baseArgs]
-      : null;
+      : mode === 'install'
+        ? ['install', '--path', 'src-tauri', '--bin', 'skills-manager-cli', '--locked', '--force']
+        : null;
 
 if (!cargoArgs) {
   console.error(`unknown mode: ${mode}`);

--- a/src-tauri/src/bin/skills-manager-cli.rs
+++ b/src-tauri/src/bin/skills-manager-cli.rs
@@ -151,10 +151,7 @@ fn main() {
 fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
     if let Some(skills_root) = &cli.skills_root {
-        let base = skills_root
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("--skills-root requires a non-root path"))?
-            .to_path_buf();
+        let base = central_repo::external_base_dir(skills_root);
         central_repo::set_runtime_base_dir_override(Some(base));
         central_repo::set_runtime_skills_dir_override(Some(skills_root.clone()));
     }

--- a/src-tauri/src/core/central_repo.rs
+++ b/src-tauri/src/core/central_repo.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -148,6 +149,51 @@ pub fn skills_dir() -> PathBuf {
     base_dir().join("skills")
 }
 
+/// Derive a stable per-skills-root state directory under the user's default base.
+///
+/// CLI's `--skills-root` lets agents operate on an external skills checkout
+/// (e.g. a freshly cloned `my-skills`) without touching the app's default repo.
+/// The manager still needs a home for its DB, scenarios, cache, and logs — but
+/// putting that state inside the external checkout would pollute the user's
+/// repo, and putting it in the parent directory would silently litter wherever
+/// the user happened to clone. Instead, namespace the state under
+/// `<default-base>/external/<sanitized-name>-<short-hash>/`, keyed by the
+/// canonical path of the skills root so repeat invocations reuse the same DB.
+pub fn external_base_dir(skills_root: &Path) -> PathBuf {
+    let canonical = skills_root
+        .canonicalize()
+        .unwrap_or_else(|_| skills_root.to_path_buf());
+    let name = canonical
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("external");
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    let short_hash: String = digest.iter().take(5).map(|b| format!("{:02x}", b)).collect();
+    default_base_dir()
+        .join("external")
+        .join(format!("{}-{}", sanitize_dir_name(name), short_hash))
+}
+
+fn sanitize_dir_name(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if cleaned.is_empty() {
+        "external".to_string()
+    } else {
+        cleaned
+    }
+}
+
 pub fn scenarios_dir() -> PathBuf {
     base_dir().join("scenarios")
 }
@@ -289,4 +335,50 @@ pub fn ensure_central_repo() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn external_base_dir_lives_under_default_base_external() {
+        let dir = external_base_dir(Path::new("/tmp/some/my-skills"));
+        let prefix = default_base_dir().join("external");
+        assert!(
+            dir.starts_with(&prefix),
+            "expected {} to start with {}",
+            dir.display(),
+            prefix.display()
+        );
+    }
+
+    #[test]
+    fn external_base_dir_is_stable_for_same_path() {
+        let a = external_base_dir(Path::new("/tmp/some/my-skills"));
+        let b = external_base_dir(Path::new("/tmp/some/my-skills"));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn external_base_dir_differs_for_different_paths() {
+        let a = external_base_dir(Path::new("/tmp/one/my-skills"));
+        let b = external_base_dir(Path::new("/tmp/two/my-skills"));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn external_base_dir_does_not_pollute_skills_root_or_its_parent() {
+        let skills_root = Path::new("/tmp/external-test/my-skills");
+        let dir = external_base_dir(skills_root);
+        assert!(!dir.starts_with(skills_root));
+        assert!(!dir.starts_with(skills_root.parent().unwrap()));
+    }
+
+    #[test]
+    fn sanitize_dir_name_replaces_unsafe_characters() {
+        assert_eq!(sanitize_dir_name("my skills"), "my-skills");
+        assert_eq!(sanitize_dir_name("a/b\\c:d"), "a-b-c-d");
+        assert_eq!(sanitize_dir_name(""), "external");
+    }
 }


### PR DESCRIPTION
Follow-up to #110. Fixes the three issues flagged in the merge review.

## 1. `--skills-root` no longer pollutes the user's filesystem

**Before:** `--skills-root /path/to/my-skills` set `base_dir = /path/to`, which silently wrote `skills-manager.db`, `scenarios/`, `cache/`, `logs/`, and `repo-config.json` into whatever directory happened to contain the cloned skills repo (e.g. `/tmp/`, `~/clones/`).

**After:** `central_repo::external_base_dir(skills_root)` derives a stable per-skills-root state directory under `~/.skills-manager/external/<name>-<hash>/`. The hash is taken from the canonical path so repeat invocations against the same skills root reuse the same DB; different skills roots get different state dirs and don't collide.

Smoke test:

```
$ skills-manager-cli --skills-root /tmp/my-skills --json repo status
{"base_dir":"/Users/me/.skills-manager/external/my-skills-7fba7d84a0",
 "skills_dir":"/tmp/my-skills",
 "db_path":"/Users/me/.skills-manager/external/my-skills-7fba7d84a0/skills-manager.db",...}
```

`/tmp/` itself stays clean.

## 2. CLI binary install path

Added `npm run cli:install` → `cargo install --path src-tauri --bin skills-manager-cli --locked --force`. Drops the binary at `~/.cargo/bin/skills-manager-cli` so agents and scripts can call it directly without `npm run`.

## 3. GUI/CLI concurrent-use caveat

The GUI and CLI share the same SQLite DB. SQLite serializes writes safely, but the running desktop app does not auto-refresh its in-memory caches when the CLI mutates state. Documented in both READMEs (real fix would need a DB file watcher in the GUI — out of scope for this PR).

## Tests

- 5 new unit tests in `core::central_repo::tests`:
  - `external_base_dir` lives under `~/.skills-manager/external/`
  - stable for the same canonical path
  - differs across different paths
  - never starts with the skills root or its parent (regression test for the original pollution bug)
  - `sanitize_dir_name` replaces unsafe characters
- Full suite: `182 passed; 0 failed`.

## Verification

- `cargo build --bin skills-manager-cli` ✓
- `cargo test` (full suite) ✓
- Smoke test of `--skills-root` in a temp dir, parent dir confirmed unpolluted ✓
- `npm run cli:install` installs binary to `~/.cargo/bin/skills-manager-cli` ✓