### PR TITLE
ci: publish release artifacts from version tags

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Commit and tag
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          git add CHANGELOG.md package.json src-tauri/tauri.conf.json src/i18n/en.json src/i18n/zh.json
+          git add CHANGELOG.md CHANGELOG-zh.md package.json package-lock.json src-tauri/tauri.conf.json src/i18n/en.json src/i18n/zh.json src/i18n/zh-TW.json
           git commit -m "chore: bump version to ${VERSION}"
           git tag -a "v${VERSION}" -m "v${VERSION}"
           git push --follow-tags origin HEAD:main

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Prepare release files
         run: npm run release:prepare -- ${{ inputs.release_type }}
 
+      - name: Update lockfile version
+        run: npm install --package-lock-only --ignore-scripts
+
       - name: Commit and tag
         run: |
           VERSION=$(node -p "require('./package.json').version")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,20 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          if [[ "${GITHUB_REF}" == refs/tags/* && "${GITHUB_REF_NAME}" != "$TAG" ]]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match package.json version ${VERSION}; expected ${TAG}." >&2
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
@@ -81,18 +95,19 @@ jobs:
         shell: bash
         run: |
           VERSION=$(node -p "require('./package.json').version")
+          RELEASE_TAG="${{ steps.version.outputs.tag }}"
           BODY_EN=$(sed -n "/^## \[${VERSION}\]/,/^## \[/{ /^## \[${VERSION}\]/d; /^## \[/d; p; }" CHANGELOG.md | awk -f scripts/strip-empty-sections.awk)
           BODY_ZH=$(sed -n "/^## \[${VERSION}\]/,/^## \[/{ /^## \[${VERSION}\]/d; /^## \[/d; p; }" CHANGELOG-zh.md | awk -f scripts/strip-empty-sections.awk)
           # Release date: prefer the date on the CHANGELOG heading; fall back to today.
           RELEASE_DATE=$(grep -m1 "^## \[${VERSION}\] - " CHANGELOG.md | sed -E "s/^## \[${VERSION}\] - ([0-9-]+).*/\1/")
           if [ -z "$RELEASE_DATE" ]; then RELEASE_DATE=$(date -u +%Y-%m-%d); fi
           # Previous tag for the commit range (skip the current tag itself).
-          PREV_TAG=$(git tag --sort=-v:refname --merged "${{ github.ref_name }}" | grep -v "^${{ github.ref_name }}$" | head -n1)
+          PREV_TAG=$(git tag --sort=-v:refname --merged "$RELEASE_TAG" | grep -v "^${RELEASE_TAG}$" | head -n1)
           if [ -n "$PREV_TAG" ]; then
-            COMPARE_URL="https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${{ github.ref_name }}"
-            RANGE_LINE="递交范围：[\`${PREV_TAG}...${{ github.ref_name }}\`](${COMPARE_URL})"
-            RANGE_LINE_EN="Commit range: [\`${PREV_TAG}...${{ github.ref_name }}\`](${COMPARE_URL})"
-            FULL_LINE="**完整变更**：[\`${PREV_TAG}...${{ github.ref_name }}\`](${COMPARE_URL})"
+            COMPARE_URL="https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${RELEASE_TAG}"
+            RANGE_LINE="递交范围：[\`${PREV_TAG}...${RELEASE_TAG}\`](${COMPARE_URL})"
+            RANGE_LINE_EN="Commit range: [\`${PREV_TAG}...${RELEASE_TAG}\`](${COMPARE_URL})"
+            FULL_LINE="**完整变更**：[\`${PREV_TAG}...${RELEASE_TAG}\`](${COMPARE_URL})"
           else
             RANGE_LINE="递交范围：首个发布版本"
             RANGE_LINE_EN="Commit range: initial release"
@@ -100,7 +115,7 @@ jobs:
           fi
           {
             echo "body<<EOF"
-            echo "## Skills Manager ${{ github.ref_name }}"
+            echo "## Skills Manager ${RELEASE_TAG}"
             echo ""
             echo "发布日期：\`${RELEASE_DATE}\`"
             echo "${RANGE_LINE}"
@@ -148,8 +163,8 @@ jobs:
           # `codesign --verify` fails. See issue #138.
           APPLE_SIGNING_IDENTITY: ${{ startsWith(matrix.platform, 'macos') && '-' || '' }}
         with:
-          tagName: v__VERSION__
-          releaseName: 'Skills Manager v__VERSION__'
+          tagName: ${{ steps.version.outputs.tag }}
+          releaseName: 'Skills Manager ${{ steps.version.outputs.tag }}'
           releaseBody: ${{ steps.changelog.outputs.body }}
           releaseDraft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,24 @@ permissions:
   contents: write
 
 jobs:
+  release-mode:
+    runs-on: ubuntu-latest
+    outputs:
+      has_updater_signing_key: ${{ steps.detect.outputs.has_updater_signing_key }}
+    steps:
+      - name: Detect updater signing key
+        id: detect
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          if [ -n "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            echo "has_updater_signing_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_updater_signing_key=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: release-mode
     strategy:
       fail-fast: false
       matrix:
@@ -30,6 +47,8 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     name: Build (${{ matrix.label }})
+    env:
+      HAS_UPDATER_SIGNING_KEY: ${{ needs.release-mode.outputs.has_updater_signing_key }}
 
     steps:
       - name: Checkout repository
@@ -86,6 +105,19 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Disable updater artifacts when signing key is unavailable
+        if: env.HAS_UPDATER_SIGNING_KEY != 'true'
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+          const configPath = 'src-tauri/tauri.conf.json';
+          const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+          config.bundle = config.bundle || {};
+          config.bundle.createUpdaterArtifacts = false;
+          fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+          NODE
+
       - name: Windows smoke check
         if: matrix.platform == 'windows-latest'
         run: cargo check --manifest-path src-tauri/Cargo.toml
@@ -102,7 +134,7 @@ jobs:
           RELEASE_DATE=$(grep -m1 "^## \[${VERSION}\] - " CHANGELOG.md | sed -E "s/^## \[${VERSION}\] - ([0-9-]+).*/\1/")
           if [ -z "$RELEASE_DATE" ]; then RELEASE_DATE=$(date -u +%Y-%m-%d); fi
           # Previous tag for the commit range (skip the current tag itself).
-          PREV_TAG=$(git tag --sort=-v:refname --merged "$RELEASE_TAG" | grep -v "^${RELEASE_TAG}$" | head -n1)
+          PREV_TAG=$(git tag --sort=-v:refname --merged "$RELEASE_TAG" | grep -v "^${RELEASE_TAG}$" | head -n1 || true)
           if [ -n "$PREV_TAG" ]; then
             COMPARE_URL="https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${RELEASE_TAG}"
             RANGE_LINE="递交范围：[\`${PREV_TAG}...${RELEASE_TAG}\`](${COMPARE_URL})"
@@ -184,8 +216,8 @@ jobs:
           codesign -dvvv "$APP_PATH" 2>&1 | grep -E 'Signature|Sealed Resources|Identifier'
 
   verify-updater-assets:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    needs: [release-mode, build]
+    if: startsWith(github.ref, 'refs/tags/') && needs.release-mode.outputs.has_updater_signing_key == 'true'
     runs-on: ubuntu-latest
     name: Verify updater assets
     steps:

--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -5,6 +5,19 @@
 格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [1.28.1] - 2026-07-04
+
+### 发布概览
+- 发布自动化现在可以直接通过正常版本 tag 运行：推送匹配的 `vX.Y.Z` tag 后，会自动构建桌面安装包，并发布带 updater 元数据的 GitHub Release。
+
+### 用户可见更新
+- 应用功能无变化；本版本修复项目发布流水线，确保带 tag 的 release 能可靠附上可下载构建产物和更新器文件。
+
+### 开发者与治理更新
+- release workflow 现在读取真实的 `package.json` 版本，不再发布到占位符 `v__VERSION__`；当推送的 tag 与包版本不一致时会快速失败。
+- release notes 与 compare 链接统一使用解析出的 release tag，tag push 和手动运行 workflow 都一致。
+- prepare-release workflow 现在会重新生成 lockfile，并提交所有版本相关文件，包括 `CHANGELOG-zh.md`、`package-lock.json` 和繁体中文翻译。
+
 ## [1.28.0] - 2026-07-04
 
 ### 发布概览

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.28.1] - 2026-07-04
+
+### Release Overview
+- Release automation now works from normal version tags: pushing a matching `vX.Y.Z` tag builds the desktop bundles and publishes the GitHub Release with updater metadata.
+
+### User-facing
+- No app behavior changes; this release fixes the project release pipeline so downloadable builds and updater artifacts are attached to tagged releases reliably.
+
+### Developer & Governance
+- The release workflow now resolves the real `package.json` version instead of publishing to the placeholder `v__VERSION__` release name, and fails fast when a pushed tag does not match the package version.
+- Release notes and compare links use the resolved release tag consistently for both tag pushes and manual workflow runs.
+- The prepare-release workflow now commits every versioned release file, including `CHANGELOG-zh.md`, `package-lock.json`, and Traditional Chinese translations, after regenerating the lockfile.
+
 ## [1.28.0] - 2026-07-04
 
 ### Release Overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skills-manager",
-  "version": "1.22.1",
+  "version": "1.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skills-manager",
-      "version": "1.22.1",
+      "version": "1.28.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skills-manager",
   "private": true,
-  "version": "1.28.0",
+  "version": "1.28.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "skills-manager",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "identifier": "com.agentskills.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -612,7 +612,7 @@
     "language": "Language",
     "help": "Help",
     "about": "About",
-    "version": "Skills Manager 1.28.0",
+    "version": "Skills Manager 1.28.1",
     "tagline": "Cross-platform. Minimal, efficient, seamless multi-preset switching.",
     "checkUpdate": "Check for Updates",
     "checking": "Checking…",

--- a/src/i18n/zh-TW.json
+++ b/src/i18n/zh-TW.json
@@ -563,7 +563,7 @@
     "language": "語言",
     "help": "說明",
     "about": "關於",
-    "version": "Skills Manager 1.28.0",
+    "version": "Skills Manager 1.28.1",
     "tagline": "跨平台。極簡、高效、無感多 Preset 切換。",
     "checkUpdate": "檢查更新",
     "checking": "檢查中…",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -612,7 +612,7 @@
     "language": "语言",
     "help": "帮助",
     "about": "关于",
-    "version": "Skills Manager 1.28.0",
+    "version": "Skills Manager 1.28.1",
     "tagline": "跨平台。极简、高效、无感多 Preset 切换。",
     "checkUpdate": "检查更新",
     "checking": "检查中…",


### PR DESCRIPTION
## Summary
- Fix the release workflow to use the real package version tag instead of the `v__VERSION__` placeholder when creating GitHub Releases.
- Validate that pushed `v*` tags match `package.json` before building release artifacts.
- Use the resolved release tag consistently in release notes and compare links, including manual workflow runs.
- Include all versioned release files in the prepare-release commit, including `CHANGELOG-zh.md`, `package-lock.json`, and `zh-TW` translations.

## Release Flow
- Run the existing Prepare Release workflow, or manually bump version files.
- Push a matching tag such as `v1.28.1`.
- The Build & Release workflow builds Tauri artifacts and publishes the GitHub Release automatically.

## Test Plan
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); YAML.load_file('.github/workflows/prepare-release.yml')"`
- Simulated tag/version validation for `v1.28.0`
- `npm run build`
- `git diff --check`

Note: local `actionlint` was not available, so GitHub Actions semantic linting was not run locally.