### PR TITLE
fix(repo-lock): wait for repo lock on foreground ops instead of failing fast

### DIFF
--- a/src-tauri/src/bin/skills-manager-cli.rs
+++ b/src-tauri/src/bin/skills-manager-cli.rs
@@ -796,7 +796,7 @@ fn install_local_action(
         bail!("local path does not exist: {}", path.display());
     }
 
-    let _lock = RepoLock::acquire("cli install local")?;
+    let _lock = RepoLock::acquire_foreground("cli install local")?;
     let result = installer::install_from_local(&path, name)?;
     let metadata = cmd::InstallSourceMetadata {
         source_type: "local".to_string(),
@@ -833,7 +833,7 @@ fn install_git_action(
         proxy_url.as_deref(),
     )?;
     let result = (|| -> anyhow::Result<(String, String, String)> {
-        let _lock = RepoLock::acquire("cli install git")?;
+        let _lock = RepoLock::acquire_foreground("cli install git")?;
         let skill_dir =
             cmd::resolve_skill_dir(&temp_dir, parsed.subpath.as_deref(), None).map_err(map_app_err)?;
         let revision = git_fetcher::get_head_revision(&temp_dir)?;
@@ -871,7 +871,7 @@ fn install_skillssh_action(
     let cancel = Arc::new(AtomicBool::new(false));
     let temp_dir = git_fetcher::clone_repo_ref(&repo_url, None, Some(&cancel), proxy_url.as_deref())?;
     let result = (|| -> anyhow::Result<(String, String, String)> {
-        let _lock = RepoLock::acquire("cli install skillssh")?;
+        let _lock = RepoLock::acquire_foreground("cli install skillssh")?;
         let skill_dir =
             cmd::resolve_skill_dir(&temp_dir, None, Some(&skill_id_field)).map_err(map_app_err)?;
         let revision = git_fetcher::get_head_revision(&temp_dir)?;
@@ -1387,7 +1387,7 @@ fn run_adopt(
     let mut adopted = Vec::new();
     for c in &candidates {
         let dir = PathBuf::from(&c.path);
-        let _lock = RepoLock::acquire("cli adopt")?;
+        let _lock = RepoLock::acquire_foreground("cli adopt")?;
         let result = installer::install_from_local(&dir, None)?;
         let metadata = if let Some((clone_url, subpath, branch, original_url)) = &resolved_git {
             cmd::InstallSourceMetadata {

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -720,7 +720,7 @@ pub async fn install_local(
                 remote_revision: None,
                 update_status: "local_only".to_string(),
             };
-            let _lock = RepoLock::acquire("install local skill").map_err(AppError::db)?;
+            let _lock = RepoLock::acquire_foreground("install local skill").map_err(AppError::db)?;
             let result =
                 installer::install_from_local(&path, name.as_deref()).map_err(AppError::io)?;
             let skill_name = result.name.clone();
@@ -794,7 +794,7 @@ pub async fn install_git(
 
             emit_progress("installing");
             let install_result = (|| -> Result<(String, String), AppError> {
-                let _lock = RepoLock::acquire("install git skill").map_err(AppError::db)?;
+                let _lock = RepoLock::acquire_foreground("install git skill").map_err(AppError::db)?;
                 let skill_dir = resolve_skill_dir(&temp_dir, parsed.subpath.as_deref(), None)?;
                 let revision = git_fetcher::get_head_revision(&temp_dir).map_err(AppError::git)?;
                 let result = installer::install_from_git_dir(&skill_dir, name.as_deref())
@@ -890,7 +890,7 @@ pub async fn install_from_skillssh(
 
             emit_progress("installing");
             let install_result = (|| -> Result<(String, String), AppError> {
-                let _lock = RepoLock::acquire("install skillssh skill").map_err(AppError::db)?;
+                let _lock = RepoLock::acquire_foreground("install skillssh skill").map_err(AppError::db)?;
                 let skill_dir = resolve_skill_dir(&temp_dir, None, Some(&skill_id))?;
                 let revision = git_fetcher::get_head_revision(&temp_dir).map_err(AppError::git)?;
                 let source_ref = format!("{}/{}", source, skill_id);
@@ -1047,7 +1047,7 @@ pub async fn confirm_git_install(
             let skill_dir = resolve_skill_dir(&temp_path, parsed.subpath.as_deref(), None)?;
             let all_dirs = collect_git_skill_dirs(&skill_dir);
             let revision = git_fetcher::get_head_revision(&temp_path).map_err(AppError::git)?;
-            let _lock = RepoLock::acquire("confirm git install")
+            let _lock = RepoLock::acquire_foreground("confirm git install")
                 .map_err(AppError::db)?;
 
             for dir in &all_dirs {
@@ -1108,7 +1108,7 @@ pub async fn check_skill_update(
     let store = store.inner().clone();
     let proxy_url = store.proxy_url();
     tauri::async_runtime::spawn_blocking(move || {
-        let _lock = RepoLock::acquire("check skill update").map_err(AppError::db)?;
+        let _lock = RepoLock::acquire_foreground("check skill update").map_err(AppError::db)?;
         check_skill_update_internal(
             &store,
             &skill_id,
@@ -1296,7 +1296,7 @@ pub async fn relink_local_skill_source(
             .map_err(AppError::db)?;
 
         let result = (|| -> Result<(), AppError> {
-            let _lock = RepoLock::acquire("relink local skill")
+            let _lock = RepoLock::acquire_foreground("relink local skill")
                 .map_err(AppError::db)?;
             let staged_path = staged_path_for(&skill.central_path);
             let install_result = installer::install_from_local_to_destination(
@@ -1357,7 +1357,7 @@ pub async fn detach_local_skill_source(
         }
 
         {
-            let _lock = RepoLock::acquire("detach local skill")
+            let _lock = RepoLock::acquire_foreground("detach local skill")
                 .map_err(AppError::db)?;
             store
                 .update_skill_after_reinstall(
@@ -1508,7 +1508,7 @@ pub fn update_git_skill_internal(
             crate::core::content_hash::hash_directory(&skill_dir).map_err(AppError::io)?;
         let content_changed = skill.content_hash.as_deref() != Some(new_hash.as_str());
         let source_subpath = git_fetcher::relative_subpath(&temp_dir, &skill_dir);
-        let _lock = RepoLock::acquire("update installed skill")
+        let _lock = RepoLock::acquire_foreground("update installed skill")
             .map_err(AppError::db)?;
 
         if content_changed {
@@ -1617,7 +1617,7 @@ pub fn reimport_local_skill_internal(
         .map_err(AppError::db)?;
 
     let result = (|| -> Result<(), AppError> {
-        let _lock = RepoLock::acquire("reimport local skill")
+        let _lock = RepoLock::acquire_foreground("reimport local skill")
             .map_err(AppError::db)?;
         let staged_path = staged_path_for(&skill.central_path);
         let install_result =
@@ -2210,7 +2210,7 @@ pub async fn batch_import_folder(
             }
 
             let install_result = (|| -> Result<String, AppError> {
-                let _lock = RepoLock::acquire("batch import skill")
+                let _lock = RepoLock::acquire_foreground("batch import skill")
                     .map_err(AppError::db)?;
                 let result =
                     installer::install_from_local(dir, Some(&name)).map_err(AppError::io)?;

--- a/src-tauri/src/core/git_backup.rs
+++ b/src-tauri/src/core/git_backup.rs
@@ -168,7 +168,7 @@ fn detect_upstream_health(dir: &Path, has_remote: bool) -> String {
 /// Initialize a new git repository in the skills directory.
 #[allow(dead_code)]
 pub fn init_repo(skills_dir: &Path) -> Result<()> {
-    let _lock = RepoLock::acquire("git init")?;
+    let _lock = RepoLock::acquire_foreground("git init")?;
     init_repo_unlocked(skills_dir)
 }
 
@@ -195,7 +195,7 @@ pub(crate) fn init_repo_unlocked(skills_dir: &Path) -> Result<()> {
 
 /// Set (or update) the remote origin URL.
 pub fn set_remote(skills_dir: &Path, url: &str) -> Result<()> {
-    let _lock = RepoLock::acquire("git set remote")?;
+    let _lock = RepoLock::acquire_foreground("git set remote")?;
     set_remote_unlocked(skills_dir, url)
 }
 
@@ -240,7 +240,7 @@ pub(crate) fn set_remote_unlocked(skills_dir: &Path, url: &str) -> Result<()> {
 /// Stage all changes and create a commit.
 #[allow(dead_code)]
 pub fn commit_all(skills_dir: &Path, message: &str) -> Result<()> {
-    let _lock = RepoLock::acquire("git commit")?;
+    let _lock = RepoLock::acquire_foreground("git commit")?;
     commit_all_unlocked(skills_dir, message)
 }
 
@@ -264,7 +264,7 @@ pub(crate) fn commit_all_unlocked(skills_dir: &Path, message: &str) -> Result<()
 
 /// Push to the remote repository.
 pub fn push(skills_dir: &Path) -> Result<()> {
-    let _lock = RepoLock::acquire("git push")?;
+    let _lock = RepoLock::acquire_foreground("git push")?;
     push_unlocked(skills_dir)
 }
 
@@ -334,7 +334,7 @@ pub(crate) fn push_unlocked(skills_dir: &Path) -> Result<()> {
 /// Pull from the remote repository.
 #[allow(dead_code)]
 pub fn pull(skills_dir: &Path) -> Result<()> {
-    let _lock = RepoLock::acquire("git pull")?;
+    let _lock = RepoLock::acquire_foreground("git pull")?;
     pull_unlocked(skills_dir)
 }
 
@@ -363,7 +363,7 @@ pub(crate) fn pull_unlocked(skills_dir: &Path) -> Result<()> {
 
 /// Create an annotated snapshot tag on current HEAD.
 pub fn create_snapshot_tag(skills_dir: &Path) -> Result<String> {
-    let _lock = RepoLock::acquire("git snapshot")?;
+    let _lock = RepoLock::acquire_foreground("git snapshot")?;
     create_snapshot_tag_unlocked(skills_dir)
 }
 
@@ -454,7 +454,7 @@ pub fn list_snapshot_versions(
 /// Restore skills files to a snapshot tag by creating a new restore commit.
 #[allow(dead_code)]
 pub fn restore_snapshot_version(skills_dir: &Path, tag: &str) -> Result<()> {
-    let _lock = RepoLock::acquire("git restore snapshot")?;
+    let _lock = RepoLock::acquire_foreground("git restore snapshot")?;
     restore_snapshot_version_unlocked(skills_dir, tag)
 }
 
@@ -529,7 +529,7 @@ pub(crate) fn restore_snapshot_version_unlocked(skills_dir: &Path, tag: &str) ->
 /// The skills directory must be empty or non-existent.
 #[allow(dead_code)]
 pub fn clone_into(skills_dir: &Path, url: &str) -> Result<()> {
-    let _lock = RepoLock::acquire("git clone")?;
+    let _lock = RepoLock::acquire_foreground("git clone")?;
     clone_into_unlocked(skills_dir, url)
 }
 
@@ -542,7 +542,7 @@ pub fn clone_into(skills_dir: &Path, url: &str) -> Result<()> {
 /// skills-manager process attempting to populate the target between check
 /// and clone is serialized.
 pub fn clone_into_strict(skills_dir: &Path, url: &str) -> Result<()> {
-    let _lock = RepoLock::acquire("git clone")?;
+    let _lock = RepoLock::acquire_foreground("git clone")?;
     ensure_clean_clone_target(skills_dir)?;
     clone_into_unlocked(skills_dir, url)
 }
@@ -758,11 +758,14 @@ fn ensure_gitignore(skills_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Runs `f` while holding the central-repo lock. Used by the user-initiated
+/// backup commands (init/commit/pull/clone/reclone/restore), so we wait out
+/// transient contention with background work instead of failing fast.
 pub(crate) fn with_repo_lock<T, F>(operation: &str, f: F) -> Result<T>
 where
     F: FnOnce() -> Result<T>,
 {
-    let _lock = RepoLock::acquire(operation)?;
+    let _lock = RepoLock::acquire_foreground(operation)?;
     f()
 }
 

--- a/src-tauri/src/core/repo_lock.rs
+++ b/src-tauri/src/core/repo_lock.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use fs2::FileExt;
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
+use std::time::{Duration, Instant};
 
 use super::central_repo;
 
@@ -14,25 +15,69 @@ use super::central_repo;
 /// see issue #99 (os error 5 / "Access is denied").
 const LOCK_FILE_NAME: &str = ".skills-manager.lock";
 
+/// How long a user-initiated ("foreground") operation waits for the central
+/// repository lock before giving up with a "busy" error. Background work holds
+/// the lock only briefly per skill, but an auto-backup `git push` can hold it
+/// for ~10–15s, so we wait comfortably longer than the longest expected
+/// background hold. Without this wait, a foreground install/update/tag/delete
+/// that happened to collide with a background update check or backup failed
+/// instantly with "skills repository is busy" (issues #196, #220, #232).
+pub const FOREGROUND_WAIT: Duration = Duration::from_secs(20);
+
+/// Poll cadence while waiting for the lock. Kept below the yield the background
+/// per-skill loops insert between releases (see `skill_auto_updater` and the
+/// tray check) so a waiting foreground op reliably wins the lock during that
+/// window instead of being starved by the background re-acquiring immediately.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
 pub struct RepoLock {
     file: File,
 }
 
 impl RepoLock {
+    /// Acquire the lock, failing immediately if it is already held. Used by
+    /// background loops that prefer to skip a unit of work and retry on the
+    /// next round rather than block a user-initiated operation.
     pub fn acquire(operation: &str) -> Result<Self> {
-        let base = central_repo::base_dir();
-        std::fs::create_dir_all(&base)?;
-        let lock_path = base.join(LOCK_FILE_NAME);
-        let mut file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .open(&lock_path)
-            .with_context(|| format!("failed to open repo lock {}", lock_path.display()))?;
-
+        let file = open_lock_file()?;
         file.try_lock_exclusive()
             .with_context(|| format!("skills repository is busy: {operation}"))?;
+        Self::stamp(file, operation)
+    }
 
+    /// Acquire the lock, waiting up to `timeout` for a concurrent holder to
+    /// release it before reporting the repository as busy. Used by
+    /// user-initiated operations so transient contention with background work
+    /// (update checks, auto-backup) surfaces as a short wait, not an error.
+    pub fn acquire_blocking(operation: &str, timeout: Duration) -> Result<Self> {
+        let file = open_lock_file()?;
+        let start = Instant::now();
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(()) => return Self::stamp(file, operation),
+                // Retry on any error (not just `WouldBlock`): on Windows
+                // `LockFileEx` reports contention as `ERROR_LOCK_VIOLATION`,
+                // which does not map to `ErrorKind::WouldBlock`, so gating on
+                // the kind would defeat the wait on the very platform that
+                // needs it most.
+                Err(err) => {
+                    if start.elapsed() >= timeout {
+                        return Err(err).with_context(|| {
+                            format!("skills repository is busy: {operation}")
+                        });
+                    }
+                    std::thread::sleep(POLL_INTERVAL);
+                }
+            }
+        }
+    }
+
+    /// Convenience for user-initiated operations: wait up to [`FOREGROUND_WAIT`].
+    pub fn acquire_foreground(operation: &str) -> Result<Self> {
+        Self::acquire_blocking(operation, FOREGROUND_WAIT)
+    }
+
+    fn stamp(mut file: File, operation: &str) -> Result<Self> {
         file.set_len(0)?;
         file.seek(SeekFrom::Start(0))?;
         writeln!(
@@ -46,9 +91,20 @@ impl RepoLock {
             chrono::Utc::now().to_rfc3339()
         )?;
         file.sync_all()?;
-
         Ok(Self { file })
     }
+}
+
+fn open_lock_file() -> Result<File> {
+    let base = central_repo::base_dir();
+    std::fs::create_dir_all(&base)?;
+    let lock_path = base.join(LOCK_FILE_NAME);
+    OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open repo lock {}", lock_path.display()))
 }
 
 impl Drop for RepoLock {
@@ -88,6 +144,36 @@ mod tests {
         );
 
         drop(lock);
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    /// A blocking acquire must report "busy" only after waiting roughly the
+    /// requested timeout while another holder keeps the lock, and must succeed
+    /// once that holder releases. This is the behaviour foreground operations
+    /// rely on to ride out transient contention with background work.
+    #[test]
+    fn blocking_acquire_waits_then_times_out_and_recovers() {
+        let _guard = central_repo::test_base_dir_lock();
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("base");
+        central_repo::set_test_base_dir_override(Some(base));
+
+        let held = RepoLock::acquire("holder").unwrap();
+
+        let start = Instant::now();
+        let busy = RepoLock::acquire_blocking("waiter", Duration::from_millis(300));
+        assert!(busy.is_err(), "should time out while the lock is held");
+        assert!(
+            start.elapsed() >= Duration::from_millis(250),
+            "should have waited close to the timeout, waited {:?}",
+            start.elapsed()
+        );
+
+        drop(held);
+        let recovered = RepoLock::acquire_blocking("waiter", Duration::from_millis(300));
+        assert!(recovered.is_ok(), "should acquire once the holder releases");
+        drop(recovered);
+
         central_repo::set_test_base_dir_override(None);
     }
 }

--- a/src-tauri/src/core/skill_auto_updater.rs
+++ b/src-tauri/src/core/skill_auto_updater.rs
@@ -25,6 +25,13 @@ const INITIAL_DELAY: Duration = Duration::from_secs(60);
 /// a changed interval setting takes effect.
 const POLL_INTERVAL: Duration = Duration::from_secs(15 * 60);
 
+/// Brief pause between per-skill checks. Each check holds the central-repo lock
+/// for a network round-trip; without a gap, this loop re-acquires the lock so
+/// quickly that a waiting user-initiated operation can be starved for the whole
+/// round. The pause must exceed the foreground poll cadence in `repo_lock`
+/// (50ms) so a foreground waiter reliably wins the lock during the gap.
+const FOREGROUND_YIELD: Duration = Duration::from_millis(200);
+
 #[derive(Serialize, Clone)]
 struct AutoUpdatePayload {
     ran_at: String,
@@ -152,6 +159,9 @@ fn run_round_blocking(store: &SkillStore) -> Result<(), String> {
     let (mut checked, mut available, mut updated, mut failed) =
         (0usize, 0usize, 0usize, 0usize);
     for skill_id in ids {
+        // Yield the lock to any waiting user-initiated operation before taking
+        // it again for the next skill (see FOREGROUND_YIELD).
+        std::thread::sleep(FOREGROUND_YIELD);
         checked += 1;
 
         // The check holds the repo lock; it must be released before applying,

--- a/src-tauri/src/core/sync_metadata.rs
+++ b/src-tauri/src/core/sync_metadata.rs
@@ -78,15 +78,20 @@ pub fn has_complete_skill_snapshot() -> bool {
 
 #[allow(dead_code)]
 pub fn write_all_from_db(store: &SkillStore) -> Result<()> {
-    let _lock = RepoLock::acquire("write sync metadata")?;
+    // Foreground wait: this runs at startup and from CLI preset/enable
+    // commands, which must succeed (startup aborts on error), not skip.
+    let _lock = RepoLock::acquire_foreground("write sync metadata")?;
     write_all_from_db_unlocked(store)
 }
 
+/// Runs `f` while holding the central-repo lock. Callers are user-initiated
+/// operations (set tags, delete, preset edits, imports), so we wait out
+/// transient contention with background work instead of failing fast.
 pub(crate) fn with_repo_lock<T, F>(operation: &str, f: F) -> Result<T>
 where
     F: FnOnce() -> Result<T>,
 {
-    let _lock = RepoLock::acquire(operation)?;
+    let _lock = RepoLock::acquire_foreground(operation)?;
     f()
 }
 
@@ -101,7 +106,9 @@ pub(crate) fn write_all_from_db_unlocked(store: &SkillStore) -> Result<()> {
 
 #[allow(dead_code)]
 pub fn reindex_from_metadata(store: &SkillStore) -> Result<()> {
-    let _lock = RepoLock::acquire("reindex sync metadata")?;
+    // Foreground wait: runs at process startup (GUI and every CLI invocation),
+    // which aborts on error — better to wait out transient contention than fail.
+    let _lock = RepoLock::acquire_foreground("reindex sync metadata")?;
     reindex_from_metadata_unlocked(store)
 }
 
@@ -208,7 +215,9 @@ pub(crate) fn reindex_from_metadata_unlocked(store: &SkillStore) -> Result<()> {
 
 #[allow(dead_code)]
 pub fn ensure_skill_metadata(store: &SkillStore, skill_id: &str) -> Result<()> {
-    let _lock = RepoLock::acquire("write skill metadata")?;
+    // Foreground wait: the CLI `tag` commands flush metadata here after a DB
+    // write; they should ride out contention rather than fail fast.
+    let _lock = RepoLock::acquire_foreground("write skill metadata")?;
     ensure_skill_metadata_unlocked(store, skill_id)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -553,6 +553,10 @@ fn check_updates_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
                 .map(|skill| skill.id)
                 .collect();
             for skill_id in ids {
+                // Yield the lock between checks so a waiting user-initiated
+                // operation isn't starved by this loop re-acquiring it
+                // immediately (mirrors the auto-updater's FOREGROUND_YIELD).
+                std::thread::sleep(std::time::Duration::from_millis(200));
                 let _repo_lock = match core::repo_lock::RepoLock::acquire("tray check skill update")
                 {
                     Ok(lock) => lock,


### PR DESCRIPTION
## Problem

The central-repo write lock used fail-fast `try_lock_exclusive`, so any
user-initiated operation (install/update/tag/delete, CLI commands, and process
startup) instantly errored with `skills repository is busy` whenever a
background task (auto-update check, tray check, auto-backup `git push`) briefly
held the lock. Reported in #196, #220, #232.

## Fix

Apply one rule consistently: **background skip-and-retry loops stay fail-fast;
every user-initiated or startup path waits.**

- `repo_lock`: add `acquire_blocking` / `acquire_foreground` (poll every 50ms up
  to `FOREGROUND_WAIT=20s`); keep `acquire()` fail-fast.
- Route all foreground GUI commands, `git_backup` leaf fns, CLI commands, and
  startup metadata paths (`reindex_from_metadata` / `write_all_from_db` /
  `ensure_skill_metadata`) through `acquire_foreground`. Startup previously
  *aborted* on a busy lock — waiting is strictly more robust.
- Yield 200ms between per-skill checks in the auto-updater and tray loops so a
  waiting foreground op wins the lock instead of being starved.
- Only the background polling loops remain fail-fast: auto-updater, tray check,
  `check_all_skill_updates`.

## Validation

- New regression test in `repo_lock.rs`; `cargo test --lib` → 272 passed.
- `cargo check --bins` clean, no new clippy warnings.
- Reviewed across 3 Codex passes (GUI commands, git_backup leaves, CLI/startup);
  final pass found no blocker/should-fix/nit and confirmed no startup
  self-deadlock and no nested CLI lock.

Refs #196, #220, #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)