### PR TITLE
fix(sync): honor sync_mode in project workspace and local-skill updates (#225, #202)

### DIFF
--- a/src-tauri/src/commands/agent_workspace.rs
+++ b/src-tauri/src/commands/agent_workspace.rs
@@ -452,8 +452,9 @@ fn update_agent_local_skill_from_center(
     ensure_agent_skill_path(&target_path, &skills_root)?;
 
     let source = PathBuf::from(&managed.central_path);
-    sync_engine::sync_skill(&source, &target_path, sync_engine::SyncMode::Copy)
-        .map_err(AppError::io)?;
+    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+    let mode = sync_engine::sync_mode_for_tool(agent, configured_mode.as_deref());
+    sync_engine::sync_skill(&source, &target_path, mode).map_err(AppError::io)?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -996,13 +996,14 @@ pub async fn export_skill_to_project(
             }
         }
 
+        let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
         for agent_key in &agent_keys {
             let (skills_root, _) = resolve_agent_skills_roots(&store, &project, agent_key)
                 .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent_key)))?;
             let target_dir = skills_root.join(&dir_name);
             std::fs::create_dir_all(&skills_root)?;
-            sync_engine::sync_skill(&source, &target_dir, sync_engine::SyncMode::Copy)
-                .map_err(AppError::io)?;
+            let mode = sync_engine::sync_mode_for_tool(agent_key, configured_mode.as_deref());
+            sync_engine::sync_skill(&source, &target_dir, mode).map_err(AppError::io)?;
         }
 
         Ok(())
@@ -1037,6 +1038,14 @@ pub async fn update_project_skill_from_center(
         let managed = find_best_center_match(skill, &all_managed)
             .ok_or_else(|| AppError::not_found("No matching skill in center"))?;
 
+        // Mirror the global-workspace protection (agent_workspace.rs): never
+        // overwrite a project copy that has unsynced local edits (#225 review).
+        if classify_sync_status(skill, Some(managed)) == "project_newer" {
+            return Err(AppError::invalid_input(
+                "Project skill is newer than the Skills Center version",
+            ));
+        }
+
         let (skills_root, disabled_root) = resolve_agent_skills_roots(&store, &record, &agent)
             .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent)))?;
         let target_path = PathBuf::from(&skill.path);
@@ -1054,8 +1063,9 @@ pub async fn update_project_skill_from_center(
         }
 
         let source = PathBuf::from(&managed.central_path);
-        sync_engine::sync_skill(&source, &target_path, sync_engine::SyncMode::Copy)
-            .map_err(AppError::io)?;
+        let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+        let mode = sync_engine::sync_mode_for_tool(&agent, configured_mode.as_deref());
+        sync_engine::sync_skill(&source, &target_path, mode).map_err(AppError::io)?;
         Ok(())
     })
     .await?

--- a/src-tauri/src/core/content_hash.rs
+++ b/src-tauri/src/core/content_hash.rs
@@ -111,6 +111,25 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
+    /// Project-workspace skills may now be symlinks to the central library
+    /// (#225). Sync-status classification hashes the project path directly,
+    /// so hashing through a symlinked root must see the real content.
+    #[cfg(unix)]
+    #[test]
+    fn hash_through_symlinked_root_matches_real_directory() {
+        let tmp = tempdir().unwrap();
+        let real = tmp.path().join("skill");
+        fs::create_dir_all(&real).unwrap();
+        fs::write(real.join("SKILL.md"), "# hello").unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert_eq!(
+            hash_directory(&link).unwrap(),
+            hash_directory(&real).unwrap()
+        );
+    }
+
     #[test]
     fn hash_deterministic_same_content() {
         let tmp1 = tempdir().unwrap();

--- a/src-tauri/src/core/sync_engine.rs
+++ b/src-tauri/src/core/sync_engine.rs
@@ -1,13 +1,19 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
-/// Refuse to copy when `dst` would land inside `src` (or equal `src`).
-/// Otherwise the recursive copy walks into the freshly-created `dst` and
-/// produces unbounded `<dst>/<dst>/<dst>/...` nesting (issue #61).
+/// Refuse to sync when `src` and `dst` overlap in either direction (equal,
+/// dst inside src, or src inside dst). Otherwise the recursive copy walks
+/// into the freshly-created `dst` and produces unbounded nesting (issue #61),
+/// or the pre-copy removal of `dst` deletes the source along with it (#199).
+///
+/// `src` must exist and canonicalize — every caller is about to read from it,
+/// and all destructive steps (remove target / remove destination) happen after
+/// this check, so failing here protects the existing target. A missing `dst`
+/// is the normal case for a fresh install and is judged via its parent.
 pub(crate) fn ensure_dst_not_inside_src(src: &Path, dst: &Path) -> Result<()> {
-    let Ok(src_canon) = src.canonicalize() else {
-        return Ok(());
-    };
+    let src_canon = src
+        .canonicalize()
+        .with_context(|| format!("Source {:?} does not exist or is not accessible", src))?;
     let dst_canon: Option<PathBuf> = dst.canonicalize().ok().or_else(|| {
         let parent = dst.parent()?.canonicalize().ok()?;
         let name = dst.file_name()?;
@@ -19,6 +25,13 @@ pub(crate) fn ensure_dst_not_inside_src(src: &Path, dst: &Path) -> Result<()> {
                 "Destination {:?} is inside source {:?}; refusing to copy to avoid infinite recursion",
                 dst,
                 src
+            );
+        }
+        if src_canon.starts_with(&dst_canon) {
+            anyhow::bail!(
+                "Source {:?} is inside destination {:?}; refusing to avoid deleting the source",
+                src,
+                dst
             );
         }
     }
@@ -501,6 +514,44 @@ mod tests {
         fs::create_dir_all(&src).unwrap();
 
         ensure_dst_not_inside_src(&src, &dst).unwrap();
+    }
+
+    #[test]
+    fn ensure_dst_not_inside_src_rejects_missing_source() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("does-not-exist");
+        let dst = tmp.path().join("target");
+        fs::create_dir_all(&dst).unwrap();
+
+        let err = ensure_dst_not_inside_src(&src, &dst).unwrap_err();
+        assert!(err.to_string().contains("not accessible"), "{err}");
+    }
+
+    #[test]
+    fn ensure_dst_not_inside_src_rejects_source_inside_destination() {
+        let tmp = tempdir().unwrap();
+        let dst = tmp.path().join("skills");
+        let src = dst.join("nested");
+        fs::create_dir_all(&src).unwrap();
+
+        let err = ensure_dst_not_inside_src(&src, &dst).unwrap_err();
+        assert!(err.to_string().contains("deleting the source"), "{err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_dst_not_inside_src_rejects_dangling_symlink_source() {
+        // A dangling symlink source used to slip past the guard (canonicalize
+        // failure returned Ok) and let the caller delete the destination
+        // before the copy inevitably failed (#199 hardening).
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("dangling");
+        std::os::unix::fs::symlink(tmp.path().join("gone"), &src).unwrap();
+        let dst = tmp.path().join("target");
+        fs::create_dir_all(&dst).unwrap();
+
+        let err = ensure_dst_not_inside_src(&src, &dst).unwrap_err();
+        assert!(err.to_string().contains("not accessible"), "{err}");
     }
 
     #[test]

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -451,7 +451,7 @@
     "changeDir": "Change Directory",
     "openInFinder": "Open Folder",
     "syncMode": "Default Sync Mode",
-    "syncModeDesc": "Symlinks are recommended — minimal disk usage with live updates.",
+    "syncModeDesc": "Symlinks are recommended — minimal disk usage with live updates. Applies to both global and project workspaces; note that symlinks in a project point to this machine's central library and won't travel with the repo.",
     "symlink": "Symlink",
     "copy": "File Copy",
     "currentPreset": "Current Preset",

--- a/src/i18n/zh-TW.json
+++ b/src/i18n/zh-TW.json
@@ -402,7 +402,7 @@
     "changeDir": "變更目錄",
     "openInFinder": "開啟資料夾",
     "syncMode": "預設同步模式",
-    "syncModeDesc": "建議使用符號連結，佔用空間極小且修改可即時生效。",
+    "syncModeDesc": "建議使用符號連結，佔用空間極小且修改可即時生效。全域與專案工作區均生效；注意專案裡的符號連結指向本機中央庫，不會隨倉庫帶走。",
     "symlink": "符號連結",
     "copy": "檔案複製",
     "currentPreset": "當前 Preset",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -451,7 +451,7 @@
     "changeDir": "更改目录",
     "openInFinder": "打开文件夹",
     "syncMode": "默认同步模式",
-    "syncModeDesc": "推荐使用符号链接，占用空间极小且修改可实时生效。",
+    "syncModeDesc": "推荐使用符号链接，占用空间极小且修改可实时生效。全局与项目工作区均生效；注意项目里的符号链接指向本机中央库，不会随仓库带走。",
     "symlink": "符号链接",
     "copy": "文件复制",
     "currentPreset": "当前 Preset",


### PR DESCRIPTION
## Summary

Fixes #225 and #202 (project workspace always copied even when symlink mode is selected), with hardening related to #199. P0 cluster #1 from the triage board. Root-cause analysis was adversarially reviewed by codex (read-only sandbox) before implementation; all review findings are addressed below.

**Root cause**: `export_skill_to_project` and `update_project_skill_from_center` (and `update_agent_local_skill_from_center` for global local skills) hardcoded `SyncMode::Copy` since their introduction — the sync_mode setting was never consulted on these paths, on any platform. The v1.23.1 Windows junction fallback lives inside the Symlink branch of `sync_skill`, which these paths never entered.

## Changes

- **Respect sync_mode**: all three paths now read the `sync_mode` setting and resolve it via `sync_mode_for_tool`, identical to the scenario/global-workspace path. Platform fallbacks (Windows junction → copy) are reused as-is.
- **Clobber protection** (review finding F1): `update_project_skill_from_center` now refuses when the project copy is newer than the center version, mirroring the existing global-workspace check — updating cannot silently discard unsynced project edits. Unmodified copies convert to symlinks naturally on their next update.
- **Guard hardening (#199, findings F4–F6)**: `ensure_dst_not_inside_src` now errors when the source fails to canonicalize (missing/dangling symlink) instead of silently passing, and rejects mutual containment in both directions. All callers perform destructive steps only after this check, so failing early protects existing targets. All callers audited in review (installer, sync_skill, git merge_backup) — none passes a legitimately missing source.
- **Symlink-root hashing verified** (finding F3): regression test proves `hash_directory` through a symlinked root equals the real directory (walkdir 2.5 follows root links), so sync-status classification stays correct for symlinked project skills.
- **Disclosure** (finding F2): sync-mode setting description now states the mode applies to project workspaces and that project symlinks point at this machine's central library (en / zh / zh-TW).

Intentionally unchanged: `resync_copy_targets` (only resyncs targets recorded as copy), CLI `export` (explicit copy-out semantics).

## Test plan

- [x] 4 new unit tests: missing source rejected, dangling-symlink source rejected, source-inside-destination rejected, hash through symlinked root
- [x] cargo test: 283 passed
- [x] Frontend build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)