### PR TITLE
fix(central-repo): surface config failures instead of silently rebuilding an empty library (#228)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -95,6 +95,14 @@ pub fn get_central_repo_path_override() -> Option<String> {
     central_repo::configured_base_dir().map(|path| path.to_string_lossy().to_string())
 }
 
+/// Warning codes recorded while resolving the central repository at startup
+/// (e.g. unreadable config, invalid configured path). Non-empty means the app
+/// fell back to the default location and the user should be told (#228).
+#[tauri::command]
+pub fn get_central_repo_warnings() -> Vec<String> {
+    central_repo::startup_warnings()
+}
+
 #[tauri::command]
 pub async fn set_central_repo_path(path: Option<String>) -> Result<String, AppError> {
     tauri::async_runtime::spawn_blocking(move || {

--- a/src-tauri/src/core/central_repo.rs
+++ b/src-tauri/src/core/central_repo.rs
@@ -10,6 +10,27 @@ const CONFIG_FILE_NAME: &str = "repo-config.json";
 
 static BASE_DIR_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
 static SKILLS_DIR_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+static STARTUP_WARNINGS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn push_startup_warning(code: &str) {
+    let mut warnings = STARTUP_WARNINGS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    if !warnings.iter().any(|w| w == code) {
+        warnings.push(code.to_string());
+    }
+}
+
+/// Warning codes recorded while resolving the central repository at startup.
+/// The frontend maps them to localized banner text (`settings.repoWarning_*`).
+pub fn startup_warnings() -> Vec<String> {
+    STARTUP_WARNINGS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
 
 /// Global mutex shared by every test that mutates the base-dir override via
 /// [`set_test_base_dir_override`]. The override is process-wide static state,
@@ -46,14 +67,40 @@ fn config_file_path() -> PathBuf {
         .join(CONFIG_FILE_NAME)
 }
 
-fn load_config() -> RepoPathConfig {
-    let path = config_file_path();
+/// Distinguishes "no config file" (normal fresh install) from "config file
+/// exists but cannot be used" (must never be silently treated as a fresh
+/// install — that is how a configured library turns into an empty default
+/// one and users report "all my skills are gone", issue #228 review).
+#[derive(Debug)]
+enum ConfigState {
+    Missing,
+    Valid(RepoPathConfig),
+    Invalid(String),
+}
+
+fn load_config_state_from(path: &Path) -> ConfigState {
     let raw = match fs::read_to_string(path) {
         Ok(raw) => raw,
-        Err(_) => return RepoPathConfig::default(),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return ConfigState::Missing,
+        Err(err) => {
+            return ConfigState::Invalid(format!("cannot read {}: {err}", path.display()));
+        }
     };
+    match serde_json::from_str(&raw) {
+        Ok(config) => ConfigState::Valid(config),
+        Err(err) => ConfigState::Invalid(format!("corrupt JSON in {}: {err}", path.display())),
+    }
+}
 
-    serde_json::from_str(&raw).unwrap_or_default()
+fn load_config_state() -> ConfigState {
+    load_config_state_from(&config_file_path())
+}
+
+fn load_config() -> RepoPathConfig {
+    match load_config_state() {
+        ConfigState::Valid(config) => config,
+        ConfigState::Missing | ConfigState::Invalid(_) => RepoPathConfig::default(),
+    }
 }
 
 fn save_config(config: &RepoPathConfig) -> Result<()> {
@@ -356,27 +403,60 @@ fn migrate_repo_if_needed(config: &mut RepoPathConfig, current_base: &Path) -> R
 }
 
 pub fn ensure_central_repo() -> Result<()> {
-    let mut config = load_config();
+    // A config file that exists but cannot be used means the app is about to
+    // run against the default location even though the user configured (and
+    // populated) another one. Never let that pass silently — it presents as
+    // "the library was rebuilt empty, all skills lost" (#228 review).
+    let mut config = match load_config_state() {
+        ConfigState::Valid(config) => {
+            if let Some(raw) = config.repo_path.as_deref() {
+                if let Err(err) = normalize_path(raw) {
+                    log::error!(
+                        "central repo: configured repo_path {raw:?} is invalid ({err}); \
+                         falling back to the default location"
+                    );
+                    push_startup_warning("repo_path_invalid");
+                }
+            }
+            config
+        }
+        ConfigState::Missing => RepoPathConfig::default(),
+        ConfigState::Invalid(detail) => {
+            log::error!(
+                "central repo: config is unreadable ({detail}); \
+                 falling back to the default location"
+            );
+            push_startup_warning("config_unreadable");
+            RepoPathConfig::default()
+        }
+    };
+
     let current_base = base_dir();
     migrate_repo_if_needed(&mut config, &current_base)?;
+
+    // Legacy `.agent-skills` migration must run before create_dir_all below:
+    // it renames entries into `current_base` and skips ones that already
+    // exist, so pre-created empty dirs would silently swallow it (the old
+    // ordering made this branch dead code).
+    let legacy_path = dirs::home_dir().map(|home| home.join(".agent-skills"));
+    if let Some(old_path) = legacy_path {
+        if old_path.exists() && !current_base.join("skills").exists() {
+            log::info!("Migrating from old path {:?}", old_path);
+            fs::create_dir_all(&current_base)?;
+            if let Ok(entries) = fs::read_dir(&old_path) {
+                for entry in entries.flatten() {
+                    let dest = current_base.join(entry.file_name());
+                    if !dest.exists() {
+                        let _ = fs::rename(entry.path(), &dest);
+                    }
+                }
+            }
+        }
+    }
 
     let dirs = [skills_dir(), scenarios_dir(), cache_dir(), logs_dir()];
     for d in &dirs {
         fs::create_dir_all(d)?;
-    }
-
-    // Migrate from old path if it exists
-    let old_path = dirs::home_dir().unwrap().join(".agent-skills");
-    if old_path.exists() && !current_base.join("skills").exists() {
-        log::info!("Migrating from old path {:?}", old_path);
-        if let Ok(entries) = fs::read_dir(&old_path) {
-            for entry in entries.flatten() {
-                let dest = current_base.join(entry.file_name());
-                if !dest.exists() {
-                    let _ = fs::rename(entry.path(), &dest);
-                }
-            }
-        }
     }
 
     Ok(())
@@ -385,6 +465,40 @@ pub fn ensure_central_repo() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── load_config_state_from ──
+
+    #[test]
+    fn config_state_missing_file_is_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = load_config_state_from(&tmp.path().join("repo-config.json"));
+        assert!(matches!(state, ConfigState::Missing));
+    }
+
+    #[test]
+    fn config_state_valid_json_is_valid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("repo-config.json");
+        fs::write(&path, r#"{ "repo_path": "/tmp/lib", "pending_migration_from": null }"#)
+            .unwrap();
+        match load_config_state_from(&path) {
+            ConfigState::Valid(config) => {
+                assert_eq!(config.repo_path.as_deref(), Some("/tmp/lib"));
+            }
+            other => panic!("expected Valid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn config_state_corrupt_json_is_invalid_not_fresh_install() {
+        // A corrupt config must never be treated like a missing one — that is
+        // the "library rebuilt empty, all skills lost" failure mode (#228).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("repo-config.json");
+        fs::write(&path, "{ not json").unwrap();
+        let state = load_config_state_from(&path);
+        assert!(matches!(state, ConfigState::Invalid(_)), "{state:?}");
+    }
 
     #[test]
     fn external_base_dir_lives_under_default_base_external() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -951,6 +951,7 @@ pub fn run() {
             commands::settings::set_settings,
             commands::settings::get_central_repo_path,
             commands::settings::get_central_repo_path_override,
+            commands::settings::get_central_repo_warnings,
             commands::settings::set_central_repo_path,
             commands::settings::open_central_repo_folder,
             commands::settings::check_app_update,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -493,6 +493,8 @@
     "exportLogsDone": "Logs exported ({{count}} file(s)). Drag the zip into your GitHub issue.",
     "exportLogsFailed": "Failed to export logs.",
     "panicBanner": "Skills Manager crashed during the last session ({{time}}).",
+    "repoWarning_config_unreadable": "The central library config file is unreadable or corrupt, so this session fell back to the default location (~/.skills-manager). If your library looks empty, your data is still at the previously configured path — set “Central Repo Path” back to it.",
+    "repoWarning_repo_path_invalid": "The configured central repository path is invalid, so this session fell back to the default location (~/.skills-manager). If your library looks empty, re-set “Central Repo Path” to where your data lives.",
     "panicDismiss": "Dismiss",
     "gitBackup": "Git Sync",
     "gitBackupDesc": "Back up your skill library to a Git repository for version control and multi-machine sync.",

--- a/src/i18n/zh-TW.json
+++ b/src/i18n/zh-TW.json
@@ -444,6 +444,8 @@
     "exportLogsDone": "已匯出日誌（{{count}} 個檔案），請把 zip 拖到 GitHub issue 附件區。",
     "exportLogsFailed": "匯出日誌失敗。",
     "panicBanner": "上次執行 Skills Manager 時發生崩潰（{{time}}）。",
+    "repoWarning_config_unreadable": "中央庫設定檔已損壞或無法讀取，本次啟動已回退到預設路徑（~/.skills-manager）。如果技能庫看起來是空的，你的資料仍在先前設定的路徑裡——請到「中央倉庫路徑」重新指定。",
+    "repoWarning_repo_path_invalid": "設定的中央倉庫路徑無效，本次啟動已回退到預設路徑（~/.skills-manager）。如果技能庫看起來是空的，請到「中央倉庫路徑」重新指定資料所在位置。",
     "panicDismiss": "忽略",
     "gitBackup": "Git 同步",
     "gitBackupDesc": "將 Skill 庫備份到 Git 倉庫，支援版本管理和多機同步。",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -493,6 +493,8 @@
     "exportLogsDone": "已导出日志（{{count}} 个文件），请把 zip 拖到 GitHub issue 附件区。",
     "exportLogsFailed": "导出日志失败。",
     "panicBanner": "上次运行 Skills Manager 时发生崩溃（{{time}}）。",
+    "repoWarning_config_unreadable": "中央库配置文件已损坏或无法读取，本次启动已回退到默认路径（~/.skills-manager）。如果技能库看起来是空的，你的数据仍在之前配置的路径里——请到「中央仓库路径」重新指定。",
+    "repoWarning_repo_path_invalid": "配置的中央仓库路径无效，本次启动已回退到默认路径（~/.skills-manager）。如果技能库看起来是空的，请到「中央仓库路径」重新指定数据所在位置。",
     "panicDismiss": "忽略",
     "gitBackup": "Git 同步",
     "gitBackupDesc": "将 Skill 库备份到 Git 仓库，支持版本管理和多机同步。",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -412,6 +412,9 @@ export const getCentralRepoPath = () =>
 export const getCentralRepoPathOverride = () =>
   invoke<string | null>("get_central_repo_path_override");
 
+export const getCentralRepoWarnings = () =>
+  invoke<string[]>("get_central_repo_warnings");
+
 export const setCentralRepoPath = (path?: string | null) =>
   invoke<string>("set_central_repo_path", { path: path ?? null });
 

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -175,6 +175,7 @@ export function Settings() {
   const [reportingIssue, setReportingIssue] = useState(false);
   const [exportingLogs, setExportingLogs] = useState(false);
   const [lastPanic, setLastPanic] = useState<api.PanicInfo | null>(null);
+  const [repoWarnings, setRepoWarnings] = useState<string[]>([]);
   const [centralRepoPath, setCentralRepoPath] = useState("");
   const [centralRepoPathOverride, setCentralRepoPathOverride] = useState<string | null>(null);
   const [editingCentralRepoPath, setEditingCentralRepoPath] = useState(false);
@@ -324,6 +325,7 @@ export function Settings() {
 
   useEffect(() => {
     api.checkLastPanic().then(setLastPanic).catch(() => {});
+    api.getCentralRepoWarnings().then(setRepoWarnings).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -1649,6 +1651,16 @@ export function Settings() {
 
         {/* About */}
         <section className="space-y-2">
+          {repoWarnings.length > 0 && (
+            <div className="app-panel flex flex-wrap items-start gap-2 p-3 border border-amber-500/40 bg-amber-500/10">
+              <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5 text-amber-700 dark:text-amber-300" />
+              <div className="min-w-0 flex-1 space-y-1 text-[13px] text-amber-800 dark:text-amber-300">
+                {repoWarnings.map((code) => (
+                  <p key={code}>{t(`settings.repoWarning_${code}`)}</p>
+                ))}
+              </div>
+            </div>
+          )}
           {lastPanic && (
             <div className="app-panel flex flex-wrap items-center justify-between gap-2 p-3 border border-red-500/40 bg-red-500/10">
               <div className="flex min-w-0 items-center gap-2 text-[13px] text-red-700 dark:text-red-300">


### PR DESCRIPTION
## Summary

Addresses the data-loss report in #228 ("changed agent name, restarted, .skills-manager was rebuilt, all skills gone"). P0 cluster #2 from the triage board, reframed after investigation + codex adversarial review:

- The reported crash path ("set path to `.agent`") is **not reproducible at current HEAD** — relative paths have been rejected by `normalize_skills_dir_input` / `normalize_path` since the custom-agent feature landed. We'll ask the reporter for `last_panic.log` separately.
- The **real, code-confirmed defect** behind "all skills lost": a `repo-config.json` that exists but cannot be used (unreadable, corrupt JSON, or invalid `repo_path`) was silently swallowed — `load_config` returned defaults, `base_dir()` fell back to `~/.skills-manager`, and `ensure_central_repo` built a fresh empty library there. The user's data still sits at the configured location; only the pointer vanished. Combined with path-change migration (which renames the old default dir away), this presents exactly as "library rebuilt, everything gone".

## Changes

- **Three-state config loader** (review finding F8): `Missing` (normal fresh install) / `Valid` / `Invalid`. Invalid config or an unparseable `repo_path` logs an error and records a startup warning instead of impersonating a fresh install. The app still falls back so it can start.
- **Startup warning surface**: new `get_central_repo_warnings` command; Settings shows an amber banner explaining the fallback and that the data is still at the previously configured path (en / zh / zh-TW).
- **Dead legacy migration fixed** (finding F9): the `.agent-skills` migration checked `skills/` existence *after* `create_dir_all` had created it, and its renames were skipped into pre-created dirs; it now runs first. Also removes a `home_dir().unwrap()` on that path.

Deliberately out of scope (per review): Mutex-poisoning hardening (separate issue), any change to migration semantics.

## Test plan

- [x] 3 new unit tests: missing config → Missing; valid JSON → Valid; corrupt JSON → Invalid (never treated as fresh install)
- [x] cargo test: 282 passed
- [x] Frontend build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)