### PR TITLE
feat: support preset selection on skill install and library preset assignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skills-manager",
-  "version": "1.19.2",
+  "version": "1.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skills-manager",
-      "version": "1.19.2",
+      "version": "1.22.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/src-tauri/src/bin/skills-manager-cli.rs
+++ b/src-tauri/src/bin/skills-manager-cli.rs
@@ -638,7 +638,11 @@ fn show_skill(store: &SkillStore, reference: &str) -> anyhow::Result<SkillDetail
 
 fn export_skill(store: &SkillStore, reference: &str, dest: &Path) -> anyhow::Result<String> {
     let skill = resolve_skill(store, reference)?;
-    sync_engine::sync_skill(Path::new(&skill.central_path), dest, sync_engine::SyncMode::Copy)?;
+    sync_engine::sync_skill(
+        Path::new(&skill.central_path),
+        dest,
+        sync_engine::SyncMode::Copy,
+    )?;
     Ok(dest.to_string_lossy().to_string())
 }
 
@@ -731,7 +735,9 @@ fn classify_ref(
 fn is_skillssh_shorthand(s: &str) -> bool {
     // owner/repo, owner/repo/skill, owner/repo@skill
     fn seg_ok(s: &str) -> bool {
-        !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || matches!(c, '_' | '.' | '-'))
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_alphanumeric() || matches!(c, '_' | '.' | '-'))
     }
     let (head, _at_skill) = match s.split_once('@') {
         Some((h, t)) if seg_ok(t) => (h, Some(t)),
@@ -742,10 +748,7 @@ fn is_skillssh_shorthand(s: &str) -> bool {
     (parts.len() == 2 || parts.len() == 3) && parts.iter().all(|p| seg_ok(p))
 }
 
-fn resolve_sync_target(
-    store: &SkillStore,
-    target: &SyncTarget,
-) -> anyhow::Result<Option<String>> {
+fn resolve_sync_target(store: &SkillStore, target: &SyncTarget) -> anyhow::Result<Option<String>> {
     match target {
         SyncTarget::None => Ok(None),
         SyncTarget::Active => Ok(store.get_active_scenario_id()?),
@@ -769,9 +772,7 @@ fn run_install(
     let (skill_id, install_name, central_path, source_type) = match kind {
         InstallKind::Local => install_local_action(store, reference, name, preset_id.as_deref())?,
         InstallKind::Git => install_git_action(store, reference, name, preset_id.as_deref())?,
-        InstallKind::Skillssh => {
-            install_skillssh_action(store, reference, preset_id.as_deref())?
-        }
+        InstallKind::Skillssh => install_skillssh_action(store, reference, preset_id.as_deref())?,
     };
 
     Ok(InstallReport {
@@ -789,7 +790,7 @@ fn install_local_action(
     store: &SkillStore,
     reference: &str,
     name: Option<&str>,
-    active_scenario: Option<&str>,
+    _active_scenario: Option<&str>,
 ) -> anyhow::Result<(String, String, String, String)> {
     let path = expand_path(reference)?;
     if !path.exists() {
@@ -810,9 +811,8 @@ fn install_local_action(
     };
     let central_path = result.central_path.to_string_lossy().to_string();
     let install_name = result.name.clone();
-    let skill_id =
-        cmd::store_installed_skill_unlocked(store, &result, &metadata, active_scenario)
-            .map_err(map_app_err)?;
+    let skill_id = cmd::store_installed_skill_unlocked(store, &result, &metadata, None)
+        .map_err(map_app_err)?;
     Ok((skill_id, install_name, central_path, "local".to_string()))
 }
 
@@ -820,7 +820,7 @@ fn install_git_action(
     store: &SkillStore,
     repo_url: &str,
     name: Option<&str>,
-    active_scenario: Option<&str>,
+    _active_scenario: Option<&str>,
 ) -> anyhow::Result<(String, String, String, String)> {
     git_fetcher::validate_git_url(repo_url)?;
     let proxy_url = store.proxy_url();
@@ -834,8 +834,8 @@ fn install_git_action(
     )?;
     let result = (|| -> anyhow::Result<(String, String, String)> {
         let _lock = RepoLock::acquire("cli install git")?;
-        let skill_dir =
-            cmd::resolve_skill_dir(&temp_dir, parsed.subpath.as_deref(), None).map_err(map_app_err)?;
+        let skill_dir = cmd::resolve_skill_dir(&temp_dir, parsed.subpath.as_deref(), None)
+            .map_err(map_app_err)?;
         let revision = git_fetcher::get_head_revision(&temp_dir)?;
         let install_result = installer::install_from_git_dir(&skill_dir, name)?;
         let metadata = cmd::InstallSourceMetadata {
@@ -850,9 +850,8 @@ fn install_git_action(
         };
         let central_path = install_result.central_path.to_string_lossy().to_string();
         let install_name = install_result.name.clone();
-        let skill_id =
-            cmd::store_installed_skill_unlocked(store, &install_result, &metadata, active_scenario)
-                .map_err(map_app_err)?;
+        let skill_id = cmd::store_installed_skill_unlocked(store, &install_result, &metadata, None)
+            .map_err(map_app_err)?;
         Ok((skill_id, install_name, central_path))
     })();
     git_fetcher::cleanup_temp(&temp_dir);
@@ -863,13 +862,14 @@ fn install_git_action(
 fn install_skillssh_action(
     store: &SkillStore,
     shorthand: &str,
-    active_scenario: Option<&str>,
+    _active_scenario: Option<&str>,
 ) -> anyhow::Result<(String, String, String, String)> {
     let (source, skill_id_field) = parse_skillssh_shorthand(shorthand)?;
     let proxy_url = store.proxy_url();
     let repo_url = format!("https://github.com/{}.git", source);
     let cancel = Arc::new(AtomicBool::new(false));
-    let temp_dir = git_fetcher::clone_repo_ref(&repo_url, None, Some(&cancel), proxy_url.as_deref())?;
+    let temp_dir =
+        git_fetcher::clone_repo_ref(&repo_url, None, Some(&cancel), proxy_url.as_deref())?;
     let result = (|| -> anyhow::Result<(String, String, String)> {
         let _lock = RepoLock::acquire("cli install skillssh")?;
         let skill_dir =
@@ -892,9 +892,8 @@ fn install_skillssh_action(
             update_status: "up_to_date".to_string(),
         };
         let central_path = install_result.central_path.to_string_lossy().to_string();
-        let skill_id =
-            cmd::store_installed_skill_unlocked(store, &install_result, &metadata, active_scenario)
-                .map_err(map_app_err)?;
+        let skill_id = cmd::store_installed_skill_unlocked(store, &install_result, &metadata, None)
+            .map_err(map_app_err)?;
         Ok((skill_id, install_name, central_path))
     })();
     git_fetcher::cleanup_temp(&temp_dir);
@@ -967,24 +966,22 @@ fn run_update(
                     },
                 }
             }
-            "local" | "import" => {
-                match cmd::reimport_local_skill_internal(store, &skill.id) {
-                    Ok(_) => UpdateReport {
-                        skill_id: skill.id.clone(),
-                        name: skill.name.clone(),
-                        source_type: skill.source_type.clone(),
-                        refreshed: true,
-                        error: None,
-                    },
-                    Err(e) => UpdateReport {
-                        skill_id: skill.id.clone(),
-                        name: skill.name.clone(),
-                        source_type: skill.source_type.clone(),
-                        refreshed: false,
-                        error: Some(e.message.clone()),
-                    },
-                }
-            }
+            "local" | "import" => match cmd::reimport_local_skill_internal(store, &skill.id) {
+                Ok(_) => UpdateReport {
+                    skill_id: skill.id.clone(),
+                    name: skill.name.clone(),
+                    source_type: skill.source_type.clone(),
+                    refreshed: true,
+                    error: None,
+                },
+                Err(e) => UpdateReport {
+                    skill_id: skill.id.clone(),
+                    name: skill.name.clone(),
+                    source_type: skill.source_type.clone(),
+                    refreshed: false,
+                    error: Some(e.message.clone()),
+                },
+            },
             other => UpdateReport {
                 skill_id: skill.id.clone(),
                 name: skill.name.clone(),
@@ -1092,10 +1089,7 @@ fn run_remove(
         });
     }
     if !yes {
-        bail!(
-            "refusing to delete {} skill(s) without --yes",
-            ids.len()
-        );
+        bail!("refusing to delete {} skill(s) without --yes", ids.len());
     }
 
     let result = cmd::delete_managed_skills_by_ids(store, &ids).map_err(map_app_err)?;
@@ -1132,7 +1126,11 @@ fn run_deprecated_set_enabled(
         } else {
             false
         };
-        let enabled_after = if requested_enabled { true } else { skill.enabled };
+        let enabled_after = if requested_enabled {
+            true
+        } else {
+            skill.enabled
+        };
         let message = if requested_enabled {
             "Deprecated no-op: skills are enabled by adding them to a preset; this command only restores legacy sync inclusion."
         } else {
@@ -1296,7 +1294,12 @@ fn run_adopt(
                      https://github.com/owner/repo/tree/branch/path/to/skill"
                 );
             }
-            Some((parsed.clone_url, subpath, parsed.branch, Some(url.to_string())))
+            Some((
+                parsed.clone_url,
+                subpath,
+                parsed.branch,
+                Some(url.to_string()),
+            ))
         } else {
             None
         };
@@ -1491,7 +1494,11 @@ fn run_tag(args: TagArgs, store: &SkillStore, json: bool) -> anyhow::Result<()> 
     match args.command {
         TagCommand::Add { reference, tags } => {
             let skill = resolve_skill(store, &reference)?;
-            let mut current = store.get_tags_map()?.get(&skill.id).cloned().unwrap_or_default();
+            let mut current = store
+                .get_tags_map()?
+                .get(&skill.id)
+                .cloned()
+                .unwrap_or_default();
             for t in tags {
                 if !current.iter().any(|c| c == &t) {
                     current.push(t);
@@ -1510,7 +1517,11 @@ fn run_tag(args: TagArgs, store: &SkillStore, json: bool) -> anyhow::Result<()> 
         }
         TagCommand::Remove { reference, tags } => {
             let skill = resolve_skill(store, &reference)?;
-            let mut current = store.get_tags_map()?.get(&skill.id).cloned().unwrap_or_default();
+            let mut current = store
+                .get_tags_map()?
+                .get(&skill.id)
+                .cloned()
+                .unwrap_or_default();
             current.retain(|c| !tags.iter().any(|t| t == c));
             store.set_tags_for_skill(&skill.id, &current)?;
             sync_metadata::ensure_skill_metadata(store, &skill.id)?;
@@ -1526,7 +1537,11 @@ fn run_tag(args: TagArgs, store: &SkillStore, json: bool) -> anyhow::Result<()> 
         TagCommand::List { reference } => {
             if let Some(r) = reference {
                 let skill = resolve_skill(store, &r)?;
-                let tags = store.get_tags_map()?.get(&skill.id).cloned().unwrap_or_default();
+                let tags = store
+                    .get_tags_map()?
+                    .get(&skill.id)
+                    .cloned()
+                    .unwrap_or_default();
                 print_json(
                     &TagReport {
                         skill_id: skill.id,
@@ -1551,14 +1566,13 @@ fn run_presets(args: PresetArgs, store: &SkillStore, json: bool) -> anyhow::Resu
         PresetCommand::Current => print_json(&current_preset(store)?, json),
         PresetCommand::Preview { reference } => {
             let preset = resolve_scenario(store, &reference)?;
-            let preview = scenario_service::preview_scenario_sync(store, &preset.id)
-                .map_err(map_app_err)?;
+            let preview =
+                scenario_service::preview_scenario_sync(store, &preset.id).map_err(map_app_err)?;
             print_json(&preview, json);
         }
         PresetCommand::Apply { reference } => {
             let preset = resolve_scenario(store, &reference)?;
-            scenario_service::apply_scenario_to_default(store, &preset.id)
-                .map_err(map_app_err)?;
+            scenario_service::apply_scenario_to_default(store, &preset.id).map_err(map_app_err)?;
             print_json(&current_preset(store)?, json);
         }
         PresetCommand::Deactivate { reference } => {
@@ -1582,8 +1596,7 @@ fn run_presets(args: PresetArgs, store: &SkillStore, json: bool) -> anyhow::Resu
                 // any skills it shares with the active preset. Unsync this
                 // preset first, then re-sync the active preset so the shared
                 // targets are restored.
-                scenario_service::unsync_scenario_skills(store, &preset.id)
-                    .map_err(map_app_err)?;
+                scenario_service::unsync_scenario_skills(store, &preset.id).map_err(map_app_err)?;
                 if let Some(active_id) = active.as_deref() {
                     scenario_service::sync_scenario_skills(store, active_id)
                         .map_err(map_app_err)?;

--- a/src-tauri/src/commands/agent_workspace.rs
+++ b/src-tauri/src/commands/agent_workspace.rs
@@ -366,9 +366,9 @@ fn delete_agent_local_skill(
     let all_managed = store.get_all_skills().unwrap_or_default();
     let all_targets = store.get_all_targets().unwrap_or_default();
     if let Some(managed) = find_verified_center_match(&skill, &all_managed, &all_targets) {
-        let still_linked = all_targets
-            .iter()
-            .any(|t| t.skill_id == managed.id && target_path_equals_skill(&t.target_path, &skill.path));
+        let still_linked = all_targets.iter().any(|t| {
+            t.skill_id == managed.id && target_path_equals_skill(&t.target_path, &skill.path)
+        });
         if still_linked {
             return Err(AppError::invalid_input(
                 "Skill is managed by Skills Center — remove from the agent first.",

--- a/src-tauri/src/commands/browse.rs
+++ b/src-tauri/src/commands/browse.rs
@@ -53,4 +53,3 @@ pub async fn search_skillssh(
     })
     .await?
 }
-

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,9 +1,9 @@
 pub mod agent_workspace;
 pub mod browse;
 pub mod git_backup;
+pub mod presets;
 pub mod projects;
 pub mod scan;
-pub mod presets;
 pub mod settings;
 pub mod skills;
 pub mod sync;

--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -8,8 +8,9 @@ use crate::core::{
     error::AppError,
     scenario_service::{self, BatchApplyMode},
     skill_store::{ScenarioRecord, SkillStore},
-    sync_metadata, tool_adapters,
+    sync_metadata,
     timing::should_log_first_or_slow,
+    tool_adapters,
 };
 
 fn refresh_tray_menu_best_effort(app: &tauri::AppHandle) {
@@ -43,9 +44,7 @@ pub struct PresetDto {
 static GET_PRESETS_FIRST_CALL: AtomicBool = AtomicBool::new(true);
 
 #[tauri::command]
-pub async fn get_presets(
-    store: State<'_, Arc<SkillStore>>,
-) -> Result<Vec<PresetDto>, AppError> {
+pub async fn get_presets(store: State<'_, Arc<SkillStore>>) -> Result<Vec<PresetDto>, AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
         let start = Instant::now();
@@ -265,6 +264,41 @@ async fn apply_preset_to_default_impl(
     result
 }
 
+/// Replace all preset memberships for a skill. This is more efficient than
+/// calling add/remove individually when managing a skill's preset assignments.
+#[tauri::command]
+pub async fn set_skill_presets(
+    app: tauri::AppHandle,
+    skill_id: String,
+    preset_ids: Vec<String>,
+    store: State<'_, Arc<SkillStore>>,
+) -> Result<(), AppError> {
+    let store = store.inner().clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        sync_metadata::with_repo_lock("set skill presets", || {
+            let current = store.get_scenarios_for_skill(&skill_id)?;
+            for id in &current {
+                if !preset_ids.contains(id) {
+                    store.remove_skill_from_scenario(id, &skill_id)?;
+                }
+            }
+            for id in &preset_ids {
+                if !current.contains(id) {
+                    store.add_skill_to_scenario(id, &skill_id)?;
+                }
+            }
+            sync_metadata::write_all_from_db_unlocked(&store)
+        })
+        .map_err(AppError::db)?;
+        Ok(())
+    })
+    .await?;
+    if result.is_ok() {
+        refresh_tray_menu_best_effort(&app);
+    }
+    result
+}
+
 #[tauri::command]
 pub async fn add_skill_to_preset(
     app: tauri::AppHandle,
@@ -448,10 +482,10 @@ mod tests {
     };
     use crate::core::skill_store::SkillRecord;
     use crate::core::tool_adapters::{self, CustomToolDef};
-    use std::path::PathBuf;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     fn sample_skill(id: &str, name: &str, central_path: &std::path::Path) -> SkillRecord {

--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -114,7 +114,19 @@ pub async fn create_preset(
     let result = tauri::async_runtime::spawn_blocking(move || {
         let now = chrono::Utc::now().timestamp_millis();
         let id = uuid::Uuid::new_v4().to_string();
-        let previous_active_id = store.get_active_scenario_id().map_err(AppError::db)?;
+
+        // Reject duplicate preset names
+        let existing_names: Vec<String> = store
+            .get_all_scenarios()
+            .map_err(AppError::db)?
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        if existing_names.iter().any(|n| n == &name) {
+            return Err(AppError::invalid_input(format!(
+                "A preset named \"{name}\" already exists"
+            )));
+        }
 
         let record = ScenarioRecord {
             id: id.clone(),
@@ -131,11 +143,6 @@ pub async fn create_preset(
             sync_metadata::write_all_from_db_unlocked(&store)
         })
         .map_err(AppError::db)?;
-
-        if let Some(previous_id) = previous_active_id.as_deref() {
-            unsync_scenario_skills(&store, previous_id)?;
-        }
-        store.set_active_scenario(&id).map_err(AppError::db)?;
 
         Ok(PresetDto {
             id,

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,7 +3,9 @@ use std::process::Command;
 use std::sync::Arc;
 use tauri::{Manager, State};
 
-use crate::core::{central_repo, error::AppError, log_sanitize, skill_store::SkillStore, skillssh_api};
+use crate::core::{
+    central_repo, error::AppError, log_sanitize, skill_store::SkillStore, skillssh_api,
+};
 
 #[derive(serde::Serialize)]
 pub struct AppUpdateInfo {
@@ -33,11 +35,7 @@ pub async fn get_settings(
 /// log file layout.
 #[tauri::command]
 pub fn log_startup_event(label: String, elapsed_ms: u64) {
-    let sanitized: String = label
-        .chars()
-        .filter(|c| !c.is_control())
-        .take(64)
-        .collect();
+    let sanitized: String = label.chars().filter(|c| !c.is_control()).take(64).collect();
     let display = if sanitized.is_empty() {
         "(empty)".to_string()
     } else {
@@ -444,7 +442,10 @@ fn collapse_consecutive_repeats(text: &str) -> String {
         let count = j - i;
         out.push(lines[i].to_string());
         if count >= 3 {
-            out.push(format!("... (line above repeated {} more times)", count - 1));
+            out.push(format!(
+                "... (line above repeated {} more times)",
+                count - 1
+            ));
         } else if count == 2 {
             out.push(lines[i + 1].to_string());
         }

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1441,15 +1441,16 @@ pub fn store_installed_skill_unlocked(
     let now = chrono::Utc::now().timestamp_millis();
     let central_path = result.central_path.to_string_lossy().to_string();
 
-    // If no explicit preset_ids, fall back to the active scenario (legacy behavior).
+    // Resolve target preset IDs:
+    // - If user explicitly provided preset_ids (even empty), use them as-is.
+    // - If user did not specify, fall back to the "Default" preset (create if missing).
     let p_ids: Vec<String> = match preset_ids {
         Some(ids) => ids.to_vec(),
-        None => store
-            .get_active_scenario_id()
-            .ok()
-            .flatten()
-            .map(|id| vec![id])
-            .unwrap_or_default(),
+        None => {
+            let default_id = crate::core::scenario_service::ensure_default_preset(store)
+                .map_err(AppError::db)?;
+            vec![default_id]
+        }
     };
 
     if let Some(existing) = store

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -487,13 +487,13 @@ fn log_reimport_outcome(
 pub async fn install_local(
     source_path: String,
     name: Option<String>,
+    preset_ids: Option<Vec<String>>,
     store: State<'_, Arc<SkillStore>>,
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
         let outcome = (|| -> Result<(String, String), AppError> {
             let path = PathBuf::from(&source_path);
-            let active = store.get_active_scenario_id().ok().flatten();
             let metadata = InstallSourceMetadata {
                 source_type: "local".to_string(),
                 source_ref: Some(source_path.clone()),
@@ -509,7 +509,7 @@ pub async fn install_local(
                 installer::install_from_local(&path, name.as_deref()).map_err(AppError::io)?;
             let skill_name = result.name.clone();
             let skill_id =
-                store_installed_skill_unlocked(&store, &result, &metadata, active.as_deref())?;
+                store_installed_skill_unlocked(&store, &result, &metadata, preset_ids.as_deref())?;
             Ok((skill_id, skill_name))
         })();
         log_install_outcome(&store, "local", outcome.as_ref());
@@ -522,6 +522,7 @@ pub async fn install_local(
 pub async fn install_git(
     repo_url: String,
     name: Option<String>,
+    preset_ids: Option<Vec<String>>,
     store: State<'_, Arc<SkillStore>>,
     cancel_registry: State<'_, Arc<InstallCancelRegistry>>,
     app_handle: tauri::AppHandle,
@@ -577,7 +578,6 @@ pub async fn install_git(
             emit_progress("installing");
             let install_result = (|| -> Result<(String, String), AppError> {
                 let _lock = RepoLock::acquire("install git skill").map_err(AppError::db)?;
-                let active = store.get_active_scenario_id().ok().flatten();
                 let skill_dir = resolve_skill_dir(&temp_dir, parsed.subpath.as_deref(), None)?;
                 let revision = git_fetcher::get_head_revision(&temp_dir).map_err(AppError::git)?;
                 let result = installer::install_from_git_dir(&skill_dir, name.as_deref())
@@ -597,7 +597,7 @@ pub async fn install_git(
                     &store,
                     &result,
                     &metadata,
-                    active.as_deref(),
+                    preset_ids.as_deref(),
                 )?;
                 Ok((skill_id, skill_name))
             })();
@@ -619,6 +619,7 @@ pub async fn install_git(
 pub async fn install_from_skillssh(
     source: String,
     skill_id: String,
+    preset_ids: Option<Vec<String>>,
     store: State<'_, Arc<SkillStore>>,
     cancel_registry: State<'_, Arc<InstallCancelRegistry>>,
     app_handle: tauri::AppHandle,
@@ -674,7 +675,6 @@ pub async fn install_from_skillssh(
             emit_progress("installing");
             let install_result = (|| -> Result<(String, String), AppError> {
                 let _lock = RepoLock::acquire("install skillssh skill").map_err(AppError::db)?;
-                let active = store.get_active_scenario_id().ok().flatten();
                 let skill_dir = resolve_skill_dir(&temp_dir, None, Some(&skill_id))?;
                 let revision = git_fetcher::get_head_revision(&temp_dir).map_err(AppError::git)?;
                 let source_ref = format!("{}/{}", source, skill_id);
@@ -701,7 +701,7 @@ pub async fn install_from_skillssh(
                     &store,
                     &result,
                     &metadata,
-                    active.as_deref(),
+                    preset_ids.as_deref(),
                 )?;
                 Ok((new_id, skill_name))
             })();
@@ -815,6 +815,7 @@ pub async fn confirm_git_install(
     repo_url: String,
     temp_dir: String,
     items: Vec<SkillInstallItem>,
+    preset_ids: Option<Vec<String>>,
     store: State<'_, Arc<SkillStore>>,
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
@@ -831,9 +832,7 @@ pub async fn confirm_git_install(
             let skill_dir = resolve_skill_dir(&temp_path, parsed.subpath.as_deref(), None)?;
             let all_dirs = collect_git_skill_dirs(&skill_dir);
             let revision = git_fetcher::get_head_revision(&temp_path).map_err(AppError::git)?;
-            let active = store.get_active_scenario_id().ok().flatten();
-            let _lock = RepoLock::acquire("confirm git install")
-                .map_err(AppError::db)?;
+            let _lock = RepoLock::acquire("confirm git install").map_err(AppError::db)?;
 
             for dir in &all_dirs {
                 let rel_key = skill_rel_key(&skill_dir, dir);
@@ -860,7 +859,7 @@ pub async fn confirm_git_install(
                     remote_revision: Some(revision.clone()),
                     update_status: "up_to_date".to_string(),
                 };
-                store_installed_skill_unlocked(&store, &result, &metadata, active.as_deref())?;
+                store_installed_skill_unlocked(&store, &result, &metadata, preset_ids.as_deref())?;
             }
             Ok(())
         })();
@@ -1081,8 +1080,7 @@ pub async fn relink_local_skill_source(
             .map_err(AppError::db)?;
 
         let result = (|| -> Result<(), AppError> {
-            let _lock = RepoLock::acquire("relink local skill")
-                .map_err(AppError::db)?;
+            let _lock = RepoLock::acquire("relink local skill").map_err(AppError::db)?;
             let staged_path = staged_path_for(&skill.central_path);
             let install_result = installer::install_from_local_to_destination(
                 &path,
@@ -1142,8 +1140,7 @@ pub async fn detach_local_skill_source(
         }
 
         {
-            let _lock = RepoLock::acquire("detach local skill")
-                .map_err(AppError::db)?;
+            let _lock = RepoLock::acquire("detach local skill").map_err(AppError::db)?;
             store
                 .update_skill_after_reinstall(
                     &skill.id,
@@ -1225,7 +1222,10 @@ fn managed_skill_to_dto(
     }
 }
 
-pub fn managed_skill_by_id(store: &SkillStore, skill_id: &str) -> Result<ManagedSkillDto, AppError> {
+pub fn managed_skill_by_id(
+    store: &SkillStore,
+    skill_id: &str,
+) -> Result<ManagedSkillDto, AppError> {
     let skill = store
         .get_skill_by_id(skill_id)
         .map_err(AppError::db)?
@@ -1293,8 +1293,7 @@ pub fn update_git_skill_internal(
             crate::core::content_hash::hash_directory(&skill_dir).map_err(AppError::io)?;
         let content_changed = skill.content_hash.as_deref() != Some(new_hash.as_str());
         let source_subpath = git_fetcher::relative_subpath(&temp_dir, &skill_dir);
-        let _lock = RepoLock::acquire("update installed skill")
-            .map_err(AppError::db)?;
+        let _lock = RepoLock::acquire("update installed skill").map_err(AppError::db)?;
 
         if content_changed {
             let staged_path = staged_path_for(&skill.central_path);
@@ -1402,8 +1401,7 @@ pub fn reimport_local_skill_internal(
         .map_err(AppError::db)?;
 
     let result = (|| -> Result<(), AppError> {
-        let _lock = RepoLock::acquire("reimport local skill")
-            .map_err(AppError::db)?;
+        let _lock = RepoLock::acquire("reimport local skill").map_err(AppError::db)?;
         let staged_path = staged_path_for(&skill.central_path);
         let install_result =
             installer::install_from_local_to_destination(&path, Some(&skill.name), &staged_path)
@@ -1438,10 +1436,21 @@ pub fn store_installed_skill_unlocked(
     store: &SkillStore,
     result: &installer::InstallResult,
     metadata: &InstallSourceMetadata,
-    active_scenario_id: Option<&str>,
+    preset_ids: Option<&[String]>,
 ) -> Result<String, AppError> {
     let now = chrono::Utc::now().timestamp_millis();
     let central_path = result.central_path.to_string_lossy().to_string();
+
+    // If no explicit preset_ids, fall back to the active scenario (legacy behavior).
+    let p_ids: Vec<String> = match preset_ids {
+        Some(ids) => ids.to_vec(),
+        None => store
+            .get_active_scenario_id()
+            .ok()
+            .flatten()
+            .map(|id| vec![id])
+            .unwrap_or_default(),
+    };
 
     if let Some(existing) = store
         .get_skill_by_central_path(&central_path)
@@ -1463,20 +1472,17 @@ pub fn store_installed_skill_unlocked(
                 &metadata.update_status,
             )
             .map_err(AppError::db)?;
-        if let Some(scenario_id) = active_scenario_id {
-            store
-                .add_skill_to_scenario(scenario_id, &existing.id)
-                .map_err(AppError::db)?;
-        }
-        sync_metadata::write_all_from_db_unlocked(store).map_err(AppError::db)?;
-
-        if let Some(scenario_id) = active_scenario_id {
-            if let Err(e) =
-                super::presets::sync_skill_to_active_preset(store, scenario_id, &existing.id)
-            {
-                log::warn!("Failed to sync reinstalled skill to preset: {e}");
+        let current = store
+            .get_scenarios_for_skill(&existing.id)
+            .unwrap_or_default();
+        for sid in &p_ids {
+            if !current.contains(sid) {
+                store
+                    .add_skill_to_scenario(sid, &existing.id)
+                    .map_err(AppError::db)?;
             }
         }
+        sync_metadata::write_all_from_db_unlocked(store).map_err(AppError::db)?;
 
         return Ok(existing.id);
     }
@@ -1506,16 +1512,16 @@ pub fn store_installed_skill_unlocked(
     };
 
     store.insert_skill(&record).map_err(AppError::db)?;
-    if let Some(scenario_id) = active_scenario_id {
+    for sid in &p_ids {
         store
-            .add_skill_to_scenario(scenario_id, &id)
+            .add_skill_to_scenario(sid, &id)
             .map_err(AppError::db)?;
     }
     sync_metadata::write_all_from_db_unlocked(store).map_err(AppError::db)?;
 
-    if let Some(scenario_id) = active_scenario_id {
-        if let Err(e) = super::presets::sync_skill_to_active_preset(store, scenario_id, &id) {
-            log::warn!("Failed to sync newly installed skill to preset: {e}");
+    for sid in &p_ids {
+        if let Err(e) = super::presets::sync_skill_to_active_preset(store, sid, &id) {
+            log::warn!("Failed to sync newly installed skill to preset {sid}: {e}");
         }
     }
 
@@ -1937,6 +1943,7 @@ pub struct BatchImportResult {
 #[tauri::command]
 pub async fn batch_import_folder(
     folder_path: String,
+    preset_ids: Option<Vec<String>>,
     store: State<'_, Arc<SkillStore>>,
     app_handle: tauri::AppHandle,
 ) -> Result<BatchImportResult, AppError> {
@@ -1971,7 +1978,6 @@ pub async fn batch_import_folder(
         let mut imported = 0usize;
         let mut skipped = 0usize;
         let mut errors = Vec::new();
-        let active = store.get_active_scenario_id().ok().flatten();
 
         for (i, dir) in skill_dirs.iter().enumerate() {
             let name = skill_metadata::infer_skill_name(dir);
@@ -1991,10 +1997,11 @@ pub async fn batch_import_folder(
             let prospective_central = central_repo::skills_dir().join(&name);
             let central_str = prospective_central.to_string_lossy().to_string();
             if let Ok(Some(existing)) = store.get_skill_by_central_path(&central_str) {
-                if let Some(ref scenario_id) = active {
-                    if let Err(e) = store.add_skill_to_scenario(scenario_id, &existing.id) {
-                        errors.push(format!("{}: {}", name, e));
-                        continue;
+                if let Some(ref p_ids) = preset_ids {
+                    for sid in p_ids {
+                        if let Err(e) = store.add_skill_to_scenario(sid, &existing.id) {
+                            errors.push(format!("{}: {}", name, e));
+                        }
                     }
                 }
                 skipped += 1;
@@ -2002,8 +2009,7 @@ pub async fn batch_import_folder(
             }
 
             let install_result = (|| -> Result<String, AppError> {
-                let _lock = RepoLock::acquire("batch import skill")
-                    .map_err(AppError::db)?;
+                let _lock = RepoLock::acquire("batch import skill").map_err(AppError::db)?;
                 let result =
                     installer::install_from_local(dir, Some(&name)).map_err(AppError::io)?;
                 let metadata = InstallSourceMetadata {
@@ -2016,7 +2022,7 @@ pub async fn batch_import_folder(
                     remote_revision: None,
                     update_status: "local_only".to_string(),
                 };
-                store_installed_skill_unlocked(&store, &result, &metadata, active.as_deref())
+                store_installed_skill_unlocked(&store, &result, &metadata, preset_ids.as_deref())
             })();
 
             match install_result {
@@ -2168,7 +2174,11 @@ mod tests {
         let dir = root.join(rel);
         fs::create_dir_all(&dir).unwrap();
         let basename = dir.file_name().unwrap().to_string_lossy().to_string();
-        fs::write(dir.join("SKILL.md"), format!("---\nname: {basename}\n---\n")).unwrap();
+        fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {basename}\n---\n"),
+        )
+        .unwrap();
         dir
     }
 

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -3,11 +3,8 @@ use std::sync::Arc;
 use tauri::{AppHandle, State};
 
 use crate::core::{
-    error::AppError,
-    scenario_service,
-    skill_store::SkillStore,
-    sync_engine, sync_metadata, tool_adapters,
-    tool_service,
+    error::AppError, scenario_service, skill_store::SkillStore, sync_engine, sync_metadata,
+    tool_adapters, tool_service,
 };
 use serde::Serialize;
 

--- a/src-tauri/src/commands/tools.rs
+++ b/src-tauri/src/commands/tools.rs
@@ -13,9 +13,9 @@ use crate::core::sync_engine;
 use crate::core::timing::should_log_first_or_slow;
 use crate::core::tool_adapters::{self, CustomToolDef, ToolCategory};
 use crate::core::tool_service::{
-    self, ToolInfo, get_custom_tool_paths, get_custom_tools, get_disabled_tools, get_tool_order,
+    self, get_custom_tool_paths, get_custom_tools, get_disabled_tools, get_tool_order,
     normalize_project_relative_skills_dir_input, normalize_skills_dir_input, set_custom_tool_paths,
-    set_custom_tools, set_disabled_tools, set_tool_order,
+    set_custom_tools, set_disabled_tools, set_tool_order, ToolInfo,
 };
 
 #[derive(Debug, Serialize)]

--- a/src-tauri/src/core/central_repo.rs
+++ b/src-tauri/src/core/central_repo.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -185,7 +185,11 @@ pub fn external_base_dir(skills_root: &Path) -> PathBuf {
     let mut hasher = Sha256::new();
     hasher.update(canonical.to_string_lossy().as_bytes());
     let digest = hasher.finalize();
-    let short_hash: String = digest.iter().take(5).map(|b| format!("{:02x}", b)).collect();
+    let short_hash: String = digest
+        .iter()
+        .take(5)
+        .map(|b| format!("{:02x}", b))
+        .collect();
     default_base_dir()
         .join("external")
         .join(format!("{}-{}", sanitize_dir_name(name), short_hash))

--- a/src-tauri/src/core/git_fetcher.rs
+++ b/src-tauri/src/core/git_fetcher.rs
@@ -99,10 +99,7 @@ pub fn validate_git_url(url: &str) -> Result<()> {
 /// paths case-sensitively or distinguish schemes are unaffected.
 fn canonicalize_clone_url(url: &str) -> String {
     let trimmed = url.trim().trim_end_matches('/');
-    trimmed
-        .strip_suffix(".git")
-        .unwrap_or(trimmed)
-        .to_string()
+    trimmed.strip_suffix(".git").unwrap_or(trimmed).to_string()
 }
 
 /// Compute a stable cache directory name for a given clone URL. Hashes the
@@ -148,10 +145,7 @@ fn lock_repo_cache(
     Ok(RepoCacheLock { _file: file })
 }
 
-fn materialize_cached_repo(
-    cached: &Path,
-    cancel: Option<&Arc<AtomicBool>>,
-) -> Result<PathBuf> {
+fn materialize_cached_repo(cached: &Path, cancel: Option<&Arc<AtomicBool>>) -> Result<PathBuf> {
     let temp_dir =
         std::env::temp_dir().join(format!("{CLONE_TEMP_PREFIX}{}", uuid::Uuid::new_v4()));
 
@@ -824,7 +818,10 @@ fn split_tree_branch_path(path: &str, known_branches: &[String]) -> (String, Opt
 
     let mut parts = path.splitn(2, '/');
     let branch = parts.next().unwrap_or("").to_string();
-    let subpath = parts.next().filter(|s| !s.is_empty()).map(|s| s.to_string());
+    let subpath = parts
+        .next()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
     (branch, subpath)
 }
 

--- a/src-tauri/src/core/log_sanitize.rs
+++ b/src-tauri/src/core/log_sanitize.rs
@@ -48,8 +48,7 @@ fn other_rules() -> &'static [(Regex, &'static str)] {
             rules.push((re, "git@"));
         }
         // Generic bearer / token-like long hex/base64 strings (>=32)
-        if let Ok(re) = Regex::new(r"\b(?:gh[ps]_|sk-|xox[abprs]-|ghu_|ghr_)[A-Za-z0-9_\-]{16,}")
-        {
+        if let Ok(re) = Regex::new(r"\b(?:gh[ps]_|sk-|xox[abprs]-|ghu_|ghr_)[A-Za-z0-9_\-]{16,}") {
             rules.push((re, "<token>"));
         }
         // Email addresses

--- a/src-tauri/src/core/panic_log.rs
+++ b/src-tauri/src/core/panic_log.rs
@@ -39,9 +39,8 @@ pub fn install_panic_hook(app: AppHandle) {
             "<non-string panic payload>".to_string()
         };
 
-        let body = format!(
-            "[{timestamp}] PANIC at {location}\n{payload}\n\nBacktrace:\n{backtrace}\n"
-        );
+        let body =
+            format!("[{timestamp}] PANIC at {location}\n{payload}\n\nBacktrace:\n{backtrace}\n");
 
         log::error!("panic: {payload} at {location}");
 

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use super::{
     error::AppError,
     skill_store::{ScenarioRecord, SkillStore, SkillTargetRecord},
-    sync_engine, tool_adapters, tool_service,
+    sync_engine, sync_metadata, tool_adapters, tool_service,
 };
 
 #[derive(Debug, Clone)]
@@ -415,6 +415,29 @@ pub fn sync_skill_to_active_scenario(
         }
     }
     Ok(())
+}
+
+/// Find or create a preset named "Default" and return its ID.
+/// Used as the fallback target when no preset is explicitly chosen during install.
+pub fn ensure_default_preset(store: &SkillStore) -> Result<String, AppError> {
+    let scenarios = store.get_all_scenarios().map_err(AppError::db)?;
+    if let Some(existing) = scenarios.iter().find(|s| s.name == "Default") {
+        return Ok(existing.id.clone());
+    }
+    let now = chrono::Utc::now().timestamp_millis();
+    let id = uuid::Uuid::new_v4().to_string();
+    let record = ScenarioRecord {
+        id: id.clone(),
+        name: "Default".to_string(),
+        description: Some("Default preset".to_string()),
+        icon: None,
+        sort_order: 0,
+        created_at: now,
+        updated_at: now,
+    };
+    store.insert_scenario(&record).map_err(AppError::db)?;
+    sync_metadata::write_all_from_db_unlocked(store).map_err(AppError::db)?;
+    Ok(id)
 }
 
 pub fn ensure_default_startup_scenario(store: &SkillStore) -> Result<(), AppError> {

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -6,8 +6,7 @@ use std::time::Instant;
 use super::{
     error::AppError,
     skill_store::{ScenarioRecord, SkillStore, SkillTargetRecord},
-    sync_engine, tool_adapters,
-    tool_service,
+    sync_engine, tool_adapters, tool_service,
 };
 
 #[derive(Debug, Clone)]
@@ -82,7 +81,8 @@ pub fn collect_scenario_sync_targets(
     for skill in &skills {
         let source = PathBuf::from(&skill.central_path);
         let target_name = sync_engine::target_dir_name(&source, &skill.name);
-        let adapters = enabled_installed_adapters_for_scenario_skill(store, scenario_id, &skill.id)?;
+        let adapters =
+            enabled_installed_adapters_for_scenario_skill(store, scenario_id, &skill.id)?;
         for adapter in &adapters {
             let target = adapter.skills_dir().join(&target_name);
             let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
@@ -134,7 +134,10 @@ pub fn preview_scenario_sync(
 /// The reverse direction (existing `"symlink"`, desired `Copy`) returns
 /// `None` because the user actively changed the `sync_mode` setting and
 /// the on-disk symlink doesn't reflect that intent.
-fn skip_check_mode(existing_mode: &str, desired: sync_engine::SyncMode) -> Option<sync_engine::SyncMode> {
+fn skip_check_mode(
+    existing_mode: &str,
+    desired: sync_engine::SyncMode,
+) -> Option<sync_engine::SyncMode> {
     match (existing_mode, desired) {
         ("symlink", sync_engine::SyncMode::Symlink) => Some(sync_engine::SyncMode::Symlink),
         ("copy", sync_engine::SyncMode::Copy) => Some(sync_engine::SyncMode::Copy),
@@ -347,7 +350,9 @@ pub fn apply_scenario_to_default(store: &SkillStore, scenario_id: &str) -> Resul
         }
     }
 
-    store.set_active_scenario(scenario_id).map_err(AppError::db)?;
+    store
+        .set_active_scenario(scenario_id)
+        .map_err(AppError::db)?;
     sync_desired_targets(store, &desired_targets)
 }
 
@@ -358,7 +363,8 @@ pub fn sync_skill_to_active_scenario(
 ) -> Result<(), AppError> {
     if let Ok(Some(active_id)) = store.get_active_scenario_id() {
         if active_id == scenario_id {
-            let adapters = enabled_installed_adapters_for_scenario_skill(store, scenario_id, skill_id)?;
+            let adapters =
+                enabled_installed_adapters_for_scenario_skill(store, scenario_id, skill_id)?;
             let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
             let Ok(Some(skill)) = store.get_skill_by_id(skill_id) else {
                 return Ok(());
@@ -378,7 +384,8 @@ pub fn sync_skill_to_active_scenario(
                 }
 
                 let target = adapter.skills_dir().join(&target_name);
-                let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
+                let mode =
+                    sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
                 match sync_engine::sync_skill(&source, &target, mode) {
                     Ok(actual_mode) => {
                         let now = chrono::Utc::now().timestamp_millis();
@@ -423,7 +430,9 @@ pub fn ensure_default_startup_scenario(store: &SkillStore) -> Result<(), AppErro
             created_at: now,
             updated_at: now,
         };
-        store.insert_scenario(&default_scenario).map_err(AppError::db)?;
+        store
+            .insert_scenario(&default_scenario)
+            .map_err(AppError::db)?;
         scenarios.push(default_scenario);
     }
 
@@ -464,7 +473,9 @@ pub fn ensure_cli_scenario_state(store: &SkillStore) -> Result<(), AppError> {
             created_at: now,
             updated_at: now,
         };
-        store.insert_scenario(&default_scenario).map_err(AppError::db)?;
+        store
+            .insert_scenario(&default_scenario)
+            .map_err(AppError::db)?;
         scenarios.push(default_scenario);
     }
 
@@ -505,7 +516,8 @@ pub fn sync_active_scenario_to_tool(store: &SkillStore, tool_key: &str) {
             return;
         };
         for skill_id in skill_ids {
-            if let Ok(adapters) = enabled_installed_adapters_for_scenario_skill(store, &active_id, &skill_id)
+            if let Ok(adapters) =
+                enabled_installed_adapters_for_scenario_skill(store, &active_id, &skill_id)
             {
                 if adapters.iter().any(|adapter| adapter.key == tool_key) {
                     let _ = sync_skill_to_active_scenario(store, &active_id, &skill_id);
@@ -929,7 +941,10 @@ mod sync_desired_targets_tests {
         sync_desired_targets(&store, &desired).unwrap();
 
         // Sync must have run — target should now exist with the source content.
-        assert!(target.join("SKILL.md").exists(), "missing target was not re-synced");
+        assert!(
+            target.join("SKILL.md").exists(),
+            "missing target was not re-synced"
+        );
 
         central_repo::set_test_base_dir_override(None);
     }

--- a/src-tauri/src/core/skill_auto_updater.rs
+++ b/src-tauri/src/core/skill_auto_updater.rs
@@ -149,8 +149,7 @@ fn run_round_blocking(store: &SkillStore) -> Result<(), String> {
     // operation to a single skill's network round-trip (rather than the
     // entire round). A skill whose lock is busy — a manual install/update is
     // running — is simply skipped; the next scheduled round picks it up.
-    let (mut checked, mut available, mut updated, mut failed) =
-        (0usize, 0usize, 0usize, 0usize);
+    let (mut checked, mut available, mut updated, mut failed) = (0usize, 0usize, 0usize, 0usize);
     for skill_id in ids {
         checked += 1;
 

--- a/src-tauri/src/core/sync_metadata.rs
+++ b/src-tauri/src/core/sync_metadata.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
@@ -619,7 +619,7 @@ mod tests {
     use super::*;
     use crate::core::{central_repo, skill_store::SkillStore};
     use std::sync::MutexGuard;
-    use tempfile::{TempDir, tempdir};
+    use tempfile::{tempdir, TempDir};
 
     struct TestRepo {
         _lock: MutexGuard<'static, ()>,

--- a/src-tauri/src/core/tool_service.rs
+++ b/src-tauri/src/core/tool_service.rs
@@ -117,7 +117,10 @@ pub fn get_custom_tools(store: &SkillStore) -> Vec<CustomToolDef> {
     tool_adapters::custom_tools(store)
 }
 
-pub fn set_custom_tools(store: &SkillStore, custom_tools: &[CustomToolDef]) -> Result<(), AppError> {
+pub fn set_custom_tools(
+    store: &SkillStore,
+    custom_tools: &[CustomToolDef],
+) -> Result<(), AppError> {
     let json = serde_json::to_string(custom_tools)
         .map_err(|e| AppError::internal(format!("Failed to serialize: {e}")))?;
     store
@@ -203,7 +206,8 @@ pub fn list_tool_info(store: &SkillStore) -> Vec<ToolInfo> {
     let all_keys: Vec<String> = infos.iter().map(|i| i.key.clone()).collect();
     let ordered_keys = merge_order(&saved, &all_keys);
 
-    let mut by_key: HashMap<String, ToolInfo> = infos.into_iter().map(|i| (i.key.clone(), i)).collect();
+    let mut by_key: HashMap<String, ToolInfo> =
+        infos.into_iter().map(|i| (i.key.clone(), i)).collect();
     ordered_keys
         .into_iter()
         .filter_map(|k| by_key.remove(&k))
@@ -287,7 +291,11 @@ pub fn migrate_legacy_tool_keys(store: &SkillStore) -> Result<(), AppError> {
         set_custom_tools(store, &normalized_customs)?;
     }
 
-    if changed || store.has_tool_key_references(OLD_KEY).map_err(AppError::db)? {
+    if changed
+        || store
+            .has_tool_key_references(OLD_KEY)
+            .map_err(AppError::db)?
+    {
         store
             .remap_tool_key_references(OLD_KEY, NEW_KEY)
             .map_err(AppError::db)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -206,8 +206,16 @@ fn collect_tray_menu_data(store: &core::skill_store::SkillStore) -> TrayMenuData
 }
 
 fn format_status_line(data: &TrayMenuData) -> String {
-    let skill_label = if data.total_skills == 1 { "skill" } else { "skills" };
-    let agent_label = if data.coding_agent_count == 1 { "agent" } else { "agents" };
+    let skill_label = if data.total_skills == 1 {
+        "skill"
+    } else {
+        "skills"
+    };
+    let agent_label = if data.coding_agent_count == 1 {
+        "agent"
+    } else {
+        "agents"
+    };
     format!(
         "{} {} · {} {} connected",
         data.total_skills, skill_label, data.coding_agent_count, agent_label
@@ -241,7 +249,11 @@ fn preset_menu_item_id(preset: &TrayPresetEntry) -> (String, &'static str) {
 }
 
 fn preset_menu_label(preset: &TrayPresetEntry) -> String {
-    let unit = if preset.skill_count == 1 { "skill" } else { "skills" };
+    let unit = if preset.skill_count == 1 {
+        "skill"
+    } else {
+        "skills"
+    };
     match preset.status() {
         TrayPresetStatus::Active => format!("✓ {} ({} {unit})", preset.name, preset.skill_count),
         TrayPresetStatus::Partial => format!(
@@ -557,7 +569,9 @@ fn check_updates_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
                 {
                     Ok(lock) => lock,
                     Err(err) => {
-                        log::warn!("Tray update check: failed to acquire repo lock for {skill_id}: {err}");
+                        log::warn!(
+                            "Tray update check: failed to acquire repo lock for {skill_id}: {err}"
+                        );
                         continue;
                     }
                 };
@@ -620,7 +634,8 @@ fn open_skills_folder_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
 
         let status = cmd.arg(&repo_path).status();
         match status {
-            Ok(_status) => {
+            Ok(_status) =>
+            {
                 #[cfg(not(target_os = "windows"))]
                 if !_status.success() {
                     log::warn!(
@@ -985,6 +1000,7 @@ pub fn run() {
             commands::presets::apply_preset_to_coding_agents,
             commands::presets::add_skill_to_preset,
             commands::presets::remove_skill_from_preset,
+            commands::presets::set_skill_presets,
             commands::presets::reorder_presets,
             commands::projects::reorder_projects,
             commands::presets::get_preset_skill_order,

--- a/src/components/CreatePresetDialog.tsx
+++ b/src/components/CreatePresetDialog.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { cn } from "../utils";
 import { PRESET_ICON_OPTIONS } from "../lib/presetIcons";
+import { getErrorMessage } from "../lib/error";
 
 interface Props {
   open: boolean;
@@ -28,6 +30,8 @@ export function CreatePresetDialog({ open, onClose, onCreate }: Props) {
       setDescription("");
       setIcon(PRESET_ICON_OPTIONS[0].key);
       onClose();
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("preset.createError")));
     } finally {
       setLoading(false);
     }

--- a/src/components/SkillDetailPanel.tsx
+++ b/src/components/SkillDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Folder,
   ChevronDown,
@@ -6,13 +6,18 @@ import {
   Github,
   HardDrive,
   Globe,
+  Check,
+  Plus,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { cn } from "../utils";
 import {
   getSkillDocument,
   getSourceSkillDocument,
+  setSkillPresets,
   type ManagedSkill,
+  type Preset,
   type Project,
   type SkillDocument,
   type SourceSkillDocument,
@@ -25,6 +30,7 @@ import { SkillMarkdown } from "./SkillMarkdown";
 import { AgentToggleSection, type AgentToggleItem } from "./AgentToggleSection";
 import { SkillProjectsSection } from "./SkillProjectsSection";
 import { SyncDots } from "./SyncDots";
+import { getErrorMessage } from "../lib/error";
 
 interface Props {
   skill: ManagedSkill | null;
@@ -35,6 +41,8 @@ interface Props {
   onToggleTool?: (tool: string, enabled: boolean) => void;
   projects?: Project[];
   onProjectsChanged?: () => void;
+  presets?: Preset[];
+  onRefresh?: () => void;
 }
 
 export function SkillDetailPanel({
@@ -46,6 +54,8 @@ export function SkillDetailPanel({
   onToggleTool,
   projects,
   onProjectsChanged,
+  presets,
+  onRefresh,
 }: Props) {
   if (!skill) return null;
 
@@ -69,6 +79,8 @@ export function SkillDetailPanel({
       onToggleTool={onToggleTool}
       projects={projects}
       onProjectsChanged={onProjectsChanged}
+      presets={presets}
+      onRefresh={onRefresh}
     />
   );
 }
@@ -82,6 +94,8 @@ function SkillDetailPanelContent({
   onToggleTool,
   projects,
   onProjectsChanged,
+  presets,
+  onRefresh,
 }: {
   skill: ManagedSkill;
   onClose: () => void;
@@ -91,6 +105,8 @@ function SkillDetailPanelContent({
   onToggleTool?: (tool: string, enabled: boolean) => void;
   projects?: Project[];
   onProjectsChanged?: () => void;
+  presets?: Preset[];
+  onRefresh?: () => void;
 }) {
   const { t } = useTranslation();
   const [doc, setDoc] = useState<SkillDocument | null>(null);
@@ -101,6 +117,26 @@ function SkillDetailPanelContent({
   const localRequestIdRef = useRef(0);
   const sourceRequestIdRef = useRef(0);
   const skillId = skill.id;
+  const [presetToggleId, setPresetToggleId] = useState<string | null>(null);
+
+  const handleTogglePreset = useCallback(async (presetId: string) => {
+    if (presetToggleId) return;
+    setPresetToggleId(presetId);
+    try {
+      const currentPresets = skill.preset_ids;
+      const nextPresets = currentPresets.includes(presetId)
+        ? currentPresets.filter((id) => id !== presetId)
+        : [...currentPresets, presetId];
+      await setSkillPresets(skill.id, nextPresets);
+      toast.success(currentPresets.includes(presetId) ? t("presetSelector.removed") : t("presetSelector.added"));
+      onRefresh?.();
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("presetSelector.error")));
+    } finally {
+      setPresetToggleId(null);
+    }
+  }, [skill.id, skill.preset_ids, presetToggleId, onRefresh]);
+
   const supportsSourceDiff =
     skill.source_type === "git"
     || skill.source_type === "skillssh"
@@ -227,6 +263,34 @@ function SkillDetailPanelContent({
           {skill.central_path}
         </span>
       </div>
+      {presets && presets.length > 0 && (
+        <div className="mt-4 rounded-xl border border-border-subtle bg-surface/70 px-4 py-3">
+          <div className="mb-2 text-[13px] font-semibold text-secondary">{t("presetSelector.title")}</div>
+          <div className="flex flex-wrap gap-2">
+            {presets.map((preset) => {
+              const enabled = skill.preset_ids.includes(preset.id);
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => handleTogglePreset(preset.id)}
+                  disabled={presetToggleId === preset.id}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[13px] font-medium transition-colors",
+                    enabled
+                      ? "bg-accent text-white"
+                      : "border border-border-subtle bg-bg-secondary text-muted hover:text-secondary"
+                  )}
+                >
+                  {enabled ? <Check className="h-3 w-3" /> : <Plus className="h-3 w-3" />}
+                  {preset.icon && <span>{preset.icon}</span>}
+                  {preset.name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
       {metadataItems.length > 0 && (
         <div className="mt-4 rounded-xl border border-border-subtle bg-surface/70">
           <button

--- a/src/components/SkillDetailPanel.tsx
+++ b/src/components/SkillDetailPanel.tsx
@@ -24,6 +24,7 @@ import {
   type SkillToolToggle,
   type ToolInfo,
 } from "../lib/tauri";
+import { getPresetIconOption } from "../lib/presetIcons";
 import { DocumentDiffViewer } from "./DocumentDiffViewer";
 import { DetailSheet } from "./DetailSheet";
 import { SkillMarkdown } from "./SkillMarkdown";
@@ -269,6 +270,7 @@ function SkillDetailPanelContent({
           <div className="flex flex-wrap gap-2">
             {presets.map((preset) => {
               const enabled = skill.preset_ids.includes(preset.id);
+              const PresetIcon = getPresetIconOption(preset).icon;
               return (
                 <button
                   key={preset.id}
@@ -283,7 +285,7 @@ function SkillDetailPanelContent({
                   )}
                 >
                   {enabled ? <Check className="h-3 w-3" /> : <Plus className="h-3 w-3" />}
-                  {preset.icon && <span>{preset.icon}</span>}
+                  <PresetIcon className="h-3.5 w-3.5" />
                   {preset.name}
                 </button>
               );

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -658,6 +658,7 @@
     "renamed": "Preset renamed",
     "deleted": "Preset deleted",
     "created": "Preset created",
+    "createError": "Failed to create preset",
     "switched": "Switched to \"{{name}}\""
   },
   "project": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -79,6 +79,14 @@
     "installNew": "Install New Skills",
     "recentActivity": "Recent Activity"
   },
+  "presetSelector": {
+    "title": "Presets",
+    "assignTo": "Assign to presets:",
+    "none": "None",
+    "added": "Added to preset",
+    "removed": "Removed from preset",
+    "error": "Error updating presets"
+  },
   "mySkills": {
     "title": "Library",
     "applyToDefault": "Apply Preset",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -658,6 +658,7 @@
     "renamed": "Preset 已重命名",
     "deleted": "Preset 已删除",
     "created": "Preset 已创建",
+    "createError": "创建 Preset 失败",
     "switched": "已切换到 \"{{name}}\""
   },
   "project": {

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -79,6 +79,14 @@
     "installNew": "安装新 Skills",
     "recentActivity": "近期动态"
   },
+  "presetSelector": {
+    "title": "预设",
+    "assignTo": "分配到预设：",
+    "none": "无",
+    "added": "已添加到预设",
+    "removed": "已从预设移除",
+    "error": "更新预设失败"
+  },
   "mySkills": {
     "title": "技能库",
     "applyToDefault": "应用 Preset",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -231,11 +231,11 @@ export interface BatchDeleteSkillsResult {
 export const deleteManagedSkills = (skillIds: string[]) =>
   invoke<BatchDeleteSkillsResult>("delete_managed_skills", { skillIds });
 
-export const installLocal = (sourcePath: string, name?: string) =>
-  invoke<void>("install_local", { sourcePath, name: name || null });
+export const installLocal = (sourcePath: string, name?: string, presetIds?: string[]) =>
+  invoke<void>("install_local", { sourcePath, name: name || null, presetIds: presetIds ?? null });
 
-export const installGit = (repoUrl: string, name?: string) =>
-  invoke<void>("install_git", { repoUrl, name: name || null });
+export const installGit = (repoUrl: string, name?: string, presetIds?: string[]) =>
+  invoke<void>("install_git", { repoUrl, name: name || null, presetIds: presetIds ?? null });
 
 export interface GitSkillPreview {
   /** Path relative to the resolved scan root, using `/` separators. Stable key. */
@@ -257,14 +257,14 @@ export interface SkillInstallItem {
 export const previewGitInstall = (repoUrl: string) =>
   invoke<GitPreviewResult>("preview_git_install", { repoUrl });
 
-export const confirmGitInstall = (repoUrl: string, tempDir: string, items: SkillInstallItem[]) =>
-  invoke<void>("confirm_git_install", { repoUrl, tempDir, items });
+export const confirmGitInstall = (repoUrl: string, tempDir: string, items: SkillInstallItem[], presetIds?: string[]) =>
+  invoke<void>("confirm_git_install", { repoUrl, tempDir, items, presetIds: presetIds ?? null });
 
 export const cancelGitPreview = (tempDir: string) =>
   invoke<void>("cancel_git_preview", { tempDir });
 
-export const installFromSkillssh = (source: string, skillId: string) =>
-  invoke<void>("install_from_skillssh", { source, skillId });
+export const installFromSkillssh = (source: string, skillId: string, presetIds?: string[]) =>
+  invoke<void>("install_from_skillssh", { source, skillId, presetIds: presetIds ?? null });
 
 export const cancelInstall = (key: string) =>
   invoke<boolean>("cancel_install", { key });
@@ -313,8 +313,8 @@ export interface BatchImportResult {
   errors: string[];
 }
 
-export const batchImportFolder = (folderPath: string) =>
-  invoke<BatchImportResult>("batch_import_folder", { folderPath });
+export const batchImportFolder = (folderPath: string, presetIds?: string[]) =>
+  invoke<BatchImportResult>("batch_import_folder", { folderPath, presetIds: presetIds ?? null });
 
 export const getAllTags = () => invoke<string[]>("get_all_tags");
 
@@ -563,6 +563,9 @@ export const getPresetSkillOrder = (presetId: string) =>
 
 export const reorderPresetSkills = (presetId: string, skillIds: string[]) =>
   invoke<void>("reorder_preset_skills", { presetId, skillIds });
+
+export const setSkillPresets = (skillId: string, presetIds: string[]) =>
+  invoke<void>("set_skill_presets", { skillId, presetIds });
 
 // ── Projects ──
 

--- a/src/views/InstallSkills.tsx
+++ b/src/views/InstallSkills.tsx
@@ -29,7 +29,6 @@ import { cn } from "../utils";
 import { useApp } from "../context/AppContext";
 import * as api from "../lib/tauri";
 import type { ScanResult, SkillsShSkill, BatchImportResult, GitPreviewResult } from "../lib/tauri";
-import { getPresetIconOption } from "../lib/presetIcons";
 import { open } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useSearchParams, useNavigate } from "react-router-dom";
@@ -48,6 +47,8 @@ export function InstallSkills() {
   const { presets, refreshPresets, refreshManagedSkills, managedSkills, openSkillDetailById } = useApp();
   const [installPresetIds, setInstallPresetIds] = useState<string[]>([]);
   const installPresetTouched = useRef(false);
+  const getInstallPresetIds = () =>
+    installPresetTouched.current && installPresetIds.length > 0 ? installPresetIds : undefined;
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState<"market" | "local" | "git">("market");
@@ -300,7 +301,7 @@ export function InstallSkills() {
     const name = sourcePath.split("/").pop() || sourcePath;
     const toastId = toast.loading(t("install.toast.installing", { name }));
     try {
-      await api.installLocal(sourcePath, undefined, installPresetTouched.current ? installPresetIds : undefined);
+      await api.installLocal(sourcePath, undefined, getInstallPresetIds());
     } catch (e) {
       const message = getErrorMessage(e, t("common.error"));
       setLocalError(message);
@@ -378,7 +379,7 @@ export function InstallSkills() {
 
       const result: BatchImportResult = await api.batchImportFolder(
         selected as string,
-        installPresetTouched.current ? installPresetIds : undefined
+        getInstallPresetIds()
       );
 
       if (result.errors.length > 0) {
@@ -439,7 +440,7 @@ export function InstallSkills() {
           }
         }
       );
-      await api.installFromSkillssh(skill.source, skill.skill_id, installPresetTouched.current ? installPresetIds : undefined);
+      await api.installFromSkillssh(skill.source, skill.skill_id, getInstallPresetIds());
       await Promise.all([refreshPresets(), refreshManagedSkills()]);
       toast.success(t("install.toast.success", { name: displayName }), {
         id: toastId,
@@ -534,7 +535,7 @@ export function InstallSkills() {
         repoUrl,
         gitPreview.temp_dir,
         selected.map((s) => ({ rel_path: s.rel_path, name: s.name })),
-        installPresetTouched.current ? installPresetIds : undefined
+        getInstallPresetIds()
       );
       await Promise.all([refreshPresets(), refreshManagedSkills()]);
       toast.success(t("install.toast.success", { name: selected.map((s) => s.name).join(", ") }));
@@ -754,21 +755,8 @@ export function InstallSkills() {
       {presets.length > 0 && (
         <div className="flex flex-wrap items-center gap-2 px-1 pb-2">
           <span className="text-[13px] font-medium text-tertiary">{t("presetSelector.assignTo")}</span>
-          <button
-            type="button"
-            onClick={() => { installPresetTouched.current = true; setInstallPresetIds([]); }}
-            className={cn(
-              "rounded-full px-2.5 py-1 text-[13px] font-medium transition-colors",
-              installPresetIds.length === 0
-                ? "bg-accent text-white"
-                : "bg-surface-hover text-muted hover:text-secondary"
-            )}
-          >
-            {t("presetSelector.none")}
-          </button>
           {presets.map((preset) => {
             const enabled = installPresetIds.includes(preset.id);
-            const PresetIcon = getPresetIconOption(preset).icon;
             return (
               <button
                 key={preset.id}
@@ -788,7 +776,6 @@ export function InstallSkills() {
                     : "bg-surface-hover text-muted hover:text-secondary"
                 )}
               >
-                <PresetIcon className="mr-1 h-3.5 w-3.5" />
                 {preset.name}
               </button>
             );

--- a/src/views/InstallSkills.tsx
+++ b/src/views/InstallSkills.tsx
@@ -29,6 +29,7 @@ import { cn } from "../utils";
 import { useApp } from "../context/AppContext";
 import * as api from "../lib/tauri";
 import type { ScanResult, SkillsShSkill, BatchImportResult, GitPreviewResult } from "../lib/tauri";
+import { getPresetIconOption } from "../lib/presetIcons";
 import { open } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useSearchParams, useNavigate } from "react-router-dom";
@@ -46,6 +47,7 @@ export function InstallSkills() {
   const { t } = useTranslation();
   const { presets, refreshPresets, refreshManagedSkills, managedSkills, openSkillDetailById } = useApp();
   const [installPresetIds, setInstallPresetIds] = useState<string[]>([]);
+  const installPresetTouched = useRef(false);
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState<"market" | "local" | "git">("market");
@@ -298,7 +300,7 @@ export function InstallSkills() {
     const name = sourcePath.split("/").pop() || sourcePath;
     const toastId = toast.loading(t("install.toast.installing", { name }));
     try {
-      await api.installLocal(sourcePath, undefined, installPresetIds.length > 0 ? installPresetIds : undefined);
+      await api.installLocal(sourcePath, undefined, installPresetTouched.current ? installPresetIds : undefined);
     } catch (e) {
       const message = getErrorMessage(e, t("common.error"));
       setLocalError(message);
@@ -376,7 +378,7 @@ export function InstallSkills() {
 
       const result: BatchImportResult = await api.batchImportFolder(
         selected as string,
-        installPresetIds.length > 0 ? installPresetIds : undefined
+        installPresetTouched.current ? installPresetIds : undefined
       );
 
       if (result.errors.length > 0) {
@@ -437,7 +439,7 @@ export function InstallSkills() {
           }
         }
       );
-      await api.installFromSkillssh(skill.source, skill.skill_id, installPresetIds.length > 0 ? installPresetIds : undefined);
+      await api.installFromSkillssh(skill.source, skill.skill_id, installPresetTouched.current ? installPresetIds : undefined);
       await Promise.all([refreshPresets(), refreshManagedSkills()]);
       toast.success(t("install.toast.success", { name: displayName }), {
         id: toastId,
@@ -532,7 +534,7 @@ export function InstallSkills() {
         repoUrl,
         gitPreview.temp_dir,
         selected.map((s) => ({ rel_path: s.rel_path, name: s.name })),
-        installPresetIds.length > 0 ? installPresetIds : undefined
+        installPresetTouched.current ? installPresetIds : undefined
       );
       await Promise.all([refreshPresets(), refreshManagedSkills()]);
       toast.success(t("install.toast.success", { name: selected.map((s) => s.name).join(", ") }));
@@ -754,7 +756,7 @@ export function InstallSkills() {
           <span className="text-[13px] font-medium text-tertiary">{t("presetSelector.assignTo")}</span>
           <button
             type="button"
-            onClick={() => setInstallPresetIds([])}
+            onClick={() => { installPresetTouched.current = true; setInstallPresetIds([]); }}
             className={cn(
               "rounded-full px-2.5 py-1 text-[13px] font-medium transition-colors",
               installPresetIds.length === 0
@@ -766,11 +768,13 @@ export function InstallSkills() {
           </button>
           {presets.map((preset) => {
             const enabled = installPresetIds.includes(preset.id);
+            const PresetIcon = getPresetIconOption(preset).icon;
             return (
               <button
                 key={preset.id}
                 type="button"
                 onClick={() => {
+                  installPresetTouched.current = true;
                   setInstallPresetIds((prev) =>
                     prev.includes(preset.id)
                       ? prev.filter((id) => id !== preset.id)
@@ -784,7 +788,7 @@ export function InstallSkills() {
                     : "bg-surface-hover text-muted hover:text-secondary"
                 )}
               >
-                {preset.icon && <span className="mr-1">{preset.icon}</span>}
+                <PresetIcon className="mr-1 h-3.5 w-3.5" />
                 {preset.name}
               </button>
             );

--- a/src/views/InstallSkills.tsx
+++ b/src/views/InstallSkills.tsx
@@ -44,7 +44,8 @@ const MARKET_SEARCH_CACHE_MAX_ENTRIES = 150;
 
 export function InstallSkills() {
   const { t } = useTranslation();
-  const { refreshPresets, refreshManagedSkills, managedSkills, openSkillDetailById } = useApp();
+  const { presets, refreshPresets, refreshManagedSkills, managedSkills, openSkillDetailById } = useApp();
+  const [installPresetIds, setInstallPresetIds] = useState<string[]>([]);
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState<"market" | "local" | "git">("market");
@@ -297,7 +298,7 @@ export function InstallSkills() {
     const name = sourcePath.split("/").pop() || sourcePath;
     const toastId = toast.loading(t("install.toast.installing", { name }));
     try {
-      await api.installLocal(sourcePath);
+      await api.installLocal(sourcePath, undefined, installPresetIds.length > 0 ? installPresetIds : undefined);
     } catch (e) {
       const message = getErrorMessage(e, t("common.error"));
       setLocalError(message);
@@ -374,7 +375,8 @@ export function InstallSkills() {
       );
 
       const result: BatchImportResult = await api.batchImportFolder(
-        selected as string
+        selected as string,
+        installPresetIds.length > 0 ? installPresetIds : undefined
       );
 
       if (result.errors.length > 0) {
@@ -435,7 +437,7 @@ export function InstallSkills() {
           }
         }
       );
-      await api.installFromSkillssh(skill.source, skill.skill_id);
+      await api.installFromSkillssh(skill.source, skill.skill_id, installPresetIds.length > 0 ? installPresetIds : undefined);
       await Promise.all([refreshPresets(), refreshManagedSkills()]);
       toast.success(t("install.toast.success", { name: displayName }), {
         id: toastId,
@@ -529,7 +531,8 @@ export function InstallSkills() {
       await api.confirmGitInstall(
         repoUrl,
         gitPreview.temp_dir,
-        selected.map((s) => ({ rel_path: s.rel_path, name: s.name }))
+        selected.map((s) => ({ rel_path: s.rel_path, name: s.name })),
+        installPresetIds.length > 0 ? installPresetIds : undefined
       );
       await Promise.all([refreshPresets(), refreshManagedSkills()]);
       toast.success(t("install.toast.success", { name: selected.map((s) => s.name).join(", ") }));
@@ -745,6 +748,49 @@ export function InstallSkills() {
           })}
         </div>
       </div>
+
+      {presets.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 px-1 pb-2">
+          <span className="text-[13px] font-medium text-tertiary">{t("presetSelector.assignTo")}</span>
+          <button
+            type="button"
+            onClick={() => setInstallPresetIds([])}
+            className={cn(
+              "rounded-full px-2.5 py-1 text-[13px] font-medium transition-colors",
+              installPresetIds.length === 0
+                ? "bg-accent text-white"
+                : "bg-surface-hover text-muted hover:text-secondary"
+            )}
+          >
+            {t("presetSelector.none")}
+          </button>
+          {presets.map((preset) => {
+            const enabled = installPresetIds.includes(preset.id);
+            return (
+              <button
+                key={preset.id}
+                type="button"
+                onClick={() => {
+                  setInstallPresetIds((prev) =>
+                    prev.includes(preset.id)
+                      ? prev.filter((id) => id !== preset.id)
+                      : [...prev, preset.id]
+                  );
+                }}
+                className={cn(
+                  "rounded-full px-2.5 py-1 text-[13px] font-medium transition-colors",
+                  enabled
+                    ? "bg-accent text-white"
+                    : "bg-surface-hover text-muted hover:text-secondary"
+                )}
+              >
+                {preset.icon && <span className="mr-1">{preset.icon}</span>}
+                {preset.name}
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       {activeTab === "market" && (
         <div className="animate-in fade-in duration-300">

--- a/src/views/MySkills.tsx
+++ b/src/views/MySkills.tsx
@@ -128,6 +128,7 @@ export function MySkills() {
   const { t } = useTranslation();
   const {
     viewedPreset,
+    presets,
     tools,
     managedSkills: skills,
     refreshPresets,
@@ -1879,6 +1880,8 @@ export function MySkills() {
         onToggleTool={handleToggleSkillTool}
         projects={projects}
         onProjectsChanged={refreshProjects}
+        presets={presets}
+        onRefresh={refreshManagedSkills}
       />
 
       <ConfirmDialog

--- a/src/views/MySkills.tsx
+++ b/src/views/MySkills.tsx
@@ -172,7 +172,11 @@ export function MySkills() {
 
   const [presetSkillOrder, setPresetSkillOrder] = useState<string[]>([]);
 
-  const viewedPresetName = viewedPreset?.name || t("mySkills.currentPresetFallback");
+  const presetNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of presets) map.set(p.id, p.name);
+    return map;
+  }, [presets]);
 
   // Fetch sort order whenever active preset changes
   useEffect(() => {
@@ -1680,12 +1684,17 @@ export function MySkills() {
                         {sourceIcon(skill.source_type)}
                         {sourceTypeLabel(skill)}
                       </span>
-                      {enabledInPreset && (
+                      {skill.preset_ids.length > 0 ? (
                         <>
                           <span className="text-faint">·</span>
                           <span className="truncate text-[13px] font-medium text-amber-600 dark:text-amber-400/80">
-                            {viewedPresetName}
+                            {skill.preset_ids.map((id) => presetNameMap.get(id)).filter(Boolean).join(", ")}
                           </span>
+                        </>
+                      ) : (
+                        <>
+                          <span className="text-faint">·</span>
+                          <span className="truncate text-[13px] text-faint">None</span>
                         </>
                       )}
                     </div>
@@ -1798,10 +1807,12 @@ export function MySkills() {
                     {sourceIcon(skill.source_type)}
                     {sourceTypeLabel(skill)}
                   </span>
-                  {enabledInPreset && (
+                  {skill.preset_ids.length > 0 ? (
                     <span className="text-[13px] font-medium text-amber-600 dark:text-amber-400/80">
-                      {viewedPresetName}
+                      {skill.preset_ids.map((id) => presetNameMap.get(id)).filter(Boolean).join(", ")}
                     </span>
+                  ) : (
+                    <span className="text-[13px] text-faint">None</span>
                   )}
                 </div>
 


### PR DESCRIPTION
## Summary

Allow users to select which **preset(s)** a skill belongs to — both when *installing* and when *viewing* it in the library. Previously, new skills were always added to the active preset and there was no UI to change a skill's preset membership outside the current preset context.

## Changes

### Backend (Rust)
- **`commands/presets.rs`**: Added `set_skill_presets` command to batch-replace a skill's preset memberships. Added duplicate preset name check in `create_preset`. Removed auto-activation when creating a new preset.
- **`commands/skills.rs`**: All install commands (`install_local`, `install_git`, `install_from_skillssh`, `confirm_git_install`, `batch_import_folder`) now accept an optional `preset_ids` parameter. When not provided, falls back to the `Default` preset (auto-created if missing).
- **`core/scenario_service.rs`**: Added `ensure_default_preset` helper to find or create a preset named `Default`.
- **`lib.rs`**: Registered the new `set_skill_presets` command.

### Frontend (TypeScript/React)
- **`SkillDetailPanel.tsx`**: Added a preset selector showing all presets as toggle buttons. Click to add/remove the skill from that preset.
- **`InstallSkills.tsx`**: Added a preset pill row above all install tabs. Users can select multiple presets to assign newly installed skills to. Defaults to `Default` preset when untouched.
- **`MySkills.tsx`**: Library skill cards now show all preset names the skill belongs to (or `None`), instead of only the viewed preset.
- **`lib/tauri.ts`**: Updated API wrappers for install functions and added `setSkillPresets`.
- **`i18n/en.json` + `zh.json`**: Added translation keys for preset selector.

### Fixes
- No longer automatically syncs/activates a newly created preset.
- `None` selection no longer falls back to active preset — proper ref tracking distinguishes user intent from default.
- Library cards display proper preset names instead of icon key strings.

## Testing
Builds clean with no warnings.