### PR TITLE
fix: improve project name visibility with many agents

### DIFF
--- a/src/components/SkillProjectsSection.tsx
+++ b/src/components/SkillProjectsSection.tsx
@@ -232,26 +232,28 @@ export function SkillProjectsSection({ skill, projects, onChanged }: Props) {
                 row?.state === "installed" && "border-emerald-500/30 bg-emerald-500/5",
               )}
             >
-              <div className="flex min-w-0 items-center gap-2">
-                <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted" />
-                <span className="min-w-0 flex-1 truncate font-medium text-secondary" title={project.name}>
-                  {project.name}
-                </span>
-                {!row || row.state === "loading" ? (
-                  <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-faint" />
-                ) : row.state === "error" ? (
-                  <span
-                    className="shrink-0 text-rose-500"
-                    title={row.error || t("common.error")}
-                  >
-                    {t("common.error")}
+              <div className="flex min-w-0 flex-col gap-1.5">
+                <div className="flex min-w-0 items-center gap-2">
+                  <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted" />
+                  <span className="min-w-0 flex-1 truncate font-medium text-secondary" title={project.name}>
+                    {project.name}
                   </span>
-                ) : (
-                  <>
-                    <div className="flex shrink-0 flex-wrap justify-end gap-1.5">
-                      {activeTargets.length === 0 ? (
-                        <span className="text-[12px] text-muted">{t("addFromLibrary.status.unavailable")}</span>
-                      ) : activeTargets.map((target) => {
+                  {!row || row.state === "loading" ? (
+                    <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-faint" />
+                  ) : row.state === "error" ? (
+                    <span
+                      className="shrink-0 text-rose-500"
+                      title={row.error || t("common.error")}
+                    >
+                      {t("common.error")}
+                    </span>
+                  ) : null}
+                </div>
+                {row && row.state !== "loading" && row.state !== "error" && (
+                  <div className="flex min-w-0 flex-wrap justify-end gap-1.5">
+                    {activeTargets.length === 0 ? (
+                      <span className="text-[12px] text-muted">{t("addFromLibrary.status.unavailable")}</span>
+                    ) : activeTargets.map((target) => {
                         const agentState = getAgentState(row, target);
                         const agentPending = pendingKey === `${project.id}:${target.key}`;
                         const label =
@@ -305,7 +307,6 @@ export function SkillProjectsSection({ skill, projects, onChanged }: Props) {
                         );
                       })}
                     </div>
-                  </>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary
Improve project name visibility in the skill project target list by restructuring each project row so labels and status chips remain readable when many agents are shown.

## Context
When a project had many agent targets, the row layout caused the project name and status area to compete for horizontal space, making project names harder to scan and reducing clarity in the installation matrix.

## Changes
- Reworked the project row container to a two-line layout.
- Kept project name and loading/error indicator on the first line.
- Moved target availability/action chips into a dedicated second line with wrapping behavior.
- Preserved existing target state logic and action handling while improving visual hierarchy.

### Key Implementation Details
The row was changed from a single horizontal flex layout to a vertical stack (`flex-col`). The first inner row keeps the folder icon, truncated project name, and loading/error state. The second row now renders only when state is ready, and wraps target chips independently, preventing the project title from being pushed out.

## Use Cases
- Users can identify project names faster when many agent targets are active.
- Long or crowded target lists no longer reduce readability of the primary project label.
- Error/loading states remain visible without collapsing action target visibility.

## Testing
```bash
npm run build
```

Build completed successfully.

## Links
- Related issue: https://github.com/xingkongliang/skills-manager/issues/188
