### PR TITLE
fix(project): restrict preset exports to enabled agents

### DIFF
--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -1,6 +1,6 @@
 use std::path::{Component, Path, PathBuf};
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 
 use serde::Serialize;
@@ -945,13 +945,33 @@ pub async fn export_skill_to_project(
         ensure_safe_skill_relative_path(&dir_name)?;
 
         let source = PathBuf::from(&skill.central_path);
-        let agent_keys = agents.filter(|items| !items.is_empty()).unwrap_or_else(|| {
+        let requested_agent_keys = agents.filter(|items| !items.is_empty()).unwrap_or_else(|| {
             if project.workspace_type == "linked" {
                 vec![linked_workspace_agent_key(&project)]
             } else {
                 vec!["claude_code".to_string()]
             }
         });
+        let agent_keys = if project.workspace_type == "linked" {
+            requested_agent_keys
+        } else {
+            let available_targets: std::collections::HashSet<String> =
+                project_agent_targets_for_record(&store, &project)
+                    .into_iter()
+                    .filter(|target| target.installed && target.enabled)
+                    .map(|target| target.key)
+                    .collect();
+            let filtered = requested_agent_keys
+                .into_iter()
+                .filter(|key| available_targets.contains(key))
+                .collect::<Vec<_>>();
+            if filtered.is_empty() {
+                return Err(AppError::invalid_input(
+                    "No enabled installed agents selected for this project",
+                ));
+            }
+            filtered
+        };
 
         for agent_key in &agent_keys {
             let (skills_root, disabled_root) =

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -276,8 +276,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
         },
       }
     );
-  // SKILL_UPDATE_TOAST_ID is a stable string constant defined in the component.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Check skill updates on startup (non-blocking, silent). When the user has

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -62,7 +62,8 @@ interface ProjectSkillGroup {
 }
 
 function getDefaultExportAgents(targets: ProjectAgentTarget[], savedValue?: string | null) {
-  const availableKeys = new Set(targets.map((target) => target.key));
+  const enabledTargets = targets.filter((target) => target.installed && target.enabled);
+  const availableKeys = new Set(enabledTargets.map((target) => target.key));
   if (savedValue) {
     try {
       const parsed = JSON.parse(savedValue);
@@ -78,7 +79,7 @@ function getDefaultExportAgents(targets: ProjectAgentTarget[], savedValue?: stri
   }
 
   const prioritized = PROJECT_EXPORT_AGENT_PRIORITY.filter((key) => availableKeys.has(key));
-  const fallback = targets.map((target) => target.key);
+  const fallback = enabledTargets.map((target) => target.key);
   return Array.from(new Set((prioritized.length > 0 ? prioritized : fallback).slice(0, 3)));
 }
 
@@ -436,6 +437,15 @@ export function ProjectDetail() {
     }
     return selectedExportAgents.filter((k) => availableKeys.has(k));
   }, [exportTargets, lastUsedExportAgents, selectedExportAgents]);
+
+  const presetBarAgentKeys = useMemo(() => {
+    const availableKeys = new Set(
+      exportTargets
+        .filter((target) => target.installed && target.enabled)
+        .map((target) => target.key)
+    );
+    return selectedExportAgents.filter((key) => availableKeys.has(key));
+  }, [exportTargets, selectedExportAgents]);
 
   const enabledCount = groupedSkills.filter((s) => s.enabledCount > 0).length;
   const allTags = useMemo(() => {
@@ -982,11 +992,11 @@ export function ProjectDetail() {
         )}
 
         {/* Preset bar */}
-        {presets.length > 0 && selectedExportAgents.length > 0 && (
+        {presets.length > 0 && presetBarAgentKeys.length > 0 && (
           <PresetBar
             presets={presets}
             managedSkills={managedSkills}
-            agentKeys={selectedExportAgents}
+            agentKeys={presetBarAgentKeys}
             existsInWorkspace={presetSkillExistsInProject}
             onAddSkill={handleAddPresetSkillToProject}
             onRemoveSkill={handleRemovePresetSkillFromProject}


### PR DESCRIPTION
## 问题

项目预设的应用流程没有遵守编码代理的启用状态。

一个可复现的场景是：

1. 禁用除 OpenCode 之外的所有编码代理。
2. 配置一个包含技能的预设。
3. 在应用中打开一个项目工作区。
4. 在项目视图中点击该预设。

预期行为：预设只会为已启用且已安装的项目代理安装技能。因此在这个场景中，只有 OpenCode 应该收到项目本地技能。

实际行为：预设安装路径仍然会以已禁用的代理为目标，例如 Claude、Cursor 和 Antigravity，从而为用户已经明确禁用的代理创建项目本地技能目录。

## 根本原因

显式的“添加技能”面板已经会把项目目标过滤为已安装且已启用的代理，但项目预设栏没有应用同样的可用性约束。

预设栏接收到的是 `selectedExportAgents`，其中可能包含已经过期的或默认的代理 key，而这些代理当前并未启用。后端的 `export_skill_to_project` 命令也信任传入的代理列表，导致行为不一致，并且很难诊断。

## 解决方案

这个改动让项目预设导出使用与显式添加项目技能相同的可用性模型：

- 从满足 `installed && enabled` 的项目目标中派生预设栏代理 key。
- 仅当至少还存在一个当前可用目标时才渲染项目预设栏。
- 只把可用代理 key 传给 `PresetBar`，防止过期的 UI 状态指向已禁用的代理。
- 强化普通项目工作区中的 `export_skill_to_project`，根据已启用且已安装的项目目标过滤传入的代理。
- 当普通项目工作区中没有任何请求的代理可用时返回错误，而不是静默报告成功。
- 保留关联工作区的行为，因为它使用自己的关联目标模型。
- 移除一个过期的 eslint 抑制注释；在 ESLint 可用后，该注释会导致 lint 失败。

## 验证

已运行：

- `npm run lint`
- `npm run build`
- `cargo check`
- `rustfmt --edition 2024 --check src/commands/projects.rs`

说明：

- `npm run build` 已完成，只出现现有的 Vite chunk 大小警告。
- 为了补齐本地缺失的依赖曾运行 `npm ci`，它报告了已有的 audit 问题，但没有修改任何已跟踪文件。

## 用户影响

修复后，在项目工作区中应用预设时，技能只会安装到同时满足已安装和已启用条件的编码代理。已禁用的代理不会再通过预设操作收到项目本地技能。

---

## Problem

Project preset application did not respect the coding-agent enablement state.

A reproducible case was:

1. Disable all coding agents except OpenCode.
2. Configure a preset with skills.
3. Open a project workspace in the app.
4. Click the preset in the project view.

Expected behavior: the preset installs skills only for enabled and installed project agents, so in this case only OpenCode should receive project-local skills.

Actual behavior: the preset install path still targeted disabled agents such as Claude, Cursor, and Antigravity, creating project-local skill folders for agents the user had explicitly disabled.

## Root Cause

The explicit add-skills sheet already filtered project targets to installed and enabled agents, but the project preset bar did not apply the same availability constraint.

The preset bar received `selectedExportAgents`, which could include stale or default agent keys that were not currently enabled. The backend `export_skill_to_project` command also trusted the requested agent list, making the behavior inconsistent and hard to diagnose.

## Solution

This change makes project preset exports use the same availability model as explicit project skill adds:

- Derive preset-bar agent keys from project targets where `installed && enabled`.
- Render the project preset bar only when at least one currently available target remains.
- Pass only available agent keys into `PresetBar`, preventing stale UI state from targeting disabled agents.
- Harden `export_skill_to_project` for normal project workspaces by filtering requested agents against enabled installed project targets.
- Return an error when no requested normal project agents are available instead of reporting a silent success.
- Preserve linked workspace behavior, which uses its own linked target model.
- Remove a stale eslint suppression that caused lint to fail once ESLint was available.

## Verification

Ran:

- `npm run lint`
- `npm run build`
- `cargo check`
- `rustfmt --edition 2024 --check src/commands/projects.rs`

Notes:

- `npm run build` completed with the existing Vite chunk-size warning.
- `npm ci` reported existing audit findings while installing missing local dependencies, but did not change tracked files.

## User Impact

After this fix, applying a preset in a project workspace only installs skills for coding agents that are both installed and enabled for that project. Disabled agents no longer receive project-local skills from preset actions.
