### PR TITLE
fix: align Kimi adapter with official Kimi Code CLI skill paths

### DIFF
--- a/src-tauri/src/core/tool_adapters.rs
+++ b/src-tauri/src/core/tool_adapters.rs
@@ -409,14 +409,14 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
         ToolAdapter {
             key: "kimi".into(),
             display_name: "Kimi Code CLI".into(),
-            relative_skills_dir: ".config/agents/skills".into(),
-            relative_detect_dir: ".kimi".into(),
+            relative_skills_dir: ".kimi-code/skills".into(),
+            relative_detect_dir: ".kimi-code".into(),
             additional_scan_dirs: vec![],
             override_skills_dir: None,
             category: ToolCategory::Coding,
             is_custom: false,
             recursive_scan: false,
-            project_relative_skills_dir: None,
+            project_relative_skills_dir: Some(".kimi-code/skills".into()),
         },
         ToolAdapter {
             key: "replit".into(),

--- a/src/views/WorkspaceView.tsx
+++ b/src/views/WorkspaceView.tsx
@@ -130,7 +130,7 @@ function WorkspaceSkillCard({
   return (
     <div
       className={cn(
-        "app-panel group relative flex h-full cursor-pointer flex-col overflow-hidden transition-all hover:border-border hover:bg-surface-hover",
+        "app-panel group relative flex min-h-[120px] cursor-pointer flex-col overflow-hidden transition-all hover:border-border hover:bg-surface-hover",
         active && "border-l-2 border-l-accent"
       )}
       onClick={onClick}
@@ -892,7 +892,7 @@ export function WorkspaceView({ config }: { config: WorkspaceConfig }) {
           className={cn(
             "pb-8",
             viewMode === "grid"
-              ? "grid grid-cols-2 gap-3 lg:grid-cols-3"
+              ? "grid auto-rows-fr grid-cols-2 gap-3 lg:grid-cols-3"
               : "flex flex-col gap-0.5"
           )}
         >


### PR DESCRIPTION
Kimi Code CLI scans ~/.kimi-code/skills/ and <project>/.kimi-code/skills/ as brand-specific paths per its scanner.ts. The previous .config/agents/skills path is not referenced by Kimi and caused skills synced by Skills Manager to be invisible.

Changes:
- Set Kimi global relative_skills_dir to .kimi-code/skills
- Set Kimi project_relative_skills_dir to .kimi-code/skills
- Set Kimi relative_detect_dir to .kimi-code so Skills Manager recognizes Kimi Code CLI as installed when ~/.kimi-code exists

Tested locally:
- npm run cli -- tools list reports ~/.kimi-code/skills for Kimi and installed: true
- Synced 62 skills appear in ~/.kimi-code/skills/ via skills sync --tool kimi
- Project-level export to .kimi-code/skills/ works

Co-Authored-By: Claude <noreply@anthropic.com>