### PR TITLE
feat: dedupe same-name skills and batch preset toggles

### DIFF
--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -6,10 +6,11 @@ use tauri::State;
 
 use crate::core::{
     error::AppError,
-    scenario_service::{self, BatchApplyMode},
+    scenario_service::{self, BatchApplyMode, ScenarioSyncReport},
     skill_store::{ScenarioRecord, SkillStore},
-    sync_metadata, tool_adapters,
+    sync_metadata,
     timing::should_log_first_or_slow,
+    tool_adapters,
 };
 
 fn refresh_tray_menu_best_effort(app: &tauri::AppHandle) {
@@ -234,7 +235,7 @@ pub async fn apply_preset_to_default(
     app: tauri::AppHandle,
     id: String,
     store: State<'_, Arc<SkillStore>>,
-) -> Result<(), AppError> {
+) -> Result<ScenarioSyncReport, AppError> {
     apply_preset_to_default_impl(app, id, store.inner().clone()).await
 }
 
@@ -246,7 +247,7 @@ pub async fn switch_preset(
     app: tauri::AppHandle,
     id: String,
     store: State<'_, Arc<SkillStore>>,
-) -> Result<(), AppError> {
+) -> Result<ScenarioSyncReport, AppError> {
     apply_preset_to_default_impl(app, id, store.inner().clone()).await
 }
 
@@ -254,9 +255,9 @@ async fn apply_preset_to_default_impl(
     app: tauri::AppHandle,
     id: String,
     store: Arc<SkillStore>,
-) -> Result<(), AppError> {
+) -> Result<ScenarioSyncReport, AppError> {
     let result = tauri::async_runtime::spawn_blocking(move || {
-        scenario_service::apply_scenario_to_default(&store, &id)
+        scenario_service::apply_scenario_to_default_with_report(&store, &id)
     })
     .await?;
     if result.is_ok() {

--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -44,9 +44,7 @@ pub struct PresetDto {
 static GET_PRESETS_FIRST_CALL: AtomicBool = AtomicBool::new(true);
 
 #[tauri::command]
-pub async fn get_presets(
-    store: State<'_, Arc<SkillStore>>,
-) -> Result<Vec<PresetDto>, AppError> {
+pub async fn get_presets(store: State<'_, Arc<SkillStore>>) -> Result<Vec<PresetDto>, AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
         let start = Instant::now();
@@ -294,6 +292,37 @@ pub async fn add_skill_to_preset(
     result
 }
 
+/// Batch add/remove skills from a preset in a single metadata write + single tray refresh.
+/// Eliminates the O(N) sequential IPC + O(N) metadata rewrite overhead of calling
+/// `add_skill_to_preset` / `remove_skill_from_preset` N times individually.
+#[tauri::command]
+pub async fn batch_toggle_preset_skills(
+    app: tauri::AppHandle,
+    preset_id: String,
+    skill_ids: Vec<String>,
+    enable: bool,
+    store: State<'_, Arc<SkillStore>>,
+) -> Result<usize, AppError> {
+    let store = store.inner().clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        sync_metadata::with_repo_lock("batch toggle scenario skills", || {
+            let count = if enable {
+                store.batch_add_skills_to_scenario(&preset_id, &skill_ids)?
+            } else {
+                store.batch_remove_skills_from_scenario(&preset_id, &skill_ids)?
+            };
+            sync_metadata::write_all_from_db_unlocked(&store)?;
+            Ok(count)
+        })
+        .map_err(AppError::db)
+    })
+    .await?;
+    if result.is_ok() {
+        refresh_tray_menu_best_effort(&app);
+    }
+    result
+}
+
 #[tauri::command]
 pub async fn remove_skill_from_preset(
     app: tauri::AppHandle,
@@ -449,10 +478,10 @@ mod tests {
     };
     use crate::core::skill_store::SkillRecord;
     use crate::core::tool_adapters::{self, CustomToolDef};
-    use std::path::PathBuf;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     fn sample_skill(id: &str, name: &str, central_path: &std::path::Path) -> SkillRecord {

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -6,8 +6,7 @@ use std::time::Instant;
 use super::{
     error::AppError,
     skill_store::{ScenarioRecord, SkillStore, SkillTargetRecord},
-    sync_engine, tool_adapters,
-    tool_service,
+    sync_engine, tool_adapters, tool_service,
 };
 
 #[derive(Debug, Clone)]
@@ -32,6 +31,26 @@ pub struct SyncPreviewTarget {
     pub tool: String,
     pub target_path: String,
     pub mode: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DuplicateScenarioSkill {
+    pub skill_id: String,
+    pub skill_name: String,
+    pub tool: String,
+    pub target_name: String,
+    pub selected_skill_id: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ScenarioSyncReport {
+    pub duplicate_skills: Vec<DuplicateScenarioSkill>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ScenarioSyncPlan {
+    pub targets: Vec<ScenarioSyncTarget>,
+    pub report: ScenarioSyncReport,
 }
 
 pub fn ensure_scenario_exists(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
@@ -73,17 +92,85 @@ pub fn collect_scenario_sync_targets(
     store: &SkillStore,
     scenario_id: &str,
 ) -> Result<Vec<ScenarioSyncTarget>, AppError> {
-    let skills = store
+    collect_scenario_sync_plan(store, scenario_id).map(|plan| plan.targets)
+}
+
+pub fn collect_scenario_sync_plan(
+    store: &SkillStore,
+    scenario_id: &str,
+) -> Result<ScenarioSyncPlan, AppError> {
+    let mut skills = store
         .get_skills_for_scenario(scenario_id)
         .map_err(AppError::db)?;
     let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+    let duplicate_names: HashSet<String> = skills
+        .iter()
+        .fold(HashMap::<String, usize>::new(), |mut counts, skill| {
+            *counts.entry(skill.name.clone()).or_default() += 1;
+            counts
+        })
+        .into_iter()
+        .filter_map(|(name, count)| (count > 1).then_some(name))
+        .collect();
+    if !duplicate_names.is_empty() {
+        skills.sort_by(|left, right| {
+            let left_duplicate = duplicate_names.contains(&left.name);
+            let right_duplicate = duplicate_names.contains(&right.name);
+            match (left_duplicate, right_duplicate) {
+                (true, true) if left.name == right.name => {
+                    let left_source = PathBuf::from(&left.central_path);
+                    let right_source = PathBuf::from(&right.central_path);
+                    let left_canonical =
+                        sync_engine::target_dir_name(&left_source, &left.name) == left.name;
+                    let right_canonical =
+                        sync_engine::target_dir_name(&right_source, &right.name) == right.name;
+                    right_canonical
+                        .cmp(&left_canonical)
+                        .then_with(|| left.created_at.cmp(&right.created_at))
+                        .then_with(|| left.id.cmp(&right.id))
+                }
+                _ => std::cmp::Ordering::Equal,
+            }
+        });
+    }
+    let mut emitted_targets = HashSet::<(String, String)>::new();
+    let mut selected_by_target = HashMap::<(String, String), String>::new();
     let mut targets = Vec::new();
+    let mut duplicate_skills = Vec::new();
 
     for skill in &skills {
         let source = PathBuf::from(&skill.central_path);
-        let target_name = sync_engine::target_dir_name(&source, &skill.name);
-        let adapters = enabled_installed_adapters_for_scenario_skill(store, scenario_id, &skill.id)?;
+        let target_name = if duplicate_names.contains(&skill.name) {
+            skill.name.clone()
+        } else {
+            sync_engine::target_dir_name(&source, &skill.name)
+        };
+        let adapters =
+            enabled_installed_adapters_for_scenario_skill(store, scenario_id, &skill.id)?;
         for adapter in &adapters {
+            if !emitted_targets.insert((adapter.key.clone(), target_name.clone())) {
+                let selected_skill_id = selected_by_target
+                    .get(&(adapter.key.clone(), target_name.clone()))
+                    .cloned()
+                    .unwrap_or_default();
+                duplicate_skills.push(DuplicateScenarioSkill {
+                    skill_id: skill.id.clone(),
+                    skill_name: skill.name.clone(),
+                    tool: adapter.key.clone(),
+                    target_name: target_name.clone(),
+                    selected_skill_id: selected_skill_id.clone(),
+                });
+                log::warn!(
+                    "Skipping duplicate skill '{}' ({}) for {}; target '{}' is already selected in preset {}",
+                    skill.name,
+                    skill.id,
+                    adapter.key,
+                    target_name,
+                    scenario_id
+                );
+                continue;
+            }
+            selected_by_target.insert((adapter.key.clone(), target_name.clone()), skill.id.clone());
             let target = adapter.skills_dir().join(&target_name);
             let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
             targets.push(ScenarioSyncTarget {
@@ -98,7 +185,10 @@ pub fn collect_scenario_sync_targets(
         }
     }
 
-    Ok(targets)
+    Ok(ScenarioSyncPlan {
+        targets,
+        report: ScenarioSyncReport { duplicate_skills },
+    })
 }
 
 pub fn preview_scenario_sync(
@@ -134,7 +224,10 @@ pub fn preview_scenario_sync(
 /// The reverse direction (existing `"symlink"`, desired `Copy`) returns
 /// `None` because the user actively changed the `sync_mode` setting and
 /// the on-disk symlink doesn't reflect that intent.
-fn skip_check_mode(existing_mode: &str, desired: sync_engine::SyncMode) -> Option<sync_engine::SyncMode> {
+fn skip_check_mode(
+    existing_mode: &str,
+    desired: sync_engine::SyncMode,
+) -> Option<sync_engine::SyncMode> {
     match (existing_mode, desired) {
         ("symlink", sync_engine::SyncMode::Symlink) => Some(sync_engine::SyncMode::Symlink),
         ("copy", sync_engine::SyncMode::Copy) => Some(sync_engine::SyncMode::Copy),
@@ -333,22 +426,44 @@ pub fn unsync_scenario_skills(store: &SkillStore, scenario_id: &str) -> Result<(
 }
 
 pub fn sync_scenario_skills(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
-    let desired_targets = collect_scenario_sync_targets(store, scenario_id)?;
-    sync_desired_targets(store, &desired_targets)
+    let plan = collect_scenario_sync_plan(store, scenario_id)?;
+    unsync_obsolete_scenario_targets(store, scenario_id, &plan.targets)?;
+    sync_desired_targets(store, &plan.targets)
+}
+
+pub fn sync_scenario_skills_with_report(
+    store: &SkillStore,
+    scenario_id: &str,
+) -> Result<ScenarioSyncReport, AppError> {
+    let plan = collect_scenario_sync_plan(store, scenario_id)?;
+    unsync_obsolete_scenario_targets(store, scenario_id, &plan.targets)?;
+    sync_desired_targets(store, &plan.targets)?;
+    Ok(plan.report)
 }
 
 pub fn apply_scenario_to_default(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
+    apply_scenario_to_default_with_report(store, scenario_id).map(|_| ())
+}
+
+pub fn apply_scenario_to_default_with_report(
+    store: &SkillStore,
+    scenario_id: &str,
+) -> Result<ScenarioSyncReport, AppError> {
     ensure_scenario_exists(store, scenario_id)?;
-    let desired_targets = collect_scenario_sync_targets(store, scenario_id)?;
+    let plan = collect_scenario_sync_plan(store, scenario_id)?;
 
     if let Ok(Some(old_id)) = store.get_active_scenario_id() {
         if old_id != scenario_id {
-            unsync_obsolete_scenario_targets(store, &old_id, &desired_targets)?;
+            unsync_obsolete_scenario_targets(store, &old_id, &plan.targets)?;
         }
     }
 
-    store.set_active_scenario(scenario_id).map_err(AppError::db)?;
-    sync_desired_targets(store, &desired_targets)
+    store
+        .set_active_scenario(scenario_id)
+        .map_err(AppError::db)?;
+    unsync_obsolete_scenario_targets(store, scenario_id, &plan.targets)?;
+    sync_desired_targets(store, &plan.targets)?;
+    Ok(plan.report)
 }
 
 pub fn sync_skill_to_active_scenario(
@@ -358,7 +473,8 @@ pub fn sync_skill_to_active_scenario(
 ) -> Result<(), AppError> {
     if let Ok(Some(active_id)) = store.get_active_scenario_id() {
         if active_id == scenario_id {
-            let adapters = enabled_installed_adapters_for_scenario_skill(store, scenario_id, skill_id)?;
+            let adapters =
+                enabled_installed_adapters_for_scenario_skill(store, scenario_id, skill_id)?;
             let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
             let Ok(Some(skill)) = store.get_skill_by_id(skill_id) else {
                 return Ok(());
@@ -378,7 +494,8 @@ pub fn sync_skill_to_active_scenario(
                 }
 
                 let target = adapter.skills_dir().join(&target_name);
-                let mode = sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
+                let mode =
+                    sync_engine::sync_mode_for_tool(&adapter.key, configured_mode.as_deref());
                 match sync_engine::sync_skill(&source, &target, mode) {
                     Ok(actual_mode) => {
                         let now = chrono::Utc::now().timestamp_millis();
@@ -423,7 +540,9 @@ pub fn ensure_default_startup_scenario(store: &SkillStore) -> Result<(), AppErro
             created_at: now,
             updated_at: now,
         };
-        store.insert_scenario(&default_scenario).map_err(AppError::db)?;
+        store
+            .insert_scenario(&default_scenario)
+            .map_err(AppError::db)?;
         scenarios.push(default_scenario);
     }
 
@@ -464,7 +583,9 @@ pub fn ensure_cli_scenario_state(store: &SkillStore) -> Result<(), AppError> {
             created_at: now,
             updated_at: now,
         };
-        store.insert_scenario(&default_scenario).map_err(AppError::db)?;
+        store
+            .insert_scenario(&default_scenario)
+            .map_err(AppError::db)?;
         scenarios.push(default_scenario);
     }
 
@@ -505,7 +626,8 @@ pub fn sync_active_scenario_to_tool(store: &SkillStore, tool_key: &str) {
             return;
         };
         for skill_id in skill_ids {
-            if let Ok(adapters) = enabled_installed_adapters_for_scenario_skill(store, &active_id, &skill_id)
+            if let Ok(adapters) =
+                enabled_installed_adapters_for_scenario_skill(store, &active_id, &skill_id)
             {
                 if adapters.iter().any(|adapter| adapter.key == tool_key) {
                     let _ = sync_skill_to_active_scenario(store, &active_id, &skill_id);
@@ -758,6 +880,144 @@ fn apply_remove(
 }
 
 #[cfg(test)]
+mod collect_scenario_sync_targets_tests {
+    use super::*;
+    use crate::core::central_repo;
+    use crate::core::skill_store::{ScenarioRecord, SkillRecord, SkillStore, SkillTargetRecord};
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn sample_skill(id: &str, name: &str, central_path: PathBuf, updated_at: i64) -> SkillRecord {
+        SkillRecord {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: None,
+            source_type: "import".to_string(),
+            source_ref: Some(central_path.to_string_lossy().to_string()),
+            source_ref_resolved: None,
+            source_subpath: None,
+            source_branch: None,
+            source_revision: None,
+            remote_revision: None,
+            central_path: central_path.to_string_lossy().to_string(),
+            content_hash: Some(format!("hash-{id}")),
+            enabled: true,
+            created_at: updated_at,
+            updated_at,
+            status: "ok".to_string(),
+            update_status: "local_only".to_string(),
+            last_checked_at: None,
+            last_check_error: None,
+        }
+    }
+
+    #[test]
+    fn duplicate_skill_names_sync_only_canonical_target_per_tool() {
+        let _lock = central_repo::test_base_dir_lock();
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("repo");
+        central_repo::set_test_base_dir_override(Some(base.clone()));
+        fs::create_dir_all(central_repo::skills_dir()).unwrap();
+        let store = SkillStore::new(&base.join("test.db")).unwrap();
+
+        let target_base = tmp.path().join("agent-skills");
+        fs::create_dir_all(&target_base).unwrap();
+        let custom_tools = vec![tool_adapters::CustomToolDef {
+            key: "test_agent".to_string(),
+            display_name: "Test Agent".to_string(),
+            skills_dir: target_base.to_string_lossy().to_string(),
+            project_relative_skills_dir: None,
+            category: Default::default(),
+        }];
+        store
+            .set_setting(
+                "custom_tools",
+                &serde_json::to_string(&custom_tools).unwrap(),
+            )
+            .unwrap();
+        let disabled_builtin_tools: Vec<String> = tool_adapters::default_tool_adapters()
+            .into_iter()
+            .map(|adapter| adapter.key)
+            .collect();
+        store
+            .set_setting(
+                "disabled_tools",
+                &serde_json::to_string(&disabled_builtin_tools).unwrap(),
+            )
+            .unwrap();
+
+        store
+            .insert_scenario(&ScenarioRecord {
+                id: "preset".to_string(),
+                name: "Preset".to_string(),
+                description: None,
+                icon: None,
+                sort_order: 0,
+                created_at: 1,
+                updated_at: 1,
+            })
+            .unwrap();
+
+        for (id, dir_name, updated_at) in [
+            ("dws-old", "dws", 1),
+            ("dws-copy-2", "dws-2", 2),
+            ("dws-copy-3", "dws-3", 3),
+        ] {
+            let central_path = central_repo::skills_dir().join(dir_name);
+            fs::create_dir_all(&central_path).unwrap();
+            fs::write(central_path.join("SKILL.md"), "---\nname: dws\n---\n").unwrap();
+            store
+                .insert_skill(&sample_skill(id, "dws", central_path, updated_at))
+                .unwrap();
+            store.add_skill_to_scenario("preset", id).unwrap();
+        }
+
+        let plan = collect_scenario_sync_plan(&store, "preset").unwrap();
+        let targets = &plan.targets;
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].skill_id, "dws-old");
+        assert_eq!(targets[0].target, target_base.join("dws"));
+        assert_eq!(plan.report.duplicate_skills.len(), 2);
+
+        for (skill_id, dir_name) in [("dws-copy-2", "dws-2"), ("dws-copy-3", "dws-3")] {
+            let target = target_base.join(dir_name);
+            fs::create_dir_all(&target).unwrap();
+            fs::write(target.join("STALE.txt"), "old duplicate target").unwrap();
+            store
+                .insert_target(&SkillTargetRecord {
+                    id: format!("target-{skill_id}"),
+                    skill_id: skill_id.to_string(),
+                    tool: "test_agent".to_string(),
+                    target_path: target.to_string_lossy().to_string(),
+                    mode: "copy".to_string(),
+                    status: "ok".to_string(),
+                    synced_at: Some(1),
+                    last_error: None,
+                    source_hash: Some(format!("hash-{skill_id}")),
+                })
+                .unwrap();
+        }
+
+        sync_scenario_skills(&store, "preset").unwrap();
+
+        assert!(target_base.join("dws").exists());
+        assert!(!target_base.join("dws-2").exists());
+        assert!(!target_base.join("dws-3").exists());
+        assert!(store
+            .get_targets_for_skill("dws-copy-2")
+            .unwrap()
+            .is_empty());
+        assert!(store
+            .get_targets_for_skill("dws-copy-3")
+            .unwrap()
+            .is_empty());
+
+        central_repo::set_test_base_dir_override(None);
+    }
+}
+
+#[cfg(test)]
 mod sync_desired_targets_tests {
     use super::*;
     use crate::core::central_repo;
@@ -929,7 +1189,10 @@ mod sync_desired_targets_tests {
         sync_desired_targets(&store, &desired).unwrap();
 
         // Sync must have run — target should now exist with the source content.
-        assert!(target.join("SKILL.md").exists(), "missing target was not re-synced");
+        assert!(
+            target.join("SKILL.md").exists(),
+            "missing target was not re-synced"
+        );
 
         central_repo::set_test_base_dir_override(None);
     }

--- a/src-tauri/src/core/skill_store.rs
+++ b/src-tauri/src/core/skill_store.rs
@@ -846,6 +846,45 @@ impl SkillStore {
         Ok(())
     }
 
+    pub fn batch_add_skills_to_scenario(
+        &self,
+        scenario_id: &str,
+        skill_ids: &[String],
+    ) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        let tx = conn.unchecked_transaction()?;
+        let mut count = 0usize;
+        for skill_id in skill_ids {
+            let rows = tx.execute(
+                "INSERT OR IGNORE INTO scenario_skills (scenario_id, skill_id, added_at) VALUES (?1, ?2, ?3)",
+                params![scenario_id, skill_id, now],
+            )?;
+            count += rows;
+        }
+        tx.commit()?;
+        Ok(count)
+    }
+
+    pub fn batch_remove_skills_from_scenario(
+        &self,
+        scenario_id: &str,
+        skill_ids: &[String],
+    ) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let tx = conn.unchecked_transaction()?;
+        let mut count = 0usize;
+        for skill_id in skill_ids {
+            let rows = tx.execute(
+                "DELETE FROM scenario_skills WHERE scenario_id = ?1 AND skill_id = ?2",
+                params![scenario_id, skill_id],
+            )?;
+            count += rows;
+        }
+        tx.commit()?;
+        Ok(count)
+    }
+
     pub fn reorder_scenario_skills(&self, scenario_id: &str, skill_ids: &[String]) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let tx = conn.unchecked_transaction()?;
@@ -1472,22 +1511,23 @@ mod scenario_membership_tests {
         let tmp = tempdir().unwrap();
         let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
 
-        store.insert_scenario(&ScenarioRecord {
-            id: "s1".to_string(),
-            name: "S1".to_string(),
-            description: None,
-            icon: None,
-            sort_order: 0,
-            created_at: 1,
-            updated_at: 1,
-        })
-        .unwrap();
+        store
+            .insert_scenario(&ScenarioRecord {
+                id: "s1".to_string(),
+                name: "S1".to_string(),
+                description: None,
+                icon: None,
+                sort_order: 0,
+                created_at: 1,
+                updated_at: 1,
+            })
+            .unwrap();
         store.upsert_skill(&sample_skill("k1")).unwrap();
 
         let memberships = vec![
-            membership("s1", "k1"),       // valid
-            membership("s1", "ghost"),    // skill missing
-            membership("ghost-s", "k1"),  // scenario missing
+            membership("s1", "k1"),      // valid
+            membership("s1", "ghost"),   // skill missing
+            membership("ghost-s", "k1"), // scenario missing
         ];
 
         // Must not panic with a FOREIGN KEY constraint failure.
@@ -1497,7 +1537,9 @@ mod scenario_membership_tests {
 
         assert_eq!(store.get_skill_ids_for_scenario("s1").unwrap(), vec!["k1"]);
         assert_eq!(
-            store.get_enabled_tools_for_scenario_skill("s1", "k1").unwrap(),
+            store
+                .get_enabled_tools_for_scenario_skill("s1", "k1")
+                .unwrap(),
             vec!["ToolA"]
         );
         assert!(store

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -206,8 +206,16 @@ fn collect_tray_menu_data(store: &core::skill_store::SkillStore) -> TrayMenuData
 }
 
 fn format_status_line(data: &TrayMenuData) -> String {
-    let skill_label = if data.total_skills == 1 { "skill" } else { "skills" };
-    let agent_label = if data.coding_agent_count == 1 { "agent" } else { "agents" };
+    let skill_label = if data.total_skills == 1 {
+        "skill"
+    } else {
+        "skills"
+    };
+    let agent_label = if data.coding_agent_count == 1 {
+        "agent"
+    } else {
+        "agents"
+    };
     format!(
         "{} {} · {} {} connected",
         data.total_skills, skill_label, data.coding_agent_count, agent_label
@@ -241,7 +249,11 @@ fn preset_menu_item_id(preset: &TrayPresetEntry) -> (String, &'static str) {
 }
 
 fn preset_menu_label(preset: &TrayPresetEntry) -> String {
-    let unit = if preset.skill_count == 1 { "skill" } else { "skills" };
+    let unit = if preset.skill_count == 1 {
+        "skill"
+    } else {
+        "skills"
+    };
     match preset.status() {
         TrayPresetStatus::Active => format!("✓ {} ({} {unit})", preset.name, preset.skill_count),
         TrayPresetStatus::Partial => format!(
@@ -561,7 +573,9 @@ fn check_updates_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
                 {
                     Ok(lock) => lock,
                     Err(err) => {
-                        log::warn!("Tray update check: failed to acquire repo lock for {skill_id}: {err}");
+                        log::warn!(
+                            "Tray update check: failed to acquire repo lock for {skill_id}: {err}"
+                        );
                         continue;
                     }
                 };
@@ -624,7 +638,8 @@ fn open_skills_folder_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
 
         let status = cmd.arg(&repo_path).status();
         match status {
-            Ok(_status) => {
+            Ok(_status) =>
+            {
                 #[cfg(not(target_os = "windows"))]
                 if !_status.success() {
                     log::warn!(
@@ -1056,6 +1071,7 @@ pub fn run() {
             commands::presets::apply_preset_to_coding_agents,
             commands::presets::add_skill_to_preset,
             commands::presets::remove_skill_from_preset,
+            commands::presets::batch_toggle_preset_skills,
             commands::presets::reorder_presets,
             commands::projects::reorder_projects,
             commands::presets::get_preset_skill_order,

--- a/src/components/PresetBar.tsx
+++ b/src/components/PresetBar.tsx
@@ -3,7 +3,7 @@ import { Check, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { cn } from "../utils";
-import { computePresetStatus } from "../lib/presetStatus";
+import { canonicalPresetSkills, computePresetStatus } from "../lib/presetStatus";
 import { getPresetIconOption } from "../lib/presetIcons";
 import type { ManagedSkill, Preset } from "../lib/tauri";
 import { getErrorMessage } from "../lib/error";
@@ -47,13 +47,24 @@ export function PresetBar({
     setLoadingKey(`${preset.id}-add`);
     try {
       const presetSkills = managedSkills.filter((s) => s.preset_ids.includes(preset.id));
+      const canonicalSkills = canonicalPresetSkills(preset, managedSkills);
+      const duplicateCount = presetSkills.length - canonicalSkills.length;
       let added = 0, skipped = 0, failed = 0;
-      for (const skill of presetSkills) {
+      for (const skill of canonicalSkills) {
         for (const agentKey of agentKeys) {
           if (existsInWorkspace(skill, agentKey)) { skipped++; continue; }
           try { await onAddSkill(skill, agentKey); added++; }
           catch { failed++; }
         }
+      }
+      if (duplicateCount > 0) {
+        const duplicateNames = Array.from(
+          new Set(presetSkills.map((skill) => skill.name))
+        ).filter((name) => presetSkills.filter((skill) => skill.name === name).length > 1);
+        toast.warning(t("presetActions.duplicateSkillsSkipped", {
+          count: duplicateCount * agentKeys.length,
+          names: duplicateNames.slice(0, 3).join(", "),
+        }));
       }
       if (added > 0) {
         toast.success(t("presetActions.addedToast", { added, skipped }));

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -151,7 +151,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   const handleApplyPresetToDefault = useCallback(
     async (id: string) => {
-      await api.applyPresetToDefault(id);
+      const report = await api.applyPresetToDefault(id);
+      const duplicateCount = report.duplicate_skills.length;
+      if (duplicateCount > 0) {
+        const names = Array.from(new Set(report.duplicate_skills.map((item) => item.skill_name)))
+          .slice(0, 3)
+          .join(", ");
+        toast.warning(i18n.t("presetActions.duplicateSkillsSkipped", { count: duplicateCount, names }));
+      }
       await Promise.all([refreshPresets(), refreshManagedSkills()]);
     },
     [refreshManagedSkills, refreshPresets]

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -978,6 +978,7 @@
     "removeButton": "Remove selected ({{count}})",
     "addedToast": "Added {{added}} skill-agent item(s), skipped {{skipped}} existing.",
     "removedToast": "Removed {{removed}} skill-agent item(s).",
+    "duplicateSkillsSkipped": "Duplicate skill names detected. Synced the canonical version only; skipped {{count}} duplicate item(s) ({{names}}).",
     "partialFailedToast": "{{count}} operation(s) failed",
     "nothingToAdd": "No missing skills to add",
     "nothingToRemove": "No matching skills to remove",

--- a/src/i18n/zh-TW.json
+++ b/src/i18n/zh-TW.json
@@ -894,6 +894,7 @@
     "removeButton": "移除所選 ({{count}})",
     "addedToast": "已加入 {{added}} 個 Skill-Agent 項，略過 {{skipped}} 個已存在項。",
     "removedToast": "已移除 {{removed}} 個 Skill-Agent 項。",
+    "duplicateSkillsSkipped": "偵測到同名 Skill，已只同步規範版本；略過 {{count}} 個重複項（{{names}}）。",
     "partialFailedToast": "{{count}} 個操作失敗",
     "nothingToAdd": "沒有缺少 Skills 可加入",
     "nothingToRemove": "沒有符合 Skills 可移除",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -978,6 +978,7 @@
     "removeButton": "移除所选 ({{count}})",
     "addedToast": "已添加 {{added}} 个 Skill-Agent 项，跳过 {{skipped}} 个已存在项。",
     "removedToast": "已移除 {{removed}} 个 Skill-Agent 项。",
+    "duplicateSkillsSkipped": "检测到同名 Skill，已只同步规范版本；跳过 {{count}} 个重复项（{{names}}）。",
     "partialFailedToast": "{{count}} 个操作失败",
     "nothingToAdd": "没有缺失 Skills 可添加",
     "nothingToRemove": "没有匹配 Skills 可移除",

--- a/src/lib/presetStatus.ts
+++ b/src/lib/presetStatus.ts
@@ -8,13 +8,32 @@ export interface PresetStatusResult {
   total: number;
 }
 
+function centralDirName(skill: ManagedSkill) {
+  return skill.central_path.split(/[\\/]/).filter(Boolean).pop() ?? skill.name;
+}
+
+export function canonicalPresetSkills(preset: Preset, skills: ManagedSkill[]) {
+  const presetSkills = skills.filter((s) => s.preset_ids.includes(preset.id));
+  const byName = new Map<string, ManagedSkill[]>();
+  for (const skill of presetSkills) {
+    const group = byName.get(skill.name) ?? [];
+    group.push(skill);
+    byName.set(skill.name, group);
+  }
+
+  return Array.from(byName.values()).map((group) => {
+    if (group.length === 1) return group[0];
+    return group.find((skill) => centralDirName(skill) === skill.name) ?? group[0];
+  });
+}
+
 export function computePresetStatus(
   preset: Preset,
   skills: ManagedSkill[],
   agentKeys: string[],
   existsInWorkspace: (skill: ManagedSkill, agentKey: string) => boolean
 ): PresetStatusResult {
-  const presetSkills = skills.filter((s) => s.preset_ids.includes(preset.id));
+  const presetSkills = canonicalPresetSkills(preset, skills);
   if (presetSkills.length === 0 || agentKeys.length === 0) {
     return { status: "empty", installed: 0, total: 0 };
   }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -109,6 +109,18 @@ export interface Preset {
   updated_at: number;
 }
 
+export interface DuplicateScenarioSkill {
+  skill_id: string;
+  skill_name: string;
+  tool: string;
+  target_name: string;
+  selected_skill_id: string;
+}
+
+export interface ScenarioSyncReport {
+  duplicate_skills: DuplicateScenarioSkill[];
+}
+
 export interface DiscoveredGroup {
   name: string;
   fingerprint: string | null;
@@ -702,10 +714,10 @@ export const deletePreset = (id: string) =>
 
 /** @deprecated v1.16+: clicking a scene no longer applies. Use applyPresetToDefault. */
 export const switchPreset = (id: string) =>
-  invoke<void>("switch_preset", { id });
+  invoke<ScenarioSyncReport>("switch_preset", { id });
 
 export const applyPresetToDefault = (id: string) =>
-  invoke<void>("apply_preset_to_default", { id });
+  invoke<ScenarioSyncReport>("apply_preset_to_default", { id });
 
 export const addSkillToPreset = (skillId: string, presetId: string) =>
   invoke<void>("add_skill_to_preset", { skillId, presetId });

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -725,6 +725,12 @@ export const addSkillToPreset = (skillId: string, presetId: string) =>
 export const removeSkillFromPreset = (skillId: string, presetId: string) =>
   invoke<void>("remove_skill_from_preset", { skillId, presetId });
 
+export const batchTogglePresetSkills = (
+  presetId: string,
+  skillIds: string[],
+  enable: boolean
+) => invoke<number>("batch_toggle_preset_skills", { presetId, skillIds, enable });
+
 export const reorderPresets = (ids: string[]) =>
   invoke<void>("reorder_presets", { ids });
 

--- a/src/views/MySkills.tsx
+++ b/src/views/MySkills.tsx
@@ -563,32 +563,25 @@ export function MySkills() {
     if (!viewedPreset) return;
     const selectedSkillsList = skills.filter((s) => selectedIds.has(s.id));
     const enabling = anyDisabled;
-    let count = 0;
-    let failed = 0;
-    for (const skill of selectedSkillsList) {
-      try {
+    const toggledSkillIds = selectedSkillsList
+      .filter((skill) => {
         const enabledInPreset = skill.preset_ids.includes(viewedPreset.id);
-        if (enabling && !enabledInPreset) {
-          await api.addSkillToPreset(skill.id, viewedPreset.id);
-          count++;
-        } else if (!enabling && enabledInPreset) {
-          await api.removeSkillFromPreset(skill.id, viewedPreset.id);
-          count++;
-        }
-      } catch {
-        failed++;
-        // continue with remaining
-      }
+        return enabling ? !enabledInPreset : enabledInPreset;
+      })
+      .map((skill) => skill.id);
+    if (toggledSkillIds.length === 0) {
+      toast.info(enabling ? t("presetActions.nothingToAdd") : t("presetActions.nothingToRemove"));
+      return;
     }
-    if (count > 0) {
+    try {
+      const count = await api.batchTogglePresetSkills(viewedPreset.id, toggledSkillIds, enabling);
       toast.success(enabling
         ? t("mySkills.batchEnabled", { count })
         : t("mySkills.batchDisabled", { count }));
+      await Promise.all([refreshManagedSkills(), refreshPresets()]);
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("common.error")));
     }
-    if (failed > 0) {
-      toast.error(t("mySkills.batchToggleFailed", { count: failed }));
-    }
-    await Promise.all([refreshManagedSkills(), refreshPresets()]);
   };
 
   const handleBatchRefresh = async () => {


### PR DESCRIPTION
## Summary
- Deduplicate same-name skills during scenario/preset sync by selecting a canonical target per `(tool, target_name)` and reporting skipped duplicates to the UI.
- Clean up stale duplicate scenario targets during sync so old duplicate entries/directories do not linger.
- Add a batched preset skill toggle command so multi-select enable/disable uses one IPC/DB transaction instead of N calls.

## Test Plan
- `npm run build`
- `cd src-tauri && cargo test scenario_service::`

## Commits
- `6044914` feat: 同名 skill 去重与存量清理
- `357100a` perf: 批量 toggle skill 从 N 次 IPC 合并为 1 次调用