### PR TITLE
feat: update Antigravity default skill paths to ~/.gemini/config/skills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skills-manager",
-  "version": "1.19.2",
+  "version": "1.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skills-manager",
-      "version": "1.19.2",
+      "version": "1.22.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/src-tauri/src/core/tool_adapters.rs
+++ b/src-tauri/src/core/tool_adapters.rs
@@ -209,9 +209,9 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
         ToolAdapter {
             key: "antigravity".into(),
             display_name: "Antigravity".into(),
-            relative_skills_dir: ".gemini/antigravity/skills".into(),
-            relative_detect_dir: ".gemini/antigravity".into(),
-            additional_scan_dirs: vec![],
+            relative_skills_dir: ".gemini/config/skills".into(),
+            relative_detect_dir: ".gemini/config".into(),
+            additional_scan_dirs: vec![".gemini/antigravity/skills".into()],
             override_skills_dir: None,
             category: ToolCategory::Coding,
             is_custom: false,
@@ -864,7 +864,8 @@ mod tests {
             .find(|adapter| adapter.key == "antigravity")
             .expect("antigravity adapter should exist");
 
-        assert_eq!(adapter.relative_skills_dir, ".gemini/antigravity/skills");
+        assert_eq!(adapter.relative_skills_dir, ".gemini/config/skills");
+        assert!(adapter.additional_scan_dirs.contains(&".gemini/antigravity/skills".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
### 描述
由于新版 Antigravity 的技能存放路径已从原来的 `~/.gemini/antigravity/skills` 变更为 `~/.gemini/config/skills`，本 PR 更新了 Antigravity 适配器的默认技能路径和安装侦测目录。

### 主要改动
- 将 Antigravity 的 `relative_skills_dir` 变更为 `.gemini/config/skills`，`relative_detect_dir` 变更为 `.gemini/config`。
- 将原路径 `.gemini/antigravity/skills` 添加到 `additional_scan_dirs` 中，以确保老用户无缝迁移，不丢失之前安装的技能。
- 更新了对应的单元测试 `antigravity_uses_current_default_skills_path`，增加了对新主路径和老路径备份的断言。

### 测试验证
执行 `cargo test`，全部 255 个测试用例顺利通过。
