### PR TITLE
feat(projects): support binding scenarios to projects for multi-project parallel Skills management

### DIFF
--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use tauri::State;
 
 use crate::core::skill_store::{ProjectRecord, SkillRecord, SkillStore};
-use crate::core::{error::AppError, installer, project_scanner, sync_engine, tool_adapters};
+use crate::core::{error::AppError, installer, project_scanner, scenario_service, sync_engine, tool_adapters};
 use crate::commands::scenarios::{sync_scenario_to_project, unsync_scenario_from_project};
 
 #[derive(Serialize, Default)]
@@ -635,8 +635,38 @@ pub async fn add_linked_workspace(
 #[tauri::command]
 pub async fn remove_project(store: State<'_, Arc<SkillStore>>, id: String) -> Result<(), AppError> {
     let store = store.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || store.delete_project(&id).map_err(AppError::db))
-        .await?
+    tauri::async_runtime::spawn_blocking(move || {
+        // Serialize with bind/unbind/delete-scenario to avoid racing symlink cleanup.
+        let _guard = crate::commands::scenarios::PROJECT_SCENARIO_MUTATION_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        // P0-4: before dropping the project row (which CASCADE-deletes all
+        // project_scenarios subscriptions), clean up the skill symlinks that
+        // Skills Manager itself wrote into the project directory on behalf of
+        // those subscriptions. Without this, removing a subscribed project
+        // would leave orphan symlinks on disk with no DB trace.
+        //
+        // Product contract: project_scenarios symlinks are Skills Manager's
+        // own artifacts and belong to the subscription lifecycle — they are
+        // NOT the user's original files, so cleaning them up does not violate
+        // the "project files will not be deleted" promise shown in the UI.
+        let subscribed_scenario_ids = store.get_project_scenario_ids(&id).unwrap_or_default();
+        for scenario_id in &subscribed_scenario_ids {
+            if let Err(e) = crate::commands::scenarios::unsync_scenario_from_project(
+                &store,
+                &id,
+                scenario_id,
+            ) {
+                log::warn!(
+                    "Failed to clean up scenario {scenario_id} symlinks while removing project {id}: {e}"
+                );
+            }
+        }
+
+        store.delete_project(&id).map_err(AppError::db)
+    })
+    .await?
 }
 
 #[tauri::command]
@@ -1118,6 +1148,21 @@ pub async fn bind_scenario_to_project(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
+        // Serialize lifecycle mutations to project_scenarios across all commands
+        // (bind/unbind/delete-scenario/remove-project). Prevents a race where two
+        // concurrent unbinds each observe the other as "still covering" a skill
+        // and both skip removal of now-orphaned symlinks.
+        let _guard = crate::commands::scenarios::PROJECT_SCENARIO_MUTATION_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        // Validate both project and scenario exist before writing anything.
+        store
+            .get_project_by_id(&project_id)
+            .map_err(AppError::db)?
+            .ok_or_else(|| AppError::not_found("Project not found"))?;
+        scenario_service::ensure_scenario_exists(&store, &scenario_id)?;
+
         store
             .bind_scenario_to_project(&project_id, &scenario_id)
             .map_err(AppError::db)?;
@@ -1139,14 +1184,24 @@ pub async fn unbind_scenario_from_project(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        // First unsync (remove symlinks) for all skills in this scenario
-        unsync_scenario_from_project(&store, &project_id, &scenario_id)
-            .map_err(AppError::db)?;
+        let _guard = crate::commands::scenarios::PROJECT_SCENARIO_MUTATION_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
 
-        // Then remove the binding
+        // Remove the DB binding FIRST so that the subsequent "covered_by_other"
+        // computation inside unsync_scenario_from_project sees the accurate set
+        // of remaining subscriptions. Doing it in this order is safe because
+        // unsync_scenario_from_project takes scenario_id explicitly — it does
+        // not re-derive which scenario to operate on from the DB.
         store
             .unbind_scenario_from_project(&project_id, &scenario_id)
             .map_err(AppError::db)?;
+
+        // Then unsync (remove symlinks) for skills that are no longer covered
+        // by any remaining bound scenario.
+        unsync_scenario_from_project(&store, &project_id, &scenario_id)
+            .map_err(AppError::db)?;
+
         Ok(())
     })
     .await?

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -6,6 +6,7 @@ use tauri::State;
 
 use crate::core::skill_store::{ProjectRecord, SkillRecord, SkillStore};
 use crate::core::{error::AppError, installer, project_scanner, sync_engine, tool_adapters};
+use crate::commands::scenarios::{sync_scenario_to_project, unsync_scenario_from_project};
 
 #[derive(Serialize, Default)]
 pub struct SyncHealthDto {
@@ -1104,6 +1105,48 @@ pub async fn delete_project_skill(
 
         ensure_dir_within_root(&target, &target_root)?;
         remove_workspace_skill_target(&target)?;
+        Ok(())
+    })
+    .await?
+}
+
+#[tauri::command]
+pub async fn bind_scenario_to_project(
+    store: State<'_, Arc<SkillStore>>,
+    project_id: String,
+    scenario_id: String,
+) -> Result<(), AppError> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        store
+            .bind_scenario_to_project(&project_id, &scenario_id)
+            .map_err(AppError::db)?;
+
+        // Sync all skills in this scenario to the project's agent directories
+        sync_scenario_to_project(&store, &project_id, &scenario_id)
+            .map_err(AppError::db)?;
+
+        Ok(())
+    })
+    .await?
+}
+
+#[tauri::command]
+pub async fn unbind_scenario_from_project(
+    store: State<'_, Arc<SkillStore>>,
+    project_id: String,
+    scenario_id: String,
+) -> Result<(), AppError> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        // First unsync (remove symlinks) for all skills in this scenario
+        unsync_scenario_from_project(&store, &project_id, &scenario_id)
+            .map_err(AppError::db)?;
+
+        // Then remove the binding
+        store
+            .unbind_scenario_from_project(&project_id, &scenario_id)
+            .map_err(AppError::db)?;
         Ok(())
     })
     .await?

--- a/src-tauri/src/commands/scenarios.rs
+++ b/src-tauri/src/commands/scenarios.rs
@@ -1,15 +1,22 @@
 use serde::Serialize;
-use std::collections::HashSet;
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use tauri::State;
 
 use crate::core::{
     error::AppError,
     scenario_service,
-    skill_store::{ProjectRecord, ScenarioRecord, SkillStore, SkillTargetRecord},
-    sync_engine, sync_metadata, tool_adapters,
+    skill_store::{ScenarioRecord, SkillStore, SkillTargetRecord},
+    sync_engine, sync_metadata,
 };
+
+/// Serializes lifecycle mutations to the project_scenarios relationship
+/// (bind/unbind/delete-scenario/remove-project). Prevents races where two
+/// concurrent unbinds both observe each other as "still covering" a skill
+/// and neither ends up removing the orphaned symlink.
+///
+/// Held only for the duration of the blocking DB + filesystem work.
+pub(crate) static PROJECT_SCENARIO_MUTATION_LOCK: Mutex<()> = Mutex::new(());
 
 fn refresh_tray_menu_best_effort(app: &tauri::AppHandle) {
     if let Err(err) = crate::refresh_tray_menu(app) {
@@ -28,56 +35,54 @@ pub(crate) fn sync_skill_to_active_scenario(
 }
 
 /// Remove all skill symlinks for a scenario from a project (used when unbinding).
+/// Skips skills that are also covered by another scenario bound to the same project.
 pub(crate) fn unsync_scenario_from_project(
     store: &SkillStore,
     project_id: &str,
     scenario_id: &str,
 ) -> Result<(), AppError> {
-    // Get project record
     let project = store
         .get_project_by_id(project_id)
         .map_err(AppError::db)?
         .ok_or_else(|| AppError::not_found("Project not found"))?;
 
-    // Get all skills in this scenario
-    let skill_ids = store.get_skill_ids_for_scenario(scenario_id).map_err(AppError::db)?;
+    // Collect skills covered by other scenarios bound to this project — don't remove those.
+    let other_scenario_ids = store
+        .get_project_scenario_ids(project_id)
+        .map_err(AppError::db)?;
+    let mut covered_skill_ids: std::collections::HashSet<String> = Default::default();
+    for sid in other_scenario_ids.iter().filter(|sid| sid.as_str() != scenario_id) {
+        let ids = store.get_skill_ids_for_scenario(sid).unwrap_or_default();
+        covered_skill_ids.extend(ids);
+    }
 
-    // Get all enabled/installed adapters
-    let adapters = tool_adapters::enabled_installed_adapters(store);
+    let skill_ids = store
+        .get_skill_ids_for_scenario(scenario_id)
+        .map_err(AppError::db)?;
 
-    for skill_id in skill_ids {
-        let Ok(Some(skill)) = store.get_skill_by_id(&skill_id) else {
+    for skill_id in &skill_ids {
+        if covered_skill_ids.contains(skill_id) {
             continue;
-        };
+        }
 
-        let target_name = sync_engine::target_dir_name(
-            &std::path::PathBuf::from(&skill.central_path),
-            &skill.name,
-        );
-
-        for adapter in &adapters {
-            let target = resolve_project_skill_target(&project, &adapter.key, &target_name);
-
-            // Remove the symlink if it exists
-            if let Err(e) = sync_engine::remove_target(&target) {
-                log::warn!("Failed to remove target {}: {e}", target.display());
+        let targets = store.get_targets_for_skill(skill_id).unwrap_or_default();
+        for target in &targets {
+            let path = PathBuf::from(&target.target_path);
+            // Only remove targets that live inside this project's directory.
+            if scenario_service::path_is_under(&path, Path::new(&project.path)) {
+                if let Err(e) = sync_engine::remove_target(&path) {
+                    log::warn!("Failed to remove target {}: {e}", path.display());
+                }
+                let _ = store.delete_target(skill_id, &target.tool);
             }
-
-            // Delete the target record
-            let _ = store.delete_target(&skill_id, &adapter.key);
         }
     }
 
     Ok(())
 }
 
-/// Sync all skills in a scenario to a specific project's skill directories.
-/// This is called when binding a scenario to a project.
-///
-/// For each skill:
-/// 1. Creates the skill in project's .skills/ directory (shared source)
-/// 2. For each agent that has opened this project (agent dir exists), creates a symlink
-///    pointing to project/.skills/skill-name
+/// Sync all skills in a scenario to a specific project's skill directory.
+/// Called when binding a scenario to a project.
 pub(crate) fn sync_scenario_to_project(
     store: &SkillStore,
     project_id: &str,
@@ -85,17 +90,14 @@ pub(crate) fn sync_scenario_to_project(
 ) -> Result<(), AppError> {
     let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
 
-    // Get project record to resolve project-specific paths
     let project = store
         .get_project_by_id(project_id)
         .map_err(AppError::db)?
         .ok_or_else(|| AppError::not_found("Project not found"))?;
 
-    // Get all skills in this scenario
-    let skill_ids = store.get_skill_ids_for_scenario(scenario_id).map_err(AppError::db)?;
-
-    // Get all enabled/installed adapters
-    let adapters = tool_adapters::enabled_installed_adapters(store);
+    let skill_ids = store
+        .get_skill_ids_for_scenario(scenario_id)
+        .map_err(AppError::db)?;
 
     for skill_id in skill_ids {
         let Ok(Some(skill)) = store.get_skill_by_id(&skill_id) else {
@@ -105,76 +107,43 @@ pub(crate) fn sync_scenario_to_project(
         let source = PathBuf::from(&skill.central_path);
         let target_name = sync_engine::target_dir_name(&source, &skill.name);
 
+        let adapters = scenario_service::enabled_installed_adapters_for_scenario_skill(
+            store,
+            scenario_id,
+            &skill_id,
+        )?;
+
         for adapter in &adapters {
-            // If scenario_skill_tools has no records for this skill (empty Vec),
-            // default to enabled for all installed agents
-            // If records exist, only enable if our adapter is in the list
-            let enabled_tools = store
-                .get_enabled_tools_for_scenario_skill(scenario_id, &skill_id)
-                .map_err(AppError::db)?;
-
-            let is_enabled = enabled_tools.is_empty() || enabled_tools.contains(&adapter.key);
-
-            if !is_enabled {
-                continue;
-            }
-
-            // Step 1: Create skill in project's shared .skills/ directory
-            let shared_target = resolve_project_skill_target(&project, &adapter.key, &target_name);
+            let Some(target) = scenario_service::resolve_project_skill_target(
+                &project,
+                adapter,
+                &target_name,
+            ) else {
+                continue; // tool not used in this project, skip
+            };
             let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
 
-            match sync_engine::sync_skill(&source, &shared_target, mode) {
+            match sync_engine::sync_skill(&source, &target, mode) {
                 Ok(actual_mode) => {
                     let now = chrono::Utc::now().timestamp_millis();
-                    let target_record = SkillTargetRecord {
+                    let record = SkillTargetRecord {
                         id: uuid::Uuid::new_v4().to_string(),
                         skill_id: skill_id.clone(),
                         tool: adapter.key.clone(),
-                        target_path: shared_target.to_string_lossy().to_string(),
+                        target_path: target.to_string_lossy().to_string(),
                         mode: actual_mode.as_str().to_string(),
                         status: "ok".to_string(),
                         synced_at: Some(now),
                         last_error: None,
                     };
-                    if let Err(e) = store.insert_target(&target_record) {
+                    if let Err(e) = store.insert_target(&record) {
                         log::warn!("Failed to insert sync target for skill {skill_id}: {e}");
                     }
                 }
                 Err(e) => {
                     log::warn!(
-                        "Failed to sync skill {skill_id} to shared {}: {e}",
-                        shared_target.display()
+                        "Failed to sync skill {skill_id} to project {project_id}: {e}"
                     );
-                }
-            }
-
-            // Step 2: Create symlink in agent's project directory if it exists
-            let agent_symlink_path = resolve_agent_skill_symlink(&project, &adapter.key, &target_name);
-
-            // Only create symlink if the agent's skills directory exists in this project
-            if let Some(parent) = agent_symlink_path.parent() {
-                if parent.is_dir() {
-                    // The symlink should point to the shared skill
-                    // Use relative path from agent dir to shared dir
-                    let relative_to_shared = PathBuf::from("..")
-                        .join(".skills")
-                        .join(&target_name);
-
-                    match sync_engine::sync_skill(&shared_target, &agent_symlink_path, mode) {
-                        Ok(_) => {
-                            log::info!(
-                                "Created symlink {} -> {}",
-                                agent_symlink_path.display(),
-                                relative_to_shared.display()
-                            );
-                        }
-                        Err(e) => {
-                            log::warn!(
-                                "Failed to create symlink {}: {e}",
-                                agent_symlink_path.display()
-                            );
-                        }
-                    }
                 }
             }
         }
@@ -182,71 +151,6 @@ pub(crate) fn sync_scenario_to_project(
 
     Ok(())
 }
-
-/// Resolve the target path for a skill within a project.
-/// Returns the path in the project's shared .skills/ directory.
-fn resolve_project_skill_target(project: &ProjectRecord, _agent_key: &str, skill_name: &str) -> PathBuf {
-    if project.workspace_type == "linked" {
-        // For linked workspaces, the skills are directly in the project path
-        return PathBuf::from(&project.path).join(skill_name);
-    }
-
-    // Use a shared .skills/ directory for all agents in the project
-    PathBuf::from(&project.path)
-        .join(".skills")
-        .join(skill_name)
-}
-
-/// Resolve the agent-specific symlink path within a project.
-/// This is where the agent's own skills directory expects the symlink.
-fn resolve_agent_skill_symlink(project: &ProjectRecord, agent_key: &str, skill_name: &str) -> PathBuf {
-    // Use the tool adapter's relative_skills_dir to find the agent's skills dir in project
-    let adapter = tool_adapters::find_adapter(agent_key);
-    let relative_dir = adapter
-        .map(|a| a.relative_skills_dir.clone())
-        .unwrap_or_else(|| agent_key.replace('_', "-").to_lowercase());
-
-    PathBuf::from(&project.path)
-        .join(&relative_dir)
-        .join(skill_name)
-}
-
-fn ensure_scenario_exists(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
-    let exists = store
-        .get_all_scenarios()
-        .map_err(AppError::db)?
-        .iter()
-        .any(|s| s.id == scenario_id);
-    if !exists {
-        return Err(AppError::not_found("Scenario not found"));
-    }
-    Ok(())
-}
-
-pub(crate) fn enabled_installed_adapters_for_scenario_skill(
-    store: &SkillStore,
-    scenario_id: &str,
-    skill_id: &str,
-) -> Result<Vec<tool_adapters::ToolAdapter>, AppError> {
-    let adapters = tool_adapters::enabled_installed_adapters(store);
-    let adapter_keys: Vec<String> = adapters.iter().map(|a| a.key.clone()).collect();
-
-    store
-        .ensure_scenario_skill_tool_defaults(scenario_id, skill_id, &adapter_keys)
-        .map_err(AppError::db)?;
-
-    let enabled = store
-        .get_enabled_tools_for_scenario_skill(scenario_id, skill_id)
-        .map_err(AppError::db)?;
-    let enabled_set: HashSet<String> = enabled.into_iter().collect();
-
-    Ok(adapters
-        .into_iter()
-        .filter(|adapter| enabled_set.contains(&adapter.key))
-        .collect())
-}
-
-
 #[derive(Debug, Serialize)]
 pub struct ScenarioDto {
     pub id: String,
@@ -426,6 +330,10 @@ pub async fn delete_scenario(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
+        // Serialize project-scenario lifecycle mutations to avoid races with
+        // bind/unbind/delete across scenarios touching the same project.
+        let _guard = PROJECT_SCENARIO_MUTATION_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
         let was_active = store
             .get_active_scenario_id()
             .map_err(AppError::db)?
@@ -434,6 +342,23 @@ pub async fn delete_scenario(
 
         if was_active {
             unsync_scenario_skills(&store, &id)?;
+        }
+
+        // P0-3: clean up skill symlinks in every project that subscribed to this scenario
+        // BEFORE the DB row (and its CASCADE) wipes the project_scenarios relationship.
+        // Without this, deleting a subscribed scenario leaves orphan symlinks in project dirs
+        // with no DB trace.
+        let subscribed_project_ids = store
+            .get_scenario_project_ids(&id)
+            .map_err(AppError::db)?;
+        for project_id in &subscribed_project_ids {
+            if let Err(e) = unsync_scenario_from_project(&store, project_id, &id) {
+                // Log and continue — best-effort cleanup; the DB CASCADE will still drop the
+                // subscription row, so leftover files are acceptable over aborting the delete.
+                log::warn!(
+                    "Failed to clean up scenario {id} symlinks in project {project_id}: {e}"
+                );
+            }
         }
 
         sync_metadata::with_repo_lock("delete scenario", || {
@@ -519,6 +444,10 @@ pub async fn add_skill_to_scenario(
 
         sync_skill_to_active_scenario(&store, &scenario_id, &skill_id)?;
 
+        // Broadcast to all projects that have subscribed to this scenario.
+        scenario_service::sync_skill_to_bound_projects(&store, &scenario_id, &skill_id)
+            .unwrap_or_else(|e| log::warn!("Failed to broadcast skill add to bound projects: {e}"));
+
         Ok(())
     })
     .await?;
@@ -543,12 +472,28 @@ pub async fn remove_skill_from_scenario(
         })
         .map_err(AppError::db)?;
 
-        // If this is the active scenario, unsync the skill
+        // If this is the active scenario, unsync the skill from global (non-project) targets only.
+        // Project-level targets are handled separately by unsync_skill_from_bound_projects below.
         if let Ok(Some(active_id)) = store.get_active_scenario_id() {
             if active_id == scenario_id {
+                // Collect all known project paths so we can exclude project-level targets.
+                let project_paths: Vec<std::path::PathBuf> = store
+                    .get_all_projects()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|p| std::path::PathBuf::from(p.path))
+                    .collect();
+
                 let targets = store.get_targets_for_skill(&skill_id).unwrap_or_default();
                 for target in &targets {
                     let path = PathBuf::from(&target.target_path);
+                    // Only remove global targets — skip anything living inside a project dir.
+                    let is_project_target = project_paths.iter().any(|proj| {
+                        scenario_service::path_is_under(&path, proj)
+                    });
+                    if is_project_target {
+                        continue;
+                    }
                     if let Err(e) = sync_engine::remove_target(&path) {
                         log::warn!("Failed to remove sync target {}: {e}", path.display());
                     }
@@ -561,6 +506,10 @@ pub async fn remove_skill_from_scenario(
                 }
             }
         }
+
+        // Broadcast removal to all projects that have subscribed to this scenario.
+        scenario_service::unsync_skill_from_bound_projects(&store, &scenario_id, &skill_id)
+            .unwrap_or_else(|e| log::warn!("Failed to broadcast skill remove to bound projects: {e}"));
 
         Ok(())
     })
@@ -833,5 +782,480 @@ mod tests {
         assert!(targets.iter().any(|target| {
             target.skill_id == "second" && target.target_path.ends_with("skill123-2")
         }));
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Regression tests for the project-scenario subscription lifecycle.
+    // Added 2026-05-08 to lock down P0 bugs fixed in this PR.
+    // ──────────────────────────────────────────────────────────────────
+
+    use crate::core::skill_store::ProjectRecord;
+    use crate::core::scenario_service;
+
+    /// Build a non-linked project at `project_path`, creating the `.claude/`
+    /// detect dir so resolve_project_skill_target returns a real target path.
+    fn insert_project_with_claude(
+        store: &SkillStore,
+        id: &str,
+        project_path: &std::path::Path,
+    ) -> ProjectRecord {
+        fs::create_dir_all(project_path.join(".claude")).unwrap();
+        let record = ProjectRecord {
+            id: id.to_string(),
+            name: id.to_string(),
+            path: project_path.to_string_lossy().to_string(),
+            workspace_type: "project".to_string(),
+            linked_agent_key: None,
+            linked_agent_name: None,
+            disabled_path: None,
+            sort_order: 0,
+            created_at: 1,
+            updated_at: 1,
+        };
+        store.insert_project(&record).unwrap();
+        record
+    }
+
+    /// P0-1 regression: removing a skill from the active scenario must NOT
+    /// delete symlinks that live inside subscribed project directories. Those
+    /// are owned by the subscription and get cleaned up via the bound-projects
+    /// broadcast, not the active-scenario global sweep.
+    #[cfg(unix)]
+    #[test]
+    fn remove_skill_from_active_scenario_does_not_delete_project_symlinks() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let project_path = tmp.path().join("proj");
+        fs::create_dir_all(&source_base).unwrap();
+
+        // Use the custom-tool escape hatch to keep the test hermetic — point
+        // the global skills_dir at an isolated temp location so built-in
+        // adapters don't probe the real $HOME.
+        let global_target = tmp.path().join("global-agent");
+        fs::create_dir_all(&global_target).unwrap();
+        configure_single_custom_tool(&store, &global_target);
+
+        store
+            .insert_scenario(&sample_scenario("s1", "S1"))
+            .unwrap();
+        let skill_dir = write_skill_dir(&source_base, "my-skill");
+        store
+            .insert_skill(&sample_skill("sk", "my-skill", &skill_dir))
+            .unwrap();
+        store.add_skill_to_scenario("s1", "sk").unwrap();
+        store.set_active_scenario("s1").unwrap();
+
+        // Project has a project-level target directly inserted to mimic
+        // what bind_scenario_to_project would have written.
+        insert_project_with_claude(&store, "p1", &project_path);
+        let project_skill_target = project_path.join(".claude/skills/my-skill");
+        fs::create_dir_all(project_skill_target.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&skill_dir, &project_skill_target).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t-project".to_string(),
+                skill_id: "sk".to_string(),
+                tool: "claude_code".to_string(),
+                target_path: project_skill_target.to_string_lossy().to_string(),
+                mode: "symlink".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+            })
+            .unwrap();
+
+        // Also put a non-project global target to make sure global IS cleaned.
+        let global_skill_target = global_target.join("my-skill");
+        std::os::unix::fs::symlink(&skill_dir, &global_skill_target).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t-global".to_string(),
+                skill_id: "sk".to_string(),
+                tool: "test_agent".to_string(),
+                target_path: global_skill_target.to_string_lossy().to_string(),
+                mode: "symlink".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+            })
+            .unwrap();
+
+        // Subscribe project p1 to scenario s1 so the project target is known
+        // to the subscription system.
+        store.bind_scenario_to_project("p1", "s1").unwrap();
+
+        // Exercise the active-scenario global-sweep branch from
+        // remove_skill_from_scenario: collect project paths, exclude any target
+        // that is under any project path, delete the rest.
+        let project_paths: Vec<std::path::PathBuf> = store
+            .get_all_projects()
+            .unwrap()
+            .into_iter()
+            .map(|p| std::path::PathBuf::from(p.path))
+            .collect();
+        let targets = store.get_targets_for_skill("sk").unwrap();
+        for t in &targets {
+            let path = PathBuf::from(&t.target_path);
+            let is_project_target = project_paths
+                .iter()
+                .any(|proj| scenario_service::path_is_under(&path, proj));
+            if is_project_target {
+                continue;
+            }
+            sync_engine::remove_target(&path).unwrap();
+            store.delete_target("sk", &t.tool).unwrap();
+        }
+
+        // Assertions: project target must survive, global target must be gone.
+        assert!(
+            project_skill_target.is_symlink(),
+            "project symlink must be preserved"
+        );
+        assert!(!global_skill_target.exists(), "global symlink must be cleaned");
+    }
+
+    /// P0-2 regression: cleanup must use path-component comparison, not byte
+    /// prefix. A project named `/tmp/proj-legacy` must NOT be affected when
+    /// we clean up artifacts for `/tmp/proj`.
+    #[cfg(unix)]
+    #[test]
+    fn unbind_scenario_does_not_affect_sibling_project_with_same_prefix() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        fs::create_dir_all(&source_base).unwrap();
+
+        let target_base = tmp.path().join("agent-skills");
+        fs::create_dir_all(&target_base).unwrap();
+        configure_single_custom_tool(&store, &target_base);
+
+        // Two project directories whose names share a common prefix.
+        let proj = tmp.path().join("proj");
+        let proj_legacy = tmp.path().join("proj-legacy");
+        fs::create_dir_all(proj.join(".claude")).unwrap();
+        fs::create_dir_all(proj_legacy.join(".claude")).unwrap();
+
+        store
+            .insert_project(&ProjectRecord {
+                id: "proj".to_string(),
+                name: "proj".to_string(),
+                path: proj.to_string_lossy().to_string(),
+                workspace_type: "project".to_string(),
+                linked_agent_key: None,
+                linked_agent_name: None,
+                disabled_path: None,
+                sort_order: 0,
+                created_at: 1,
+                updated_at: 1,
+            })
+            .unwrap();
+
+        // Pretend a skill target lives inside proj-legacy. The cleanup routine
+        // for `proj` must NOT treat it as being under `proj`.
+        let legacy_target = proj_legacy.join(".claude").join("skills").join("foo");
+        let under = scenario_service::path_is_under(&legacy_target, &proj);
+        assert!(
+            !under,
+            "path_is_under must not match sibling project with shared name prefix"
+        );
+
+        // Conversely, a real descendant of `proj` must match.
+        let own_target = proj.join(".claude").join("skills").join("foo");
+        assert!(
+            scenario_service::path_is_under(&own_target, &proj),
+            "path_is_under must match genuine descendants"
+        );
+    }
+
+    /// P0-3 regression: deleting a scenario must remove the symlinks that
+    /// subscribed projects hold for that scenario's skills, even though the
+    /// scenario row (and its project_scenarios rows via CASCADE) is about to
+    /// disappear.
+    #[cfg(unix)]
+    #[test]
+    fn delete_scenario_cleans_up_subscribed_project_symlinks() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let project_path = tmp.path().join("proj");
+        fs::create_dir_all(&source_base).unwrap();
+
+        // No global adapters — we only care about project-side cleanup here.
+        let target_base = tmp.path().join("agent-skills-unused");
+        fs::create_dir_all(&target_base).unwrap();
+        configure_single_custom_tool(&store, &target_base);
+
+        store
+            .insert_scenario(&sample_scenario("s1", "S1"))
+            .unwrap();
+        let skill_dir = write_skill_dir(&source_base, "my-skill");
+        store
+            .insert_skill(&sample_skill("sk", "my-skill", &skill_dir))
+            .unwrap();
+        store.add_skill_to_scenario("s1", "sk").unwrap();
+
+        insert_project_with_claude(&store, "p1", &project_path);
+        let project_skill_target = project_path.join(".claude/skills/my-skill");
+        fs::create_dir_all(project_skill_target.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&skill_dir, &project_skill_target).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t1".to_string(),
+                skill_id: "sk".to_string(),
+                tool: "claude_code".to_string(),
+                target_path: project_skill_target.to_string_lossy().to_string(),
+                mode: "symlink".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+            })
+            .unwrap();
+        store.bind_scenario_to_project("p1", "s1").unwrap();
+
+        assert!(project_skill_target.is_symlink(), "precondition: symlink should exist");
+
+        // Simulate the P0-3 fix: iterate subscribed projects and unsync before
+        // deleting the scenario.
+        let subscribed = store.get_scenario_project_ids("s1").unwrap();
+        for project_id in &subscribed {
+            unsync_scenario_from_project(&store, project_id, "s1").unwrap();
+        }
+        store.delete_scenario("s1").unwrap();
+
+        assert!(
+            !project_skill_target.exists(),
+            "subscribed-project symlink must be removed when its source scenario is deleted"
+        );
+        assert!(
+            skill_dir.exists(),
+            "central skill dir must be untouched — we only removed the symlink"
+        );
+    }
+
+    /// P0-4 regression: removing a project must clean up the skill symlinks
+    /// that its subscriptions put into the project directory. Central-repo
+    /// files must remain untouched.
+    #[cfg(unix)]
+    #[test]
+    fn remove_project_cleans_up_subscription_symlinks() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let project_path = tmp.path().join("proj");
+        fs::create_dir_all(&source_base).unwrap();
+
+        let target_base = tmp.path().join("agent-skills-unused");
+        fs::create_dir_all(&target_base).unwrap();
+        configure_single_custom_tool(&store, &target_base);
+
+        store
+            .insert_scenario(&sample_scenario("s1", "S1"))
+            .unwrap();
+        let skill_dir = write_skill_dir(&source_base, "my-skill");
+        store
+            .insert_skill(&sample_skill("sk", "my-skill", &skill_dir))
+            .unwrap();
+        store.add_skill_to_scenario("s1", "sk").unwrap();
+
+        insert_project_with_claude(&store, "p1", &project_path);
+        let project_skill_target = project_path.join(".claude/skills/my-skill");
+        fs::create_dir_all(project_skill_target.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&skill_dir, &project_skill_target).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t1".to_string(),
+                skill_id: "sk".to_string(),
+                tool: "claude_code".to_string(),
+                target_path: project_skill_target.to_string_lossy().to_string(),
+                mode: "symlink".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+            })
+            .unwrap();
+        store.bind_scenario_to_project("p1", "s1").unwrap();
+
+        assert!(project_skill_target.is_symlink(), "precondition: symlink should exist");
+
+        // Simulate the P0-4 fix: iterate subscribed scenarios and unsync
+        // before dropping the project row.
+        let subscribed = store.get_project_scenario_ids("p1").unwrap();
+        for scenario_id in &subscribed {
+            unsync_scenario_from_project(&store, "p1", scenario_id).unwrap();
+        }
+        store.delete_project("p1").unwrap();
+
+        assert!(
+            !project_skill_target.exists(),
+            "subscription-owned symlink must be removed when project is removed"
+        );
+        assert!(
+            skill_dir.exists(),
+            "central skill source must remain — removing a project only affects its own dir"
+        );
+    }
+
+    /// P0-5 regression: app startup runs `unsync_scenario_skills` on the
+    /// previously-active scenario when switching to the configured default.
+    /// That sweep must NOT touch symlinks in subscribed project directories,
+    /// otherwise users see "bound" scenes in the UI but missing skill files
+    /// on disk after every restart.
+    ///
+    /// Reproduction without the fix:
+    ///   1. Bind project P to scenario S
+    ///   2. App writes ~/work/proj/.claude/skills/foo
+    ///   3. Restart app — startup picks default scenario, calls
+    ///      `unsync_scenario_skills(S)` which deletes ALL targets of S's skills
+    ///   4. ~/work/proj/.claude/skills/foo is gone, DB still says P is bound to S
+    #[cfg(unix)]
+    #[test]
+    fn unsync_scenario_skills_preserves_subscribed_project_symlinks() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let project_path = tmp.path().join("proj");
+        fs::create_dir_all(&source_base).unwrap();
+
+        let global_target = tmp.path().join("global-agent");
+        fs::create_dir_all(&global_target).unwrap();
+        configure_single_custom_tool(&store, &global_target);
+
+        store
+            .insert_scenario(&sample_scenario("dev", "Dev"))
+            .unwrap();
+        let skill_dir = write_skill_dir(&source_base, "agent-manage-build");
+        store
+            .insert_skill(&sample_skill("sk", "agent-manage-build", &skill_dir))
+            .unwrap();
+        store.add_skill_to_scenario("dev", "sk").unwrap();
+
+        // Project subscribes to the dev scenario.
+        insert_project_with_claude(&store, "p1", &project_path);
+        let project_skill_target = project_path.join(".claude/skills/agent-manage-build");
+        fs::create_dir_all(project_skill_target.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&skill_dir, &project_skill_target).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t-project".to_string(),
+                skill_id: "sk".to_string(),
+                tool: "claude_code".to_string(),
+                target_path: project_skill_target.to_string_lossy().to_string(),
+                mode: "symlink".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+            })
+            .unwrap();
+        store.bind_scenario_to_project("p1", "dev").unwrap();
+
+        // Also a global target so we verify global IS still cleaned.
+        let global_skill_target = global_target.join("agent-manage-build");
+        std::os::unix::fs::symlink(&skill_dir, &global_skill_target).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t-global".to_string(),
+                skill_id: "sk".to_string(),
+                tool: "test_agent".to_string(),
+                target_path: global_skill_target.to_string_lossy().to_string(),
+                mode: "symlink".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+            })
+            .unwrap();
+
+        // Simulate the startup path: switch active scenario away from "dev",
+        // which calls unsync_scenario_skills("dev").
+        scenario_service::unsync_scenario_skills(&store, "dev").unwrap();
+
+        // The subscribed project symlink MUST survive — its lifecycle is owned
+        // by the subscription, not by the active-scenario sweep.
+        assert!(
+            project_skill_target.is_symlink(),
+            "subscribed project symlink must survive startup unsync sweep"
+        );
+        // The DB target row for the project must also survive.
+        let remaining: Vec<_> = store
+            .get_targets_for_skill("sk")
+            .unwrap()
+            .into_iter()
+            .filter(|t| t.target_path.contains("proj/.claude"))
+            .collect();
+        assert_eq!(
+            remaining.len(),
+            1,
+            "project-level skill_targets row must be preserved"
+        );
+
+        // The global target SHOULD be cleaned — that's the whole point of
+        // unsync_scenario_skills.
+        assert!(
+            !global_skill_target.exists(),
+            "global symlink must still be cleaned by unsync_scenario_skills"
+        );
+    }
+
+    /// P0-5 regression for the "Apply to Default" path: switching the active
+    /// scenario via apply_scenario_to_default → unsync_obsolete_scenario_targets
+    /// must also leave subscribed project symlinks alone.
+    #[cfg(unix)]
+    #[test]
+    fn unsync_obsolete_scenario_targets_preserves_subscribed_project_symlinks() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let project_path = tmp.path().join("proj");
+        fs::create_dir_all(&source_base).unwrap();
+
+        let global_target = tmp.path().join("global-agent");
+        fs::create_dir_all(&global_target).unwrap();
+        configure_single_custom_tool(&store, &global_target);
+
+        // Two scenarios — switch from "dev" to "release".
+        store
+            .insert_scenario(&sample_scenario("dev", "Dev"))
+            .unwrap();
+        store
+            .insert_scenario(&sample_scenario("release", "Release"))
+            .unwrap();
+
+        let skill_dir = write_skill_dir(&source_base, "swagger-sync");
+        store
+            .insert_skill(&sample_skill("sk", "swagger-sync", &skill_dir))
+            .unwrap();
+        store.add_skill_to_scenario("dev", "sk").unwrap();
+
+        insert_project_with_claude(&store, "p1", &project_path);
+        let project_skill_target = project_path.join(".claude/skills/swagger-sync");
+        fs::create_dir_all(project_skill_target.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&skill_dir, &project_skill_target).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t-project".to_string(),
+                skill_id: "sk".to_string(),
+                tool: "claude_code".to_string(),
+                target_path: project_skill_target.to_string_lossy().to_string(),
+                mode: "symlink".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+            })
+            .unwrap();
+        store.bind_scenario_to_project("p1", "dev").unwrap();
+        store.set_active_scenario("dev").unwrap();
+
+        // "release" doesn't contain "sk", so its desired_targets is empty.
+        // Without the fix, unsync_obsolete_scenario_targets would wipe ALL of
+        // dev's targets, including the subscribed project's symlink.
+        let desired_targets =
+            collect_scenario_sync_targets(&store, "release").unwrap();
+        scenario_service::unsync_obsolete_scenario_targets(&store, "dev", &desired_targets)
+            .unwrap();
+
+        assert!(
+            project_skill_target.is_symlink(),
+            "subscribed project symlink must survive 'Apply to Default' switch"
+        );
     }
 }

--- a/src-tauri/src/commands/scenarios.rs
+++ b/src-tauri/src/commands/scenarios.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tauri::State;
@@ -6,8 +7,8 @@ use tauri::State;
 use crate::core::{
     error::AppError,
     scenario_service,
-    skill_store::{ScenarioRecord, SkillStore},
-    sync_engine, sync_metadata,
+    skill_store::{ProjectRecord, ScenarioRecord, SkillStore, SkillTargetRecord},
+    sync_engine, sync_metadata, tool_adapters,
 };
 
 fn refresh_tray_menu_best_effort(app: &tauri::AppHandle) {
@@ -25,6 +26,226 @@ pub(crate) fn sync_skill_to_active_scenario(
 ) -> Result<(), AppError> {
     scenario_service::sync_skill_to_active_scenario(store, scenario_id, skill_id)
 }
+
+/// Remove all skill symlinks for a scenario from a project (used when unbinding).
+pub(crate) fn unsync_scenario_from_project(
+    store: &SkillStore,
+    project_id: &str,
+    scenario_id: &str,
+) -> Result<(), AppError> {
+    // Get project record
+    let project = store
+        .get_project_by_id(project_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Project not found"))?;
+
+    // Get all skills in this scenario
+    let skill_ids = store.get_skill_ids_for_scenario(scenario_id).map_err(AppError::db)?;
+
+    // Get all enabled/installed adapters
+    let adapters = tool_adapters::enabled_installed_adapters(store);
+
+    for skill_id in skill_ids {
+        let Ok(Some(skill)) = store.get_skill_by_id(&skill_id) else {
+            continue;
+        };
+
+        let target_name = sync_engine::target_dir_name(
+            &std::path::PathBuf::from(&skill.central_path),
+            &skill.name,
+        );
+
+        for adapter in &adapters {
+            let target = resolve_project_skill_target(&project, &adapter.key, &target_name);
+
+            // Remove the symlink if it exists
+            if let Err(e) = sync_engine::remove_target(&target) {
+                log::warn!("Failed to remove target {}: {e}", target.display());
+            }
+
+            // Delete the target record
+            let _ = store.delete_target(&skill_id, &adapter.key);
+        }
+    }
+
+    Ok(())
+}
+
+/// Sync all skills in a scenario to a specific project's skill directories.
+/// This is called when binding a scenario to a project.
+///
+/// For each skill:
+/// 1. Creates the skill in project's .skills/ directory (shared source)
+/// 2. For each agent that has opened this project (agent dir exists), creates a symlink
+///    pointing to project/.skills/skill-name
+pub(crate) fn sync_scenario_to_project(
+    store: &SkillStore,
+    project_id: &str,
+    scenario_id: &str,
+) -> Result<(), AppError> {
+    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+
+    // Get project record to resolve project-specific paths
+    let project = store
+        .get_project_by_id(project_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Project not found"))?;
+
+    // Get all skills in this scenario
+    let skill_ids = store.get_skill_ids_for_scenario(scenario_id).map_err(AppError::db)?;
+
+    // Get all enabled/installed adapters
+    let adapters = tool_adapters::enabled_installed_adapters(store);
+
+    for skill_id in skill_ids {
+        let Ok(Some(skill)) = store.get_skill_by_id(&skill_id) else {
+            continue;
+        };
+
+        let source = PathBuf::from(&skill.central_path);
+        let target_name = sync_engine::target_dir_name(&source, &skill.name);
+
+        for adapter in &adapters {
+            // If scenario_skill_tools has no records for this skill (empty Vec),
+            // default to enabled for all installed agents
+            // If records exist, only enable if our adapter is in the list
+            let enabled_tools = store
+                .get_enabled_tools_for_scenario_skill(scenario_id, &skill_id)
+                .map_err(AppError::db)?;
+
+            let is_enabled = enabled_tools.is_empty() || enabled_tools.contains(&adapter.key);
+
+            if !is_enabled {
+                continue;
+            }
+
+            // Step 1: Create skill in project's shared .skills/ directory
+            let shared_target = resolve_project_skill_target(&project, &adapter.key, &target_name);
+            let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
+
+            match sync_engine::sync_skill(&source, &shared_target, mode) {
+                Ok(actual_mode) => {
+                    let now = chrono::Utc::now().timestamp_millis();
+                    let target_record = SkillTargetRecord {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        skill_id: skill_id.clone(),
+                        tool: adapter.key.clone(),
+                        target_path: shared_target.to_string_lossy().to_string(),
+                        mode: actual_mode.as_str().to_string(),
+                        status: "ok".to_string(),
+                        synced_at: Some(now),
+                        last_error: None,
+                    };
+                    if let Err(e) = store.insert_target(&target_record) {
+                        log::warn!("Failed to insert sync target for skill {skill_id}: {e}");
+                    }
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Failed to sync skill {skill_id} to shared {}: {e}",
+                        shared_target.display()
+                    );
+                }
+            }
+
+            // Step 2: Create symlink in agent's project directory if it exists
+            let agent_symlink_path = resolve_agent_skill_symlink(&project, &adapter.key, &target_name);
+
+            // Only create symlink if the agent's skills directory exists in this project
+            if let Some(parent) = agent_symlink_path.parent() {
+                if parent.is_dir() {
+                    // The symlink should point to the shared skill
+                    // Use relative path from agent dir to shared dir
+                    let relative_to_shared = PathBuf::from("..")
+                        .join(".skills")
+                        .join(&target_name);
+
+                    match sync_engine::sync_skill(&shared_target, &agent_symlink_path, mode) {
+                        Ok(_) => {
+                            log::info!(
+                                "Created symlink {} -> {}",
+                                agent_symlink_path.display(),
+                                relative_to_shared.display()
+                            );
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "Failed to create symlink {}: {e}",
+                                agent_symlink_path.display()
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolve the target path for a skill within a project.
+/// Returns the path in the project's shared .skills/ directory.
+fn resolve_project_skill_target(project: &ProjectRecord, _agent_key: &str, skill_name: &str) -> PathBuf {
+    if project.workspace_type == "linked" {
+        // For linked workspaces, the skills are directly in the project path
+        return PathBuf::from(&project.path).join(skill_name);
+    }
+
+    // Use a shared .skills/ directory for all agents in the project
+    PathBuf::from(&project.path)
+        .join(".skills")
+        .join(skill_name)
+}
+
+/// Resolve the agent-specific symlink path within a project.
+/// This is where the agent's own skills directory expects the symlink.
+fn resolve_agent_skill_symlink(project: &ProjectRecord, agent_key: &str, skill_name: &str) -> PathBuf {
+    // Use the tool adapter's relative_skills_dir to find the agent's skills dir in project
+    let adapter = tool_adapters::find_adapter(agent_key);
+    let relative_dir = adapter
+        .map(|a| a.relative_skills_dir.clone())
+        .unwrap_or_else(|| agent_key.replace('_', "-").to_lowercase());
+
+    PathBuf::from(&project.path)
+        .join(&relative_dir)
+        .join(skill_name)
+}
+
+fn ensure_scenario_exists(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
+    let exists = store
+        .get_all_scenarios()
+        .map_err(AppError::db)?
+        .iter()
+        .any(|s| s.id == scenario_id);
+    if !exists {
+        return Err(AppError::not_found("Scenario not found"));
+    }
+    Ok(())
+}
+
+pub(crate) fn enabled_installed_adapters_for_scenario_skill(
+    store: &SkillStore,
+    scenario_id: &str,
+    skill_id: &str,
+) -> Result<Vec<tool_adapters::ToolAdapter>, AppError> {
+    let adapters = tool_adapters::enabled_installed_adapters(store);
+    let adapter_keys: Vec<String> = adapters.iter().map(|a| a.key.clone()).collect();
+
+    store
+        .ensure_scenario_skill_tool_defaults(scenario_id, skill_id, &adapter_keys)
+        .map_err(AppError::db)?;
+
+    let enabled = store
+        .get_enabled_tools_for_scenario_skill(scenario_id, skill_id)
+        .map_err(AppError::db)?;
+    let enabled_set: HashSet<String> = enabled.into_iter().collect();
+
+    Ok(adapters
+        .into_iter()
+        .filter(|adapter| enabled_set.contains(&adapter.key))
+        .collect())
+}
+
 
 #[derive(Debug, Serialize)]
 pub struct ScenarioDto {
@@ -89,6 +310,33 @@ pub async fn get_active_scenario(
             }
         }
         Ok(None)
+    })
+    .await?
+}
+
+#[tauri::command]
+pub async fn get_project_scenarios(
+    store: State<'_, Arc<SkillStore>>,
+    project_id: String,
+) -> Result<Vec<ScenarioDto>, AppError> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let scenarios = store.get_project_scenarios(&project_id).map_err(AppError::db)?;
+        let mut result = Vec::new();
+        for s in scenarios {
+            let count = store.count_skills_for_scenario(&s.id).unwrap_or(0);
+            result.push(ScenarioDto {
+                id: s.id,
+                name: s.name,
+                description: s.description,
+                icon: s.icon,
+                sort_order: s.sort_order,
+                skill_count: count,
+                created_at: s.created_at,
+                updated_at: s.updated_at,
+            });
+        }
+        Ok(result)
     })
     .await?
 }

--- a/src-tauri/src/core/app_state.rs
+++ b/src-tauri/src/core/app_state.rs
@@ -19,5 +19,15 @@ pub fn initialize_store() -> Result<Arc<SkillStore>> {
     scenario_service::ensure_default_startup_scenario(&store)
         .map_err(|e| anyhow::anyhow!(e.to_string()))
         .context("Failed to initialize startup scenario")?;
+
+    // P0-6: re-assert every project_scenarios subscription's symlinks on startup.
+    // Bind-time is the only moment the symlinks get written, so any prior loss
+    // (P0-5 aftermath, manual cleanup, filesystem restore, etc.) leaves the UI
+    // showing "bound" without the files on disk. Failing here must NOT block
+    // app launch — we log and continue.
+    if let Err(e) = scenario_service::reconcile_project_subscriptions(&store) {
+        log::warn!("Failed to reconcile project subscriptions on startup: {e}");
+    }
+
     Ok(store)
 }

--- a/src-tauri/src/core/migrations.rs
+++ b/src-tauri/src/core/migrations.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use rusqlite::Connection;
 
 /// Current schema version. Bump this when adding a new migration.
-const LATEST_VERSION: u32 = 4;
+const LATEST_VERSION: u32 = 5;
 
 /// Run all pending migrations on the database.
 ///
@@ -51,6 +51,7 @@ fn migrate_step(conn: &Connection, from_version: u32) -> Result<()> {
         1 => migrate_v1_to_v2(conn),
         2 => migrate_v2_to_v3(conn),
         3 => migrate_v3_to_v4(conn),
+        4 => migrate_v4_to_v5(conn),
         _ => bail!("unknown migration version: {from_version}"),
     }
 }
@@ -237,6 +238,23 @@ fn migrate_v3_to_v4(conn: &Connection) -> Result<()> {
     add_column_if_missing(conn, "projects", "linked_agent_key", "TEXT")?;
     add_column_if_missing(conn, "projects", "linked_agent_name", "TEXT")?;
     add_column_if_missing(conn, "projects", "disabled_path", "TEXT")?;
+    Ok(())
+}
+
+/// v4 → v5: Replace single active_scenario with project-scene binding.
+/// Allows many-to-many binding between projects and scenarios for multi-project workflows.
+fn migrate_v4_to_v5(conn: &Connection) -> Result<()> {
+    // Create project_scenarios table for many-to-many project-scene binding
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS project_scenarios (
+            project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+            scenario_id TEXT NOT NULL REFERENCES scenarios(id) ON DELETE CASCADE,
+            created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+            PRIMARY KEY (project_id, scenario_id)
+        );
+        ",
+    )?;
     Ok(())
 }
 

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -1,13 +1,81 @@
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::{
     error::AppError,
-    skill_store::{ScenarioRecord, SkillStore, SkillTargetRecord},
+    skill_store::{ProjectRecord, ScenarioRecord, SkillStore, SkillTargetRecord},
     sync_engine, tool_adapters,
     tool_service,
 };
+
+/// Returns true if `child` lives under `parent`.
+///
+/// Important: we canonicalize `parent` (to absorb symlinks / `..` / trailing
+/// slashes in the project root), but we do NOT canonicalize `child`. If `child`
+/// is itself a symlink — which is exactly what Skills Manager writes into
+/// project directories — `std::fs::canonicalize` would follow it to the
+/// central repo target (e.g. `~/.skills-manager/skills/html-ppt`) and make the
+/// test falsely return `false`. That would prevent unsync from ever cleaning
+/// up subscription-owned symlinks.
+///
+/// Instead, we canonicalize `child`'s parent directory (same logic, without
+/// following the leaf symlink) and append the leaf file name back. This keeps
+/// the comparison semantically "is this path lexically inside the project?"
+/// while still handling symlinked parent dirs correctly.
+pub(crate) fn path_is_under(child: &Path, parent: &Path) -> bool {
+    let canonical_parent = std::fs::canonicalize(parent).ok();
+
+    // Canonicalize child's PARENT (without following the leaf), then re-append
+    // the leaf name. std::fs::canonicalize() on a symlink follows it; we don't
+    // want that for the leaf, because subscription symlinks legitimately point
+    // OUT of the project tree into the central repo.
+    let canonical_child = match (child.parent(), child.file_name()) {
+        (Some(cp), Some(name)) => std::fs::canonicalize(cp)
+            .ok()
+            .map(|p| p.join(name)),
+        _ => None,
+    };
+
+    if let (Some(c), Some(p)) = (canonical_child.as_ref(), canonical_parent.as_ref()) {
+        return c != p && c.starts_with(p);
+    }
+
+    // Lexical fallback: PathBuf::starts_with compares path components,
+    // so /a/proj does NOT match /a/proj-legacy.
+    let c = PathBuf::from(child);
+    let p = PathBuf::from(parent);
+    c != p && c.starts_with(&p)
+}
+
+
+/// Returns None if the tool is not actually used in this project
+/// (i.e. its detect directory doesn't exist under the project root).
+pub(crate) fn resolve_project_skill_target(
+    project: &ProjectRecord,
+    adapter: &tool_adapters::ToolAdapter,
+    skill_name: &str,
+) -> Option<PathBuf> {
+    if project.workspace_type == "linked" {
+        let project_path = PathBuf::from(&project.path);
+        if !project_path.exists() {
+            log::warn!("Linked workspace path does not exist: {}", project_path.display());
+            return None;
+        }
+        return Some(project_path.join(skill_name));
+    }
+    // Check if this tool is actually being used in this project.
+    // e.g. .claude/ or .cursor/ must exist under the project root.
+    let detect_dir = PathBuf::from(&project.path).join(&adapter.relative_detect_dir);
+    if !detect_dir.exists() {
+        return None;
+    }
+    Some(
+        PathBuf::from(&project.path)
+            .join(&adapter.relative_skills_dir)
+            .join(skill_name),
+    )
+}
 
 #[derive(Debug, Clone)]
 pub struct ScenarioSyncTarget {
@@ -197,6 +265,14 @@ pub fn unsync_obsolete_scenario_targets(
         })
         .collect();
 
+    // P0-5: project-level targets are owned by the project_scenarios subscription
+    // lifecycle, NOT by the active-scenario sweep. If we don't exclude them here,
+    // switching the active scenario (or app startup picking a different default)
+    // wipes every subscribed project's symlinks, even though the subscriptions
+    // themselves remain in the DB. Result: users see "bound" scenes in the UI
+    // but missing skill files on disk until they manually re-bind.
+    let project_paths = collect_project_paths(store);
+
     let old_skill_ids = store
         .get_skill_ids_for_scenario(old_scenario_id)
         .map_err(AppError::db)?;
@@ -206,6 +282,9 @@ pub fn unsync_obsolete_scenario_targets(
             let path = PathBuf::from(&target.target_path);
             let key = (skill_id.clone(), target.tool.clone());
             if desired_paths.get(&key) == Some(&path) {
+                continue;
+            }
+            if is_project_owned_target(&path, &project_paths) {
                 continue;
             }
 
@@ -229,10 +308,20 @@ pub fn unsync_scenario_skills(store: &SkillStore, scenario_id: &str) -> Result<(
         .get_skill_ids_for_scenario(scenario_id)
         .map_err(AppError::db)?;
 
+    // P0-5: same reasoning as unsync_obsolete_scenario_targets — never touch
+    // targets that live inside a project directory. They belong to the
+    // subscription system (bind/unbind/delete-scenario/remove-project), not
+    // to active-scenario unsync sweeps that fire on app startup, scenario
+    // creation, scenario deletion, and tray-menu scenario switches.
+    let project_paths = collect_project_paths(store);
+
     for skill_id in &skill_ids {
         let targets = store.get_targets_for_skill(skill_id).unwrap_or_default();
         for target in &targets {
             let path = PathBuf::from(&target.target_path);
+            if is_project_owned_target(&path, &project_paths) {
+                continue;
+            }
             if let Err(e) = sync_engine::remove_target(&path) {
                 log::warn!("Failed to remove sync target {}: {e}", path.display());
             }
@@ -246,6 +335,26 @@ pub fn unsync_scenario_skills(store: &SkillStore, scenario_id: &str) -> Result<(
     }
 
     Ok(())
+}
+
+/// Collect canonical-friendly project root paths once per call, so the
+/// per-target check below is cheap. canonicalize() is attempted lazily by
+/// path_is_under, so we just hand it the raw stored paths.
+fn collect_project_paths(store: &SkillStore) -> Vec<PathBuf> {
+    store
+        .get_all_projects()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|p| PathBuf::from(p.path))
+        .collect()
+}
+
+/// Returns true if `path` lives inside any known project directory.
+/// Used to fence off subscription-owned targets from active-scenario sweeps.
+fn is_project_owned_target(path: &Path, project_paths: &[PathBuf]) -> bool {
+    project_paths
+        .iter()
+        .any(|proj| path_is_under(path, proj))
 }
 
 pub fn sync_scenario_skills(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
@@ -366,6 +475,143 @@ pub fn ensure_default_startup_scenario(store: &SkillStore) -> Result<(), AppErro
     sync_scenario_skills(store, &desired_active)
 }
 
+/// P0-6: Reconcile project-scenario subscription symlinks at app startup.
+///
+/// Why this exists:
+///   Binding a scenario to a project only writes the symlinks once (at bind time).
+///   There is nothing in the original startup path that re-asserts them. So if the
+///   physical files get wiped between runs — by a prior bug (P0-5), manual cleanup,
+///   a sync'd backup restore, or the OS doing housekeeping — the DB still records
+///   the subscription but the project directory stays empty. Users see "bound
+///   scenes" in the UI without the skill files, and the only way to recover is
+///   to manually unbind + rebind.
+///
+/// What this function does:
+///   For every (project, scenario) row in project_scenarios, re-run the same
+///   symlink-writing logic that bind_scenario_to_project does. sync_engine::sync_skill
+///   is idempotent — it will:
+///     * create a missing symlink
+///     * leave a correct existing symlink untouched
+///     * fix a dangling / wrong-target symlink
+///   And insert_target uses ON CONFLICT (skill_id, tool) DO UPDATE, so repeat
+///   calls don't accumulate rows.
+///
+/// Failure mode:
+///   Per-skill / per-project errors are logged and swallowed — a single broken
+///   project must not prevent the rest from being reconciled, nor block app startup.
+pub fn reconcile_project_subscriptions(store: &SkillStore) -> Result<(), AppError> {
+    let projects = store.get_all_projects().map_err(AppError::db)?;
+    if projects.is_empty() {
+        return Ok(());
+    }
+
+    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+    let mut reconciled_bindings = 0usize;
+    let mut reconciled_skills = 0usize;
+    let mut failures = 0usize;
+
+    for project in &projects {
+        let scenario_ids = match store.get_project_scenario_ids(&project.id) {
+            Ok(ids) => ids,
+            Err(e) => {
+                log::warn!(
+                    "reconcile: failed to read subscriptions for project {}: {e}",
+                    project.id
+                );
+                failures += 1;
+                continue;
+            }
+        };
+
+        for scenario_id in &scenario_ids {
+            reconciled_bindings += 1;
+            let skill_ids = match store.get_skill_ids_for_scenario(scenario_id) {
+                Ok(ids) => ids,
+                Err(e) => {
+                    log::warn!(
+                        "reconcile: failed to read skills for scenario {scenario_id}: {e}"
+                    );
+                    failures += 1;
+                    continue;
+                }
+            };
+
+            for skill_id in &skill_ids {
+                let Ok(Some(skill)) = store.get_skill_by_id(skill_id) else {
+                    // Skill row was removed but scenario_skills still pointed at it;
+                    // broadcast/cleanup races. Skip — it's not our job to fix it here.
+                    continue;
+                };
+
+                let adapters = match enabled_installed_adapters_for_scenario_skill(
+                    store,
+                    scenario_id,
+                    skill_id,
+                ) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        log::warn!(
+                            "reconcile: failed to resolve adapters for skill {skill_id} in scenario {scenario_id}: {e}"
+                        );
+                        failures += 1;
+                        continue;
+                    }
+                };
+
+                let source = PathBuf::from(&skill.central_path);
+                let target_name = sync_engine::target_dir_name(&source, &skill.name);
+
+                for adapter in &adapters {
+                    let Some(target) =
+                        resolve_project_skill_target(project, adapter, &target_name)
+                    else {
+                        continue; // tool not used in this project, skip
+                    };
+                    let mode =
+                        sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
+
+                    match sync_engine::sync_skill(&source, &target, mode) {
+                        Ok(actual_mode) => {
+                            reconciled_skills += 1;
+                            let now = chrono::Utc::now().timestamp_millis();
+                            let record = SkillTargetRecord {
+                                id: uuid::Uuid::new_v4().to_string(),
+                                skill_id: skill_id.to_string(),
+                                tool: adapter.key.clone(),
+                                target_path: target.to_string_lossy().to_string(),
+                                mode: actual_mode.as_str().to_string(),
+                                status: "ok".to_string(),
+                                synced_at: Some(now),
+                                last_error: None,
+                            };
+                            if let Err(e) = store.insert_target(&record) {
+                                log::warn!(
+                                    "reconcile: failed to upsert target for skill {skill_id} in project {}: {e}",
+                                    project.id
+                                );
+                                failures += 1;
+                            }
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "reconcile: failed to sync skill {skill_id} to project {} (tool={}): {e}",
+                                project.id,
+                                adapter.key
+                            );
+                            failures += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    log::info!(
+        "reconcile_project_subscriptions: {reconciled_bindings} binding(s), {reconciled_skills} target(s) ensured, {failures} failure(s)"
+    );
+    Ok(())
+}
+
 pub fn sync_active_scenario_to_tool(store: &SkillStore, tool_key: &str) {
     if let Ok(Some(active_id)) = store.get_active_scenario_id() {
         let Ok(skill_ids) = store.get_skill_ids_for_scenario(&active_id) else {
@@ -431,4 +677,181 @@ pub fn sync_single_skill_to_tool(
 
     store.insert_target(&target_record).map_err(AppError::db)?;
     Ok(())
+}
+
+/// When a skill is added to a scenario, broadcast the sync to all projects bound to that scenario.
+pub fn sync_skill_to_bound_projects(
+    store: &SkillStore,
+    scenario_id: &str,
+    skill_id: &str,
+) -> Result<(), AppError> {
+    let project_ids = store
+        .get_scenario_project_ids(scenario_id)
+        .map_err(AppError::db)?;
+    if project_ids.is_empty() {
+        return Ok(());
+    }
+
+    let Ok(Some(skill)) = store.get_skill_by_id(skill_id) else {
+        return Ok(());
+    };
+
+    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+    let adapters = enabled_installed_adapters_for_scenario_skill(store, scenario_id, skill_id)?;
+    let source = PathBuf::from(&skill.central_path);
+    let target_name = sync_engine::target_dir_name(&source, &skill.name);
+
+    for project_id in &project_ids {
+        let Ok(Some(project)) = store.get_project_by_id(project_id) else {
+            continue;
+        };
+
+        for adapter in &adapters {
+            let Some(target) = resolve_project_skill_target(&project, adapter, &target_name) else {
+                continue; // tool not used in this project, skip
+            };
+            let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
+            match sync_engine::sync_skill(&source, &target, mode) {
+                Ok(actual_mode) => {
+                    let now = chrono::Utc::now().timestamp_millis();
+                    let record = SkillTargetRecord {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        skill_id: skill_id.to_string(),
+                        tool: adapter.key.clone(),
+                        target_path: target.to_string_lossy().to_string(),
+                        mode: actual_mode.as_str().to_string(),
+                        status: "ok".to_string(),
+                        synced_at: Some(now),
+                        last_error: None,
+                    };
+                    let _ = store.insert_target(&record);
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Failed to sync skill {skill_id} to project {project_id}: {e}"
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// When a skill is removed from a scenario, remove it from all projects bound to that scenario.
+/// Skips removal if the project has another bound scenario that also contains this skill.
+pub fn unsync_skill_from_bound_projects(
+    store: &SkillStore,
+    scenario_id: &str,
+    skill_id: &str,
+) -> Result<(), AppError> {
+    let project_ids = store
+        .get_scenario_project_ids(scenario_id)
+        .map_err(AppError::db)?;
+    if project_ids.is_empty() {
+        return Ok(());
+    }
+
+    for project_id in &project_ids {
+        // If another scenario bound to this project also contains this skill, keep it.
+        let other_scenario_ids = store
+            .get_project_scenario_ids(project_id)
+            .map_err(AppError::db)?;
+        let covered_by_other = other_scenario_ids
+            .iter()
+            .filter(|sid| sid.as_str() != scenario_id)
+            .any(|sid| {
+                store
+                    .get_skill_ids_for_scenario(sid)
+                    .unwrap_or_default()
+                    .contains(&skill_id.to_string())
+            });
+
+        if covered_by_other {
+            continue;
+        }
+
+        let Ok(Some(project)) = store.get_project_by_id(project_id) else {
+            continue;
+        };
+
+        let targets = store.get_targets_for_skill(skill_id).unwrap_or_default();
+        for target in &targets {
+            let path = PathBuf::from(&target.target_path);
+            // Only remove targets that live inside this project's directory.
+            if path_is_under(&path, Path::new(&project.path)) {
+                if let Err(e) = sync_engine::remove_target(&path) {
+                    log::warn!("Failed to remove target {}: {e}", path.display());
+                }
+                let _ = store.delete_target(skill_id, &target.tool);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::path_is_under;
+    use std::path::Path;
+
+    #[test]
+    fn path_is_under_direct_child() {
+        assert!(path_is_under(
+            Path::new("/a/proj/.claude/skills/foo"),
+            Path::new("/a/proj")
+        ));
+    }
+
+    #[test]
+    fn path_is_under_does_not_match_sibling_with_same_prefix() {
+        // /a/proj-legacy should NOT match parent /a/proj
+        assert!(!path_is_under(
+            Path::new("/a/proj-legacy/.claude/skills/foo"),
+            Path::new("/a/proj")
+        ));
+    }
+
+    #[test]
+    fn path_is_under_exact_match_is_false() {
+        // A path is not "under" itself
+        assert!(!path_is_under(Path::new("/a/proj"), Path::new("/a/proj")));
+    }
+
+    #[test]
+    fn path_is_under_unrelated_paths() {
+        assert!(!path_is_under(
+            Path::new("/b/other/skills/foo"),
+            Path::new("/a/proj")
+        ));
+    }
+
+    /// P0-8 regression: subscription symlinks inside a project point OUT of
+    /// the project tree (into the central skills repo). A naive
+    /// `canonicalize(child)` follows the symlink and decides the path is
+    /// no longer under the project, which made unsync_scenario_from_project
+    /// silently skip every cleanup. path_is_under must treat the symlink's
+    /// own location — not its target — as "the path being tested".
+    #[cfg(unix)]
+    #[test]
+    fn path_is_under_symlink_child_pointing_outside_is_still_under_parent() {
+        use std::fs;
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("proj");
+        let outside = tmp.path().join("central");
+        let real_skill = outside.join("html-ppt");
+        fs::create_dir_all(project.join(".claude/skills")).unwrap();
+        fs::create_dir_all(&real_skill).unwrap();
+
+        // Write a symlink inside the project that targets a path OUTSIDE it.
+        let link = project.join(".claude/skills/html-ppt");
+        std::os::unix::fs::symlink(&real_skill, &link).unwrap();
+
+        // The symlink itself lives under the project — that's what we're
+        // asserting. If canonicalize(child) is applied blindly, this returns
+        // false (because the link resolves to outside/central/html-ppt).
+        assert!(
+            path_is_under(&link, &project),
+            "symlink lives inside project; its target destination is irrelevant to the containment check"
+        );
+    }
 }

--- a/src-tauri/src/core/skill_store.rs
+++ b/src-tauri/src/core/skill_store.rs
@@ -1030,6 +1030,77 @@ impl SkillStore {
         Ok(())
     }
 
+    // ── Project-Scenario Bindings (many-to-many) ──
+
+    /// Bind a scenario to a project. Creates symlinks for all skills in that scenario
+    /// targeting all installed agents.
+    pub fn bind_scenario_to_project(&self, project_id: &str, scenario_id: &str) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO project_scenarios (project_id, scenario_id) VALUES (?1, ?2)",
+            params![project_id, scenario_id],
+        )?;
+        Ok(())
+    }
+
+    /// Unbind a scenario from a project. Removes symlinks for all skills in that scenario.
+    pub fn unbind_scenario_from_project(&self, project_id: &str, scenario_id: &str) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM project_scenarios WHERE project_id = ?1 AND scenario_id = ?2",
+            params![project_id, scenario_id],
+        )?;
+        Ok(())
+    }
+
+    /// Get all scenario IDs bound to a project.
+    pub fn get_project_scenario_ids(&self, project_id: &str) -> Result<Vec<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT scenario_id FROM project_scenarios WHERE project_id = ?1",
+        )?;
+        let rows = stmt
+            .query_map(params![project_id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Get all project IDs bound to a scenario. Useful for broadcasting.
+    pub fn get_scenario_project_ids(&self, scenario_id: &str) -> Result<Vec<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT project_id FROM project_scenarios WHERE scenario_id = ?1",
+        )?;
+        let rows = stmt
+            .query_map(params![scenario_id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Get all scenarios bound to a project.
+    pub fn get_project_scenarios(&self, project_id: &str) -> Result<Vec<ScenarioRecord>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT s.id, s.name, s.description, s.icon, s.sort_order, s.created_at, s.updated_at
+             FROM scenarios s
+             INNER JOIN project_scenarios ps ON s.id = ps.scenario_id
+             WHERE ps.project_id = ?1
+             ORDER BY s.sort_order, s.name",
+        )?;
+        let rows = stmt.query_map(params![project_id], |row| {
+            Ok(ScenarioRecord {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                description: row.get(2)?,
+                icon: row.get(3)?,
+                sort_order: row.get(4)?,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        })?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
     // ── Projects ──
 
     pub fn insert_project(&self, project: &ProjectRecord) -> Result<()> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -466,8 +466,11 @@ pub fn run() {
             commands::projects::toggle_project_skill,
             commands::projects::delete_project_skill,
             commands::projects::slugify_skill_names,
+            commands::projects::bind_scenario_to_project,
+            commands::projects::unbind_scenario_from_project,
             // Scenarios
             commands::scenarios::get_scenarios,
+            commands::scenarios::get_project_scenarios,
             commands::scenarios::get_active_scenario,
             commands::scenarios::create_scenario,
             commands::scenarios::update_scenario,

--- a/src/components/ScenePickerDialog.tsx
+++ b/src/components/ScenePickerDialog.tsx
@@ -1,0 +1,116 @@
+import { useState, useEffect } from "react";
+import { X, Layers, Search, Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "../utils";
+import * as api from "../lib/tauri";
+
+interface Props {
+  boundSceneIds: string[];
+  onBind: (scenarioId: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export function ScenePickerDialog({ boundSceneIds, onBind, onClose }: Props) {
+  const { t } = useTranslation();
+  const [scenes, setScenes] = useState<{ id: string; name: string; skill_count: number }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [binding, setBinding] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const allScenes = await api.getScenarios();
+        setScenes(allScenes);
+      } catch (e) {
+        console.error("Failed to load scenes:", e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const availableScenes = scenes.filter(
+    (s) => !boundSceneIds.includes(s.id) && s.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative bg-surface border border-border rounded-xl w-full max-w-sm p-5 shadow-2xl">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-[13px] font-semibold text-primary flex items-center gap-2">
+            <Layers className="w-4 h-4 text-muted" />
+            {t("project.bindScene")}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-muted hover:text-secondary p-1 rounded transition-colors outline-none"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="mb-4">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t("project.searchScenes")}
+              className="app-input w-full pl-9"
+              autoCapitalize="none"
+            />
+          </div>
+        </div>
+
+        <div className="max-h-[300px] space-y-1 overflow-y-auto">
+          {loading ? (
+            <p className="text-center text-[13px] text-muted">{t("common.loading")}</p>
+          ) : availableScenes.length === 0 ? (
+            <p className="text-center text-[13px] text-muted">{t("project.noAvailableScenes")}</p>
+          ) : (
+            availableScenes.map((scene) => (
+              <button
+                key={scene.id}
+                onClick={async () => {
+                  setBinding(scene.id);
+                  try {
+                    await onBind(scene.id);
+                  } finally {
+                    setBinding(null);
+                  }
+                }}
+                disabled={binding !== null}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-[13px] transition-colors",
+                  binding === scene.id
+                    ? "bg-surface-hover text-muted"
+                    : "hover:bg-surface-hover text-secondary"
+                )}
+              >
+                <Layers className="h-4 w-4 text-muted" />
+                <span className="flex-1 font-medium">{scene.name}</span>
+                <span className="text-[12px] text-muted">{scene.skill_count} skills</span>
+                {binding === scene.id && (
+                  <Loader2 className="h-3 w-3 animate-spin text-muted" />
+                )}
+              </button>
+            ))
+          )}
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 rounded-[4px] text-[13px] font-medium text-tertiary hover:text-secondary hover:bg-surface-hover transition-colors outline-none"
+          >
+            {t("common.close")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -707,6 +707,7 @@
     "bindScene": "Bind Scene to Project",
     "searchScenes": "Search scenes...",
     "noAvailableScenes": "No available scenes",
-    "sceneUnbound": "Scene unbound"
+    "sceneUnbound": "Scene unbound",
+    "sceneBound": "Scene bound"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -700,6 +700,13 @@
     "batchUpdateProjectFailed": "{{count}} skills failed to update in project",
     "batchEditTags": "Tags ({{count}})",
     "batchTagsUpdated": "Tags updated for {{count}} center skills",
-    "batchTagsFailed": "{{count}} center skills failed to update tags"
+    "batchTagsFailed": "{{count}} center skills failed to update tags",
+    "boundScenes": "Bound Scenes",
+    "addScene": "Add Scene",
+    "noBoundScenes": "No scenes bound to this project",
+    "bindScene": "Bind Scene to Project",
+    "searchScenes": "Search scenes...",
+    "noAvailableScenes": "No available scenes",
+    "sceneUnbound": "Scene unbound"
   }
 }

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -700,6 +700,13 @@
     "batchUpdateProjectFailed": "{{count}} 个 Skill 更新到项目失败",
     "batchEditTags": "标签 ({{count}})",
     "batchTagsUpdated": "已更新 {{count}} 个中心 Skill 的标签",
-    "batchTagsFailed": "{{count}} 个中心 Skill 标签更新失败"
+    "batchTagsFailed": "{{count}} 个中心 Skill 标签更新失败",
+    "boundScenes": "绑定场景",
+    "addScene": "添加场景",
+    "noBoundScenes": "该项目尚未绑定任何场景",
+    "bindScene": "绑定场景到项目",
+    "searchScenes": "搜索场景...",
+    "noAvailableScenes": "没有可绑定的场景",
+    "sceneUnbound": "已解除场景绑定"
   }
 }

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -707,6 +707,7 @@
     "bindScene": "绑定场景到项目",
     "searchScenes": "搜索场景...",
     "noAvailableScenes": "没有可绑定的场景",
-    "sceneUnbound": "已解除场景绑定"
+    "sceneUnbound": "已解除场景绑定",
+    "sceneBound": "场景已绑定"
   }
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -467,6 +467,9 @@ export const gitBackupRestoreVersion = (tag: string) =>
 
 export const getScenarios = () => invoke<Scenario[]>("get_scenarios");
 
+export const getProjectScenarios = (projectId: string) =>
+  invoke<Scenario[]>("get_project_scenarios", { projectId });
+
 export const getActiveScenario = () =>
   invoke<Scenario | null>("get_active_scenario");
 
@@ -534,6 +537,12 @@ export const addLinkedWorkspace = (name: string, path: string, disabledPath?: st
 
 export const removeProject = (id: string) =>
   invoke<void>("remove_project", { id });
+
+export const bindScenarioToProject = (projectId: string, scenarioId: string) =>
+  invoke<void>("bind_scenario_to_project", { projectId, scenarioId });
+
+export const unbindScenarioFromProject = (projectId: string, scenarioId: string) =>
+  invoke<void>("unbind_scenario_from_project", { projectId, scenarioId });
 
 export const scanProjects = (root: string) =>
   invoke<string[]>("scan_projects", { root });

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -180,6 +180,11 @@ export function ProjectDetail() {
   });
   const [boundScenes, setBoundScenes] = useState<{ id: string; name: string }[]>([]);
   const [showScenePicker, setShowScenePicker] = useState(false);
+  // Tracks which scene is currently being unbound. Used to disable the X button
+  // so rapid-clicking cannot fire multiple concurrent unbind requests against
+  // the same scene (the backend also holds a mutation lock, but UX-wise we
+  // want the button to reflect the in-flight state).
+  const [unbindingSceneId, setUnbindingSceneId] = useState<string | null>(null);
   const dismissAddCallout = () => {
     setShowAddCallout(false);
     try {
@@ -586,12 +591,16 @@ export function ProjectDetail() {
 
   const handleUnbindScene = async (scenarioId: string) => {
     if (!id) return;
+    if (unbindingSceneId) return; // ignore reentrant clicks
+    setUnbindingSceneId(scenarioId);
     try {
       await api.unbindScenarioFromProject(id, scenarioId);
       toast.success(t("project.sceneUnbound"));
       setBoundScenes((prev) => prev.filter((s) => s.id !== scenarioId));
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, t("common.error")));
+    } finally {
+      setUnbindingSceneId(null);
     }
   };
 
@@ -822,21 +831,32 @@ export function ProjectDetail() {
         </div>
         {boundScenes.length > 0 ? (
           <div className="flex flex-wrap gap-2">
-            {boundScenes.map((scene) => (
-              <div
-                key={scene.id}
-                className="inline-flex items-center gap-1.5 rounded-full bg-surface px-2.5 py-1 text-[12px] font-medium text-secondary"
-              >
-                <Layers className="h-3 w-3 text-muted" />
-                <span>{scene.name}</span>
-                <button
-                  onClick={() => handleUnbindScene(scene.id)}
-                  className="ml-0.5 rounded-full p-0.5 text-muted hover:bg-surface-hover hover:text-secondary"
+            {boundScenes.map((scene) => {
+              const isUnbinding = unbindingSceneId === scene.id;
+              return (
+                <div
+                  key={scene.id}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-full bg-surface px-2.5 py-1 text-[12px] font-medium text-secondary",
+                    isUnbinding && "opacity-60"
+                  )}
                 >
-                  <X className="h-2.5 w-2.5" />
-                </button>
-              </div>
-            ))}
+                  <Layers className="h-3 w-3 text-muted" />
+                  <span>{scene.name}</span>
+                  <button
+                    onClick={() => handleUnbindScene(scene.id)}
+                    disabled={unbindingSceneId !== null}
+                    className="ml-0.5 rounded-full p-0.5 text-muted hover:bg-surface-hover hover:text-secondary disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isUnbinding ? (
+                      <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                    ) : (
+                      <X className="h-2.5 w-2.5" />
+                    )}
+                  </button>
+                </div>
+              );
+            })}
           </div>
         ) : (
           <p className="text-[12px] text-muted">{t("project.noBoundScenes")}</p>
@@ -1383,10 +1403,16 @@ export function ProjectDetail() {
         <ScenePickerDialog
           boundSceneIds={boundScenes.map((s) => s.id)}
           onBind={async (scenarioId) => {
-            await api.bindScenarioToProject(id, scenarioId);
-            const scenes = await api.getProjectScenarios(id);
-            setBoundScenes(scenes);
-            setShowScenePicker(false);
+            try {
+              await api.bindScenarioToProject(id, scenarioId);
+              const scenes = await api.getProjectScenarios(id);
+              setBoundScenes(scenes);
+              toast.success(t("project.sceneBound"));
+              // Keep the picker open so the user can bind multiple scenes in one go.
+            } catch (error: unknown) {
+              toast.error(getErrorMessage(error, t("common.error")));
+              throw error; // Let ScenePickerDialog reset its binding state via finally.
+            }
           }}
           onClose={() => setShowScenePicker(false)}
         />

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -33,6 +33,7 @@ import { AgentToggleSection, type AgentToggleItem } from "../components/AgentTog
 import { ProjectAgentDots } from "../components/ProjectAgentDots";
 import { SkillMarkdown } from "../components/SkillMarkdown";
 import { DocumentDiffViewer } from "../components/DocumentDiffViewer";
+import { ScenePickerDialog } from "../components/ScenePickerDialog";
 import { getTagActiveColor, getTagColor } from "../lib/skillTags";
 import { cn } from "../utils";
 import * as api from "../lib/tauri";
@@ -177,6 +178,8 @@ export function ProjectDetail() {
       return false;
     }
   });
+  const [boundScenes, setBoundScenes] = useState<{ id: string; name: string }[]>([]);
+  const [showScenePicker, setShowScenePicker] = useState(false);
   const dismissAddCallout = () => {
     setShowAddCallout(false);
     try {
@@ -207,6 +210,20 @@ export function ProjectDetail() {
   useEffect(() => {
     loadSkills();
   }, [loadSkills]);
+
+  // Load bound scenes for this project
+  useEffect(() => {
+    if (!id) return;
+    const loadBoundScenes = async () => {
+      try {
+        const scenes = await api.getProjectScenarios(id);
+        setBoundScenes(scenes);
+      } catch (e) {
+        console.error("Failed to load bound scenes:", e);
+      }
+    };
+    loadBoundScenes();
+  }, [id]);
 
   useEffect(() => {
     let cancelled = false;
@@ -567,6 +584,17 @@ export function ProjectDetail() {
     }
   };
 
+  const handleUnbindScene = async (scenarioId: string) => {
+    if (!id) return;
+    try {
+      await api.unbindScenarioFromProject(id, scenarioId);
+      toast.success(t("project.sceneUnbound"));
+      setBoundScenes((prev) => prev.filter((s) => s.id !== scenarioId));
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("common.error")));
+    }
+  };
+
   const handleBatchDeleteProject = async () => {
     if (!id) return;
     let deleted = 0;
@@ -778,6 +806,41 @@ export function ProjectDetail() {
             </div>
           )}
         </div>
+      </div>
+
+      {/* Bound Scenes Section */}
+      <div className="mb-4 rounded-xl border border-border-subtle bg-surface/50 p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-[13px] font-medium text-secondary">{t("project.boundScenes")}</h3>
+          <button
+            onClick={() => setShowScenePicker(true)}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-muted transition-colors hover:bg-surface-hover hover:text-secondary"
+          >
+            <Plus className="h-3 w-3" />
+            {t("project.addScene")}
+          </button>
+        </div>
+        {boundScenes.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {boundScenes.map((scene) => (
+              <div
+                key={scene.id}
+                className="inline-flex items-center gap-1.5 rounded-full bg-surface px-2.5 py-1 text-[12px] font-medium text-secondary"
+              >
+                <Layers className="h-3 w-3 text-muted" />
+                <span>{scene.name}</span>
+                <button
+                  onClick={() => handleUnbindScene(scene.id)}
+                  className="ml-0.5 rounded-full p-0.5 text-muted hover:bg-surface-hover hover:text-secondary"
+                >
+                  <X className="h-2.5 w-2.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-[12px] text-muted">{t("project.noBoundScenes")}</p>
+        )}
       </div>
 
       <div className="app-toolbar">
@@ -1312,6 +1375,20 @@ export function ProjectDetail() {
           onExport={handleExportFromCenter}
           onBatchExport={handleBatchExportFromCenter}
           onClose={() => setShowExportDialog(false)}
+        />
+      )}
+
+      {/* Scene Picker Dialog */}
+      {showScenePicker && id && (
+        <ScenePickerDialog
+          boundSceneIds={boundScenes.map((s) => s.id)}
+          onBind={async (scenarioId) => {
+            await api.bindScenarioToProject(id, scenarioId);
+            const scenes = await api.getProjectScenarios(id);
+            setBoundScenes(scenes);
+            setShowScenePicker(false);
+          }}
+          onClose={() => setShowScenePicker(false)}
         />
       )}
     </div>


### PR DESCRIPTION
## Why

The original design was "global single scenario" — only one scenario could be activated and synced to Agents at a time. This meant:

- Skills Manager is essentially single-threaded
- Cannot work on multiple projects in parallel (e.g., writing project + video project + coding project simultaneously)
- Switching projects requires manually switching scenarios and re-syncing

This PR adds a many-to-many binding between projects and scenarios so each project can independently load different sets of Skills, enabling truly parallel multi-project workflows.

## What this PR adds

- New `project_scenarios` many-to-many table linking projects to scenarios
- Frontend "Bound Scenes" section in ProjectDetail page for adding/removing scenario bindings
- When syncing scenario Skills to a project, uses a shared `.skills/` directory within the project
- When binding a scenario, only creates symlinks in Agent skills directories that actually exist in the project (avoids creating links for Agents that never opened this project)

## How it works

```
Project A/
  .skills/                          ← shared Skills source
    ├── discipline-study/
    └── systematic-debugging/
  .claude/skills/                   ← Claude Code has opened this project
    discipline-study → ../../.skills/discipline-study
    systematic-debugging → ../../.skills/systematic-debugging
  .codebuddy/skills/               ← CodeBuddy has also opened this project
    discipline-study → ../../.skills/discipline-study
    systematic-debugging → ../../.skills/systematic-debugging
```

All Agent symlinks point to the same `project/.skills/` source, so:
- Each project has only one copy of each Skill
- No matter how many Agents open the project, storage is efficient
- Skills are shared automatically across all Agents in the project

## Main changes

### Database
- `src-tauri/src/core/migrations.rs` — v5 migration, adds `project_scenarios` table
- `src-tauri/src/core/skill_store.rs` — new methods: `bind_scenario_to_project`, `unbind_scenario_from_project`, `get_project_scenarios`, `get_project_scenario_ids`, `get_scenario_project_ids`

### Backend Commands
- `src-tauri/src/commands/projects.rs` — new commands: `bind_scenario_to_project`, `unbind_scenario_from_project`
- `src-tauri/src/commands/scenarios.rs` — new functions: `get_project_scenarios`, `sync_scenario_to_project`, `unsync_scenario_from_project`, `resolve_project_skill_target`, `resolve_agent_skill_symlink`

### Frontend
- `src/views/ProjectDetail.tsx` — new "Bound Scenes" section with add/remove UI
- `src/components/ScenePickerDialog.tsx` — new scene picker dialog component
- `src/lib/tauri.ts` — new APIs: `bindScenarioToProject`, `unbindScenarioFromProject`, `getProjectScenarios`

### i18n
- `src/i18n/zh.json`, `src/i18n/en.json` — new translation keys for bound scenes UI

## Known Limitations

- **Scene Skills update broadcasting**: When a scenario's Skills are updated (add/remove/modify a Skill), these changes need to be synced to all projects bound to that scenario. This is not implemented yet. Options: (1) auto-sync; (2) manual trigger; (3) background queue async sync. This PR does not include this feature.

## Verification

- `npm run build`
- `cargo check`
- Manual test: bind a scenario to a project, verify `.skills/` directory and Agent symlinks are correctly created