### PR TITLE
fix: prevent refresh loop from app-files-changed events

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -134,10 +134,17 @@ export function AppProvider({ children }: { children: ReactNode }) {
     refreshProjects();
   }, [setTranslatedError, refreshProjects]);
 
+  const refreshAppDataLockRef = useRef(false);
   const refreshAppData = useCallback(async () => {
-    setLoading(true);
-    await Promise.all([refreshPresets(), refreshTools(), refreshManagedSkills(), refreshProjects()]);
-    setLoading(false);
+    if (refreshAppDataLockRef.current) return;
+    refreshAppDataLockRef.current = true;
+    try {
+      setLoading(true);
+      await Promise.all([refreshPresets(), refreshTools(), refreshManagedSkills(), refreshProjects()]);
+      setLoading(false);
+    } finally {
+      refreshAppDataLockRef.current = false;
+    }
   }, [refreshManagedSkills, refreshProjects, refreshPresets, refreshTools]);
 
   const setViewedPresetId = useCallback((id: string) => {
@@ -218,16 +225,23 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+    let isRefreshing = false;
 
     const unlistenPromise = listen("app-files-changed", () => {
+      if (isRefreshing) return;
       if (refreshTimer) {
         clearTimeout(refreshTimer);
       }
       refreshTimer = setTimeout(() => {
-        refreshAppData().catch((error) => {
-          console.error("Failed to refresh after filesystem change:", error);
-        });
-      }, 500);
+        isRefreshing = true;
+        refreshAppData()
+          .catch((error) => {
+            console.error("Failed to refresh after filesystem change:", error);
+          })
+          .finally(() => {
+            isRefreshing = false;
+          });
+      }, 5000);
     });
 
     return () => {


### PR DESCRIPTION
## Problem

When sync operations write files to tool directories, the filesystem watcher fires `app-files-changed`, which calls `refreshAppData`. This may trigger more sync operations (e.g., re-importing discovered skills), creating an infinite refresh loop.

Evidence from logs:
```
get_managed_skills: 612 skills in 120 ms   # initial load
get_managed_skills: 674 skills in 146 ms   # after sync imported new skills
get_managed_skills: 697 skills in 140 ms   # more imports
# Then repeated every 3-5 seconds indefinitely
```

This causes the UI to stay in perpetual loading state.

## Fix

1. **Increase debounce** from 500ms to 5000ms — batches rapid file change events from a single sync operation
2. **Add `isRefreshing` guard** in the event listener — skips if a refresh is already in progress
3. **Add `refreshAppDataLockRef`** — prevents concurrent `refreshAppData` calls via a ref-based mutex

## Changes

- `src/context/AppContext.tsx`: 21 insertions, 7 deletions

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>