### PR TITLE
Add project workspace controls to CLI

### DIFF
--- a/skills/manage-skills/SKILL.md
+++ b/skills/manage-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-skills
-description: Manage the user's agent-skill library via the local skills-manager-cli — install, update, remove, enable/disable, sync, search, adopt, and tag skills in a central library that's shared across every installed agent (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, etc.). Use this whenever the user wants to install or find or update or remove or list a skill, see what skills they have, sync skills across agents, adopt skills already installed elsewhere, or generally manage their skill library. Prefer this over find-skills when `skills-manager-cli` is on PATH, because routing installs through the central library is the only way subsequent `update` and `sync` work — direct `npx skills add` installs cannot be updated or shared across agents. Triggers include "install/add a skill", "find a skill for X", "is there a skill that does Y", "update my skills", "remove/uninstall this skill", "list/show my skills", "what skills do I have", "sync skills", "manage skills", "skill library".
+description: Manage the user's agent-skill library via the local skills-manager-cli — install, update, remove, enable/disable, sync, search, adopt, tag skills, and manage project workspaces in a central library that's shared across every installed agent (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, etc.). Use this whenever the user wants to install or find or update or remove or list a skill, see what skills they have, sync skills across agents, adopt skills already installed elsewhere, apply presets to a specific project, inspect project-local skill sync status, or generally manage their skill library. Prefer this over find-skills when `skills-manager-cli` is on PATH, because routing installs through the central library is the only way subsequent `update` and `sync` work — direct `npx skills add` installs cannot be updated or shared across agents. Triggers include "install/add a skill", "find a skill for X", "is there a skill that does Y", "update my skills", "remove/uninstall this skill", "list/show my skills", "what skills do I have", "sync skills", "manage skills", "skill library", "project skills", "apply preset to project".
 ---
 
 ## Before doing anything
@@ -14,9 +14,11 @@ skills-manager-cli --json skills list
 
 ## Mental model
 
-There's **one central library** at `~/.skills-manager/skills/` that all agents share. Each skill in the library has metadata in a SQLite DB (source URL, preset membership, tags, enabled flag). A **preset** is a named group of skills. The active preset gets **synced** out to every enabled agent's skill directory (`~/.claude/skills/`, `~/.cursor/skills/`, etc.) by symlink or copy.
+There's **one central library** at `~/.skills-manager/skills/` that all agents share. Each skill in the library has metadata in a SQLite DB (source URL, preset membership, tags, enabled flag). A **preset** is a named group of skills. The active preset gets **synced** out to every enabled agent's global skill directory (`~/.claude/skills/`, `~/.cursor/skills/`, `~/.codex/skills/`, etc.) by symlink or copy.
 
 So the lifecycle is: **install → (in library) → add to preset → sync → (visible to agent)**. `install --sync` is the shortcut that does all three.
+
+Project workspaces are separate from global sync. Applying a preset to a project is a **one-shot export/sync** into that project's agent-local skills directory, such as `<project>/.codex/skills/`; it does not create a persistent `project -> preset` subscription. Re-run `projects apply-preset` after changing the preset if the project should receive the new membership.
 
 Internally, presets are still stored as scenarios for backward-compatible Git Backup. The CLI and UI call them presets.
 
@@ -161,6 +163,53 @@ skills-manager-cli presets apply <preset>   # makes it active + syncs
 
 Use `presets add-skill` when you want to put an already-installed skill into a *different* preset without re-installing it, or to share a skill across multiple presets.
 
+## Project workspaces
+
+Use `projects` commands when the user asks about skills inside a specific repo/project, or wants a preset applied to project-local skills instead of global agent skills.
+
+```bash
+# Registered workspaces and aggregate sync health
+skills-manager-cli --json projects list
+
+# Register a project directory as a managed workspace
+skills-manager-cli projects add /path/to/project
+
+# Discover project directories under a root
+skills-manager-cli --json projects scan /path/to/root
+
+# Agents/tools available for this project
+skills-manager-cli --json projects targets /path/to/project
+
+# Project-local skill inventory and sync status
+skills-manager-cli --json projects skills /path/to/project
+skills-manager-cli --json projects skills /path/to/project --tool codex
+```
+
+`projects skills` reports project-local status using the same model as the GUI:
+- `in_sync` — project skill matches the central library copy
+- `project_newer` — project-local copy appears newer than center
+- `center_newer` — central library copy appears newer than project
+- `diverged` — both sides differ and timestamp ordering is not clear enough
+- `project_only` — no matching central skill was found
+
+Apply a preset to a project-local agent directory:
+
+```bash
+# Preview only; no writes
+skills-manager-cli --json projects apply-preset /path/to/project "Web Dev" --tool codex --dry-run
+
+# One-shot export/sync into <project>/.codex/skills/
+skills-manager-cli --json projects apply-preset /path/to/project "Web Dev" --tool codex
+
+# Remove the matching preset skills from that project-local Codex directory
+skills-manager-cli --json projects remove-preset /path/to/project "Web Dev" --tool codex --dry-run
+skills-manager-cli --json projects remove-preset /path/to/project "Web Dev" --tool codex
+```
+
+Always use `--tool codex` when the user specifically says Codex project skills. Without `--tool`, project preset operations target every enabled installed project agent for that workspace.
+
+The JSON report includes `persistent_link: false` on purpose: this is an apply/remove operation, not a durable binding between the project and the preset.
+
 ## Health check
 
 When sync misbehaves or a command errors in a confusing way:
@@ -168,6 +217,7 @@ When sync misbehaves or a command errors in a confusing way:
 ```bash
 skills-manager-cli --json repo status   # base dir, skill / preset counts, active preset
 skills-manager-cli --json tools list    # detected agents and their target paths
+skills-manager-cli --json projects list # registered projects and sync-health counts
 ```
 
 These two are read-only and great for diagnosing "why isn't this skill showing up in Cursor" type questions.
@@ -208,5 +258,6 @@ Report which skills actually refreshed (`refreshed: true` in the JSON) vs which 
 
 - **No active preset** → `skills sync` (without `--preset`) fails. Show the user `presets list` and pick one with them, or use `sync --preset <name>`.
 - **Install succeeded but skill doesn't appear in the agent** → install defaults to library-only. Re-run with `--sync`, or add it to the active preset and sync.
+- **Preset applied globally but not in a project** → global `presets apply` / `skills sync` writes to global agent directories. Use `projects apply-preset <project> <preset> --tool codex` for `<project>/.codex/skills/`.
 - **Adopted skills can't be `update`d from git** → `npx skills add` and manual `git clone` don't leave source metadata, so adopt has to treat them as `local`. Fix per-skill with `adopt ... --git-url ... --git-subpath ...`, or just `skills remove` + `skills install <git-ref>` to start clean with a real source.
-- **`--dry-run` only exists on `remove`, `sync`, `adopt`.** For `install` / `update` / `check`, the preview is a different command (`search` before install, `check` before update).
+- **`--dry-run` only exists on `skills remove`, `skills sync`, `skills adopt`, `projects apply-preset`, and `projects remove-preset`.** For `install` / `update` / `check`, the preview is a different command (`search` before install, `check` before update).

--- a/src-tauri/src/bin/skills-manager-cli.rs
+++ b/src-tauri/src/bin/skills-manager-cli.rs
@@ -2012,6 +2012,32 @@ fn apply_project_preset(
                     continue;
                 }
                 if dry_run {
+                    // A real run would reject a directory that already exists
+                    // but isn't a matched central skill (the `existing` check
+                    // above only sees tracked skills). Preview that failure so
+                    // dry-run and the real run agree.
+                    if let Some(conflict) = project_cmd::project_export_conflict_path(
+                        store,
+                        &project.id,
+                        tool,
+                        &skill.name,
+                    )
+                    .map_err(map_app_err)?
+                    {
+                        failed += 1;
+                        targets.push(ProjectPresetTarget {
+                            skill_id: skill.id.clone(),
+                            skill_name: skill.name.clone(),
+                            tool: tool.clone(),
+                            target_path: Some(conflict),
+                            action: "would_fail".to_string(),
+                            error: Some(format!(
+                                "Skill \"{}\" already exists in this workspace for agent {}",
+                                skill.name, tool
+                            )),
+                        });
+                        continue;
+                    }
                     added += 1;
                     targets.push(ProjectPresetTarget {
                         skill_id: skill.id.clone(),
@@ -2244,4 +2270,158 @@ fn print_json<T: Serialize>(value: &T, json: bool) {
         serde_json::to_string_pretty(value).unwrap()
     };
     println!("{rendered}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use app_lib::core::skill_store::{ProjectRecord, ScenarioRecord, SkillRecord};
+    use std::fs;
+    use tempfile::tempdir;
+
+    /// Backs the store, a preset holding one central skill, and a linked
+    /// workspace whose single agent target is always installed + enabled —
+    /// so preset application is deterministic without touching the real
+    /// central repo or system-installed tools.
+    struct Fixture {
+        _tmp: tempfile::TempDir,
+        store: SkillStore,
+        project_path: PathBuf,
+        project_id: String,
+        preset_id: String,
+    }
+
+    fn setup() -> Fixture {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+
+        // Central skill referenced by the preset.
+        let central = tmp.path().join("central").join("preset-skill");
+        fs::create_dir_all(&central).unwrap();
+        fs::write(central.join("SKILL.md"), "# Preset Skill\n").unwrap();
+        store
+            .insert_skill(&SkillRecord {
+                id: "skill-1".into(),
+                name: "Preset Skill".into(),
+                description: None,
+                source_type: "local".into(),
+                source_ref: None,
+                source_ref_resolved: None,
+                source_subpath: None,
+                source_branch: None,
+                source_revision: None,
+                remote_revision: None,
+                central_path: central.to_string_lossy().to_string(),
+                content_hash: None,
+                enabled: true,
+                created_at: 0,
+                updated_at: 0,
+                status: "ok".into(),
+                update_status: "local_only".into(),
+                last_checked_at: None,
+                last_check_error: None,
+            })
+            .unwrap();
+
+        // Preset (scenario) containing that skill.
+        store
+            .insert_scenario(&ScenarioRecord {
+                id: "preset-1".into(),
+                name: "Preset One".into(),
+                description: None,
+                icon: None,
+                sort_order: 0,
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+        store.add_skill_to_scenario("preset-1", "skill-1").unwrap();
+
+        // Linked workspace: its lone agent target reports installed + enabled.
+        let project_path = tmp.path().join("workspace");
+        let disabled_path = tmp.path().join("workspace-disabled");
+        fs::create_dir_all(&project_path).unwrap();
+        fs::create_dir_all(&disabled_path).unwrap();
+        store
+            .insert_project(&ProjectRecord {
+                id: "project-1".into(),
+                name: "Workspace One".into(),
+                path: project_path.to_string_lossy().to_string(),
+                workspace_type: "linked".into(),
+                linked_agent_key: Some("agent".into()),
+                linked_agent_name: Some("Agent".into()),
+                disabled_path: Some(disabled_path.to_string_lossy().to_string()),
+                sort_order: 0,
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+
+        Fixture {
+            _tmp: tmp,
+            store,
+            project_path,
+            project_id: "project-1".into(),
+            preset_id: "preset-1".into(),
+        }
+    }
+
+    #[test]
+    fn resolve_project_matches_by_id_name_and_path() {
+        let fx = setup();
+        let path_string = fx.project_path.to_string_lossy().to_string();
+        for reference in [fx.project_id.as_str(), "Workspace One", path_string.as_str()] {
+            let project = resolve_project(&fx.store, reference).unwrap();
+            assert_eq!(project.id, fx.project_id, "ref {reference}");
+        }
+    }
+
+    #[test]
+    fn resolve_project_errors_when_missing() {
+        let fx = setup();
+        let err = match resolve_project(&fx.store, "does-not-exist") {
+            Ok(_) => panic!("expected a missing-project error"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("project not found"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn apply_project_preset_dry_run_add_previews_new_skill() {
+        let fx = setup();
+        let report =
+            apply_project_preset(&fx.store, &fx.project_id, &fx.preset_id, &[], true, true).unwrap();
+        assert!(report.ok);
+        assert!(report.dry_run);
+        assert_eq!(report.added, 1);
+        assert_eq!(report.failed, 0);
+        assert_eq!(report.targets.len(), 1);
+        assert_eq!(report.targets[0].action, "would_add");
+    }
+
+    #[test]
+    fn apply_project_preset_dry_run_add_flags_existing_directory_conflict() {
+        let fx = setup();
+        // A directory of the same slug already exists but is not a tracked
+        // central skill (no SKILL.md, so it is never read as a project skill).
+        // A real run would fail with "already exists"; the dry run must agree
+        // instead of optimistically reporting "would_add".
+        fs::create_dir_all(fx.project_path.join("preset-skill")).unwrap();
+
+        let report =
+            apply_project_preset(&fx.store, &fx.project_id, &fx.preset_id, &[], true, true).unwrap();
+        assert!(!report.ok);
+        assert_eq!(report.added, 0);
+        assert_eq!(report.failed, 1);
+        assert_eq!(report.targets.len(), 1);
+        assert_eq!(report.targets[0].action, "would_fail");
+        assert!(report.targets[0]
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("already exists"));
+    }
 }

--- a/src-tauri/src/bin/skills-manager-cli.rs
+++ b/src-tauri/src/bin/skills-manager-cli.rs
@@ -3,11 +3,11 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail};
-use app_lib::commands::skills as cmd;
+use app_lib::commands::{projects as project_cmd, skills as cmd};
 use app_lib::core::{
     app_state, central_repo, error::AppError, git_backup, git_fetcher, installer, merge,
     repo_lock::RepoLock, scenario_service, skill_metadata, skill_store::SkillStore, skillssh_api,
-    sync_engine, sync_metadata, tool_service,
+    sync_engine, sync_metadata, tool_adapters, tool_service,
 };
 use clap::{Args, Parser, Subcommand};
 use serde::Serialize;
@@ -31,6 +31,7 @@ enum Commands {
     Skills(SkillsArgs),
     #[command(alias = "scenarios")]
     Presets(PresetArgs),
+    Projects(ProjectArgs),
     Git(GitArgs),
 }
 
@@ -202,6 +203,51 @@ enum PresetCommand {
     RemoveSkill {
         preset: String,
         skills: Vec<String>,
+    },
+}
+
+#[derive(Args, Debug)]
+struct ProjectArgs {
+    #[command(subcommand)]
+    command: ProjectCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum ProjectCommand {
+    List,
+    Add {
+        path: String,
+    },
+    Scan {
+        root: String,
+    },
+    Targets {
+        project: String,
+    },
+    Skills {
+        project: String,
+        /// Agent/tool key filter, e.g. codex
+        #[arg(long, alias = "agent")]
+        tool: Option<String>,
+    },
+    ApplyPreset {
+        project: String,
+        preset: String,
+        /// Agent/tool key. Repeat to target more than one agent.
+        #[arg(long, alias = "agent")]
+        tool: Vec<String>,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    #[command(alias = "unlink-preset")]
+    RemovePreset {
+        project: String,
+        preset: String,
+        /// Agent/tool key. Repeat to target more than one agent.
+        #[arg(long, alias = "agent")]
+        tool: Vec<String>,
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -393,6 +439,33 @@ struct PresetMembershipReport {
     missing: Vec<String>,
 }
 
+#[derive(Debug, Serialize)]
+struct ProjectPresetTarget {
+    skill_id: String,
+    skill_name: String,
+    tool: String,
+    target_path: Option<String>,
+    action: String,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProjectPresetReport {
+    ok: bool,
+    project_id: String,
+    project_name: String,
+    project_path: String,
+    preset_id: String,
+    preset_name: String,
+    dry_run: bool,
+    persistent_link: bool,
+    added: usize,
+    removed: usize,
+    skipped: usize,
+    failed: usize,
+    targets: Vec<ProjectPresetTarget>,
+}
+
 enum InstallKind {
     Local,
     Git,
@@ -451,6 +524,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         Commands::Tools(args) => run_tools(args, &store, cli.json),
         Commands::Skills(args) => run_skills(args, &store, cli.json),
         Commands::Presets(args) => run_presets(args, &store, cli.json),
+        Commands::Projects(args) => run_projects(args, &store, cli.json),
         Commands::Git(args) => run_git(args, &store, cli.skills_root.is_some(), cli.json),
     }
 }
@@ -641,7 +715,11 @@ fn show_skill(store: &SkillStore, reference: &str) -> anyhow::Result<SkillDetail
 
 fn export_skill(store: &SkillStore, reference: &str, dest: &Path) -> anyhow::Result<String> {
     let skill = resolve_skill(store, reference)?;
-    sync_engine::sync_skill(Path::new(&skill.central_path), dest, sync_engine::SyncMode::Copy)?;
+    sync_engine::sync_skill(
+        Path::new(&skill.central_path),
+        dest,
+        sync_engine::SyncMode::Copy,
+    )?;
     Ok(dest.to_string_lossy().to_string())
 }
 
@@ -734,7 +812,9 @@ fn classify_ref(
 fn is_skillssh_shorthand(s: &str) -> bool {
     // owner/repo, owner/repo/skill, owner/repo@skill
     fn seg_ok(s: &str) -> bool {
-        !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || matches!(c, '_' | '.' | '-'))
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_alphanumeric() || matches!(c, '_' | '.' | '-'))
     }
     let (head, _at_skill) = match s.split_once('@') {
         Some((h, t)) if seg_ok(t) => (h, Some(t)),
@@ -745,10 +825,7 @@ fn is_skillssh_shorthand(s: &str) -> bool {
     (parts.len() == 2 || parts.len() == 3) && parts.iter().all(|p| seg_ok(p))
 }
 
-fn resolve_sync_target(
-    store: &SkillStore,
-    target: &SyncTarget,
-) -> anyhow::Result<Option<String>> {
+fn resolve_sync_target(store: &SkillStore, target: &SyncTarget) -> anyhow::Result<Option<String>> {
     match target {
         SyncTarget::None => Ok(None),
         SyncTarget::Active => Ok(store.get_active_scenario_id()?),
@@ -772,9 +849,7 @@ fn run_install(
     let (skill_id, install_name, central_path, source_type) = match kind {
         InstallKind::Local => install_local_action(store, reference, name, preset_id.as_deref())?,
         InstallKind::Git => install_git_action(store, reference, name, preset_id.as_deref())?,
-        InstallKind::Skillssh => {
-            install_skillssh_action(store, reference, preset_id.as_deref())?
-        }
+        InstallKind::Skillssh => install_skillssh_action(store, reference, preset_id.as_deref())?,
     };
 
     Ok(InstallReport {
@@ -813,9 +888,8 @@ fn install_local_action(
     };
     let central_path = result.central_path.to_string_lossy().to_string();
     let install_name = result.name.clone();
-    let skill_id =
-        cmd::store_installed_skill_unlocked(store, &result, &metadata, active_scenario)
-            .map_err(map_app_err)?;
+    let skill_id = cmd::store_installed_skill_unlocked(store, &result, &metadata, active_scenario)
+        .map_err(map_app_err)?;
     Ok((skill_id, install_name, central_path, "local".to_string()))
 }
 
@@ -837,8 +911,8 @@ fn install_git_action(
     )?;
     let result = (|| -> anyhow::Result<(String, String, String)> {
         let _lock = RepoLock::acquire_foreground("cli install git")?;
-        let skill_dir =
-            cmd::resolve_skill_dir(&temp_dir, parsed.subpath.as_deref(), None).map_err(map_app_err)?;
+        let skill_dir = cmd::resolve_skill_dir(&temp_dir, parsed.subpath.as_deref(), None)
+            .map_err(map_app_err)?;
         let revision = git_fetcher::get_head_revision(&temp_dir)?;
         let install_result = installer::install_from_git_dir(&skill_dir, name)?;
         let metadata = cmd::InstallSourceMetadata {
@@ -872,7 +946,8 @@ fn install_skillssh_action(
     let proxy_url = store.proxy_url();
     let repo_url = format!("https://github.com/{}.git", source);
     let cancel = Arc::new(AtomicBool::new(false));
-    let temp_dir = git_fetcher::clone_repo_ref(&repo_url, None, Some(&cancel), proxy_url.as_deref())?;
+    let temp_dir =
+        git_fetcher::clone_repo_ref(&repo_url, None, Some(&cancel), proxy_url.as_deref())?;
     let result = (|| -> anyhow::Result<(String, String, String)> {
         let _lock = RepoLock::acquire_foreground("cli install skillssh")?;
         let skill_dir =
@@ -970,24 +1045,22 @@ fn run_update(
                     },
                 }
             }
-            "local" | "import" => {
-                match cmd::reimport_local_skill_internal(store, &skill.id) {
-                    Ok(_) => UpdateReport {
-                        skill_id: skill.id.clone(),
-                        name: skill.name.clone(),
-                        source_type: skill.source_type.clone(),
-                        refreshed: true,
-                        error: None,
-                    },
-                    Err(e) => UpdateReport {
-                        skill_id: skill.id.clone(),
-                        name: skill.name.clone(),
-                        source_type: skill.source_type.clone(),
-                        refreshed: false,
-                        error: Some(e.message.clone()),
-                    },
-                }
-            }
+            "local" | "import" => match cmd::reimport_local_skill_internal(store, &skill.id) {
+                Ok(_) => UpdateReport {
+                    skill_id: skill.id.clone(),
+                    name: skill.name.clone(),
+                    source_type: skill.source_type.clone(),
+                    refreshed: true,
+                    error: None,
+                },
+                Err(e) => UpdateReport {
+                    skill_id: skill.id.clone(),
+                    name: skill.name.clone(),
+                    source_type: skill.source_type.clone(),
+                    refreshed: false,
+                    error: Some(e.message.clone()),
+                },
+            },
             other => UpdateReport {
                 skill_id: skill.id.clone(),
                 name: skill.name.clone(),
@@ -1095,10 +1168,7 @@ fn run_remove(
         });
     }
     if !yes {
-        bail!(
-            "refusing to delete {} skill(s) without --yes",
-            ids.len()
-        );
+        bail!("refusing to delete {} skill(s) without --yes", ids.len());
     }
 
     let result = cmd::delete_managed_skills_by_ids(store, &ids).map_err(map_app_err)?;
@@ -1135,7 +1205,11 @@ fn run_deprecated_set_enabled(
         } else {
             false
         };
-        let enabled_after = if requested_enabled { true } else { skill.enabled };
+        let enabled_after = if requested_enabled {
+            true
+        } else {
+            skill.enabled
+        };
         let message = if requested_enabled {
             "Deprecated no-op: skills are enabled by adding them to a preset; this command only restores legacy sync inclusion."
         } else {
@@ -1299,7 +1373,12 @@ fn run_adopt(
                      https://github.com/owner/repo/tree/branch/path/to/skill"
                 );
             }
-            Some((parsed.clone_url, subpath, parsed.branch, Some(url.to_string())))
+            Some((
+                parsed.clone_url,
+                subpath,
+                parsed.branch,
+                Some(url.to_string()),
+            ))
         } else {
             None
         };
@@ -1494,7 +1573,11 @@ fn run_tag(args: TagArgs, store: &SkillStore, json: bool) -> anyhow::Result<()> 
     match args.command {
         TagCommand::Add { reference, tags } => {
             let skill = resolve_skill(store, &reference)?;
-            let mut current = store.get_tags_map()?.get(&skill.id).cloned().unwrap_or_default();
+            let mut current = store
+                .get_tags_map()?
+                .get(&skill.id)
+                .cloned()
+                .unwrap_or_default();
             for t in tags {
                 if !current.iter().any(|c| c == &t) {
                     current.push(t);
@@ -1513,7 +1596,11 @@ fn run_tag(args: TagArgs, store: &SkillStore, json: bool) -> anyhow::Result<()> 
         }
         TagCommand::Remove { reference, tags } => {
             let skill = resolve_skill(store, &reference)?;
-            let mut current = store.get_tags_map()?.get(&skill.id).cloned().unwrap_or_default();
+            let mut current = store
+                .get_tags_map()?
+                .get(&skill.id)
+                .cloned()
+                .unwrap_or_default();
             current.retain(|c| !tags.iter().any(|t| t == c));
             store.set_tags_for_skill(&skill.id, &current)?;
             sync_metadata::ensure_skill_metadata(store, &skill.id)?;
@@ -1529,7 +1616,11 @@ fn run_tag(args: TagArgs, store: &SkillStore, json: bool) -> anyhow::Result<()> 
         TagCommand::List { reference } => {
             if let Some(r) = reference {
                 let skill = resolve_skill(store, &r)?;
-                let tags = store.get_tags_map()?.get(&skill.id).cloned().unwrap_or_default();
+                let tags = store
+                    .get_tags_map()?
+                    .get(&skill.id)
+                    .cloned()
+                    .unwrap_or_default();
                 print_json(
                     &TagReport {
                         skill_id: skill.id,
@@ -1554,14 +1645,13 @@ fn run_presets(args: PresetArgs, store: &SkillStore, json: bool) -> anyhow::Resu
         PresetCommand::Current => print_json(&current_preset(store)?, json),
         PresetCommand::Preview { reference } => {
             let preset = resolve_scenario(store, &reference)?;
-            let preview = scenario_service::preview_scenario_sync(store, &preset.id)
-                .map_err(map_app_err)?;
+            let preview =
+                scenario_service::preview_scenario_sync(store, &preset.id).map_err(map_app_err)?;
             print_json(&preview, json);
         }
         PresetCommand::Apply { reference } => {
             let preset = resolve_scenario(store, &reference)?;
-            scenario_service::apply_scenario_to_default(store, &preset.id)
-                .map_err(map_app_err)?;
+            scenario_service::apply_scenario_to_default(store, &preset.id).map_err(map_app_err)?;
             print_json(&current_preset(store)?, json);
         }
         PresetCommand::Deactivate { reference } => {
@@ -1585,8 +1675,7 @@ fn run_presets(args: PresetArgs, store: &SkillStore, json: bool) -> anyhow::Resu
                 // any skills it shares with the active preset. Unsync this
                 // preset first, then re-sync the active preset so the shared
                 // targets are restored.
-                scenario_service::unsync_scenario_skills(store, &preset.id)
-                    .map_err(map_app_err)?;
+                scenario_service::unsync_scenario_skills(store, &preset.id).map_err(map_app_err)?;
                 if let Some(active_id) = active.as_deref() {
                     scenario_service::sync_scenario_skills(store, active_id)
                         .map_err(map_app_err)?;
@@ -1715,6 +1804,327 @@ fn replacement_preset_after_deactivate(
         .find(|scenario| scenario.id != deactivated_id))
 }
 
+// ── projects ──────────────────────────────────────────────────────────────
+
+fn run_projects(args: ProjectArgs, store: &SkillStore, json: bool) -> anyhow::Result<()> {
+    match args.command {
+        ProjectCommand::List => print_json(
+            &project_cmd::get_projects_internal(store).map_err(map_app_err)?,
+            json,
+        ),
+        ProjectCommand::Add { path } => {
+            let project = project_cmd::add_project_internal(store, path).map_err(map_app_err)?;
+            print_json(&project, json);
+        }
+        ProjectCommand::Scan { root } => {
+            let projects =
+                project_cmd::scan_projects_internal(store, &root).map_err(map_app_err)?;
+            print_json(&projects, json);
+        }
+        ProjectCommand::Targets { project } => {
+            let p = resolve_project(store, &project)?;
+            let targets =
+                project_cmd::project_agent_targets_internal(store, &p.id).map_err(map_app_err)?;
+            print_json(&targets, json);
+        }
+        ProjectCommand::Skills { project, tool } => {
+            let p = resolve_project(store, &project)?;
+            let mut skills =
+                project_cmd::get_project_skills_internal(store, &p.id).map_err(map_app_err)?;
+            if let Some(tool) = tool {
+                skills.retain(|skill| skill.agent == tool);
+            }
+            print_json(&skills, json);
+        }
+        ProjectCommand::ApplyPreset {
+            project,
+            preset,
+            tool,
+            dry_run,
+        } => {
+            let report = apply_project_preset(store, &project, &preset, &tool, dry_run, true)?;
+            print_json(&report, json);
+        }
+        ProjectCommand::RemovePreset {
+            project,
+            preset,
+            tool,
+            dry_run,
+        } => {
+            let report = apply_project_preset(store, &project, &preset, &tool, dry_run, false)?;
+            print_json(&report, json);
+        }
+    }
+    Ok(())
+}
+
+fn resolve_project(store: &SkillStore, reference: &str) -> anyhow::Result<project_cmd::ProjectDto> {
+    let projects = project_cmd::get_projects_internal(store).map_err(map_app_err)?;
+    let direct_matches: Vec<_> = projects
+        .into_iter()
+        .filter(|project| {
+            project.id == reference || project.name == reference || project.path == reference
+        })
+        .collect();
+    if direct_matches.len() == 1 {
+        return Ok(direct_matches.into_iter().next().unwrap());
+    }
+    if direct_matches.len() > 1 {
+        bail!("ambiguous project ref '{}'", reference);
+    }
+
+    let ref_path = Path::new(reference);
+    if let Ok(ref_canon) = ref_path.canonicalize() {
+        let matches: Vec<_> = project_cmd::get_projects_internal(store)
+            .map_err(map_app_err)?
+            .into_iter()
+            .filter(|project| {
+                Path::new(&project.path)
+                    .canonicalize()
+                    .map(|path| path == ref_canon)
+                    .unwrap_or(false)
+            })
+            .collect();
+        if matches.len() == 1 {
+            return Ok(matches.into_iter().next().unwrap());
+        }
+        if matches.len() > 1 {
+            bail!("ambiguous project path '{}'", reference);
+        }
+    }
+
+    Err(anyhow!("project not found: {}", reference))
+}
+
+fn selected_project_tools(
+    store: &SkillStore,
+    project: &project_cmd::ProjectDto,
+    requested: &[String],
+) -> anyhow::Result<Vec<String>> {
+    let targets =
+        project_cmd::project_agent_targets_internal(store, &project.id).map_err(map_app_err)?;
+    let available: std::collections::HashSet<String> = targets
+        .iter()
+        .filter(|target| target.installed && target.enabled)
+        .map(|target| target.key.clone())
+        .collect();
+
+    let selected = if requested.is_empty() {
+        available.into_iter().collect::<Vec<_>>()
+    } else {
+        let mut missing = Vec::new();
+        let mut selected = Vec::new();
+        for tool in requested {
+            if available.contains(tool) {
+                selected.push(tool.clone());
+            } else {
+                missing.push(tool.clone());
+            }
+        }
+        if !missing.is_empty() {
+            bail!(
+                "project target is not available/enabled: {}",
+                missing.join(", ")
+            );
+        }
+        selected
+    };
+
+    if selected.is_empty() {
+        bail!("no enabled installed project targets");
+    }
+    Ok(selected)
+}
+
+fn project_target_path(
+    store: &SkillStore,
+    project: &project_cmd::ProjectDto,
+    tool: &str,
+    skill_name: &str,
+) -> Option<String> {
+    let dir_name = project_cmd::slugify_skill_names(vec![skill_name.to_string()])
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| "skill".to_string());
+    if project.workspace_type == "linked" {
+        return Some(
+            Path::new(&project.path)
+                .join(dir_name)
+                .to_string_lossy()
+                .to_string(),
+        );
+    }
+    let adapter = tool_adapters::find_adapter_with_store(store, tool)?;
+    Some(
+        Path::new(&project.path)
+            .join(adapter.project_relative_skills_dir())
+            .join(dir_name)
+            .to_string_lossy()
+            .to_string(),
+    )
+}
+
+fn apply_project_preset(
+    store: &SkillStore,
+    project_ref: &str,
+    preset_ref: &str,
+    requested_tools: &[String],
+    dry_run: bool,
+    add: bool,
+) -> anyhow::Result<ProjectPresetReport> {
+    let project = resolve_project(store, project_ref)?;
+    let preset = resolve_scenario(store, preset_ref)?;
+    let tools = selected_project_tools(store, &project, requested_tools)?;
+    let preset_skill_ids = store.get_skill_ids_for_scenario(&preset.id)?;
+    let project_skills =
+        project_cmd::get_project_skills_internal(store, &project.id).map_err(map_app_err)?;
+
+    let mut targets = Vec::new();
+    let mut added = 0usize;
+    let mut removed = 0usize;
+    let mut skipped = 0usize;
+    let mut failed = 0usize;
+
+    for skill_id in preset_skill_ids {
+        let Some(skill) = store.get_skill_by_id(&skill_id)? else {
+            continue;
+        };
+        for tool in &tools {
+            let existing = project_skills.iter().find(|project_skill| {
+                project_skill.agent == *tool
+                    && project_skill.center_skill_id.as_deref() == Some(skill.id.as_str())
+            });
+            let target_path = existing
+                .map(|project_skill| project_skill.path.clone())
+                .or_else(|| project_target_path(store, &project, tool, &skill.name));
+
+            if add {
+                if existing.is_some() {
+                    skipped += 1;
+                    targets.push(ProjectPresetTarget {
+                        skill_id: skill.id.clone(),
+                        skill_name: skill.name.clone(),
+                        tool: tool.clone(),
+                        target_path,
+                        action: "skipped_existing".to_string(),
+                        error: None,
+                    });
+                    continue;
+                }
+                if dry_run {
+                    added += 1;
+                    targets.push(ProjectPresetTarget {
+                        skill_id: skill.id.clone(),
+                        skill_name: skill.name.clone(),
+                        tool: tool.clone(),
+                        target_path,
+                        action: "would_add".to_string(),
+                        error: None,
+                    });
+                    continue;
+                }
+                match project_cmd::export_skill_to_project_internal(
+                    store,
+                    &skill.id,
+                    &project.id,
+                    Some(vec![tool.clone()]),
+                ) {
+                    Ok(()) => {
+                        added += 1;
+                        targets.push(ProjectPresetTarget {
+                            skill_id: skill.id.clone(),
+                            skill_name: skill.name.clone(),
+                            tool: tool.clone(),
+                            target_path,
+                            action: "added".to_string(),
+                            error: None,
+                        });
+                    }
+                    Err(err) => {
+                        failed += 1;
+                        targets.push(ProjectPresetTarget {
+                            skill_id: skill.id.clone(),
+                            skill_name: skill.name.clone(),
+                            tool: tool.clone(),
+                            target_path,
+                            action: "failed".to_string(),
+                            error: Some(err.message),
+                        });
+                    }
+                }
+            } else if let Some(existing) = existing {
+                if dry_run {
+                    removed += 1;
+                    targets.push(ProjectPresetTarget {
+                        skill_id: skill.id.clone(),
+                        skill_name: skill.name.clone(),
+                        tool: tool.clone(),
+                        target_path,
+                        action: "would_remove".to_string(),
+                        error: None,
+                    });
+                    continue;
+                }
+                match project_cmd::delete_project_skill_internal(
+                    store,
+                    &project.id,
+                    &existing.relative_path,
+                    tool,
+                ) {
+                    Ok(()) => {
+                        removed += 1;
+                        targets.push(ProjectPresetTarget {
+                            skill_id: skill.id.clone(),
+                            skill_name: skill.name.clone(),
+                            tool: tool.clone(),
+                            target_path,
+                            action: "removed".to_string(),
+                            error: None,
+                        });
+                    }
+                    Err(err) => {
+                        failed += 1;
+                        targets.push(ProjectPresetTarget {
+                            skill_id: skill.id.clone(),
+                            skill_name: skill.name.clone(),
+                            tool: tool.clone(),
+                            target_path,
+                            action: "failed".to_string(),
+                            error: Some(err.message),
+                        });
+                    }
+                }
+            } else {
+                skipped += 1;
+                targets.push(ProjectPresetTarget {
+                    skill_id: skill.id.clone(),
+                    skill_name: skill.name.clone(),
+                    tool: tool.clone(),
+                    target_path,
+                    action: "skipped_missing".to_string(),
+                    error: None,
+                });
+            }
+        }
+    }
+
+    Ok(ProjectPresetReport {
+        ok: failed == 0,
+        project_id: project.id,
+        project_name: project.name,
+        project_path: project.path,
+        preset_id: preset.id,
+        preset_name: preset.name,
+        dry_run,
+        persistent_link: false,
+        added,
+        removed,
+        skipped,
+        failed,
+        targets,
+    })
+}
+
 fn resolve_scenario(
     store: &SkillStore,
     reference: &str,
@@ -1742,7 +2152,12 @@ fn resolve_scenario(
 
 // ── git ───────────────────────────────────────────────────────────────────
 
-fn run_git(args: GitArgs, store: &SkillStore, has_skills_root: bool, json: bool) -> anyhow::Result<()> {
+fn run_git(
+    args: GitArgs,
+    store: &SkillStore,
+    has_skills_root: bool,
+    json: bool,
+) -> anyhow::Result<()> {
     match args.command {
         GitCommand::Status => {
             print_json(&git_backup::get_status(&central_repo::skills_dir())?, json)
@@ -1751,7 +2166,10 @@ fn run_git(args: GitArgs, store: &SkillStore, has_skills_root: bool, json: bool)
             // No settings store on this path; the hostname default matches
             // what the GUI derives, and the GUI reconciles the repo identity
             // on its next backup anyway.
-            git_backup::init_repo(&central_repo::skills_dir(), &git_backup::default_device_name())?;
+            git_backup::init_repo(
+                &central_repo::skills_dir(),
+                &git_backup::default_device_name(),
+            )?;
             print_json(&git_backup::get_status(&central_repo::skills_dir())?, json);
         }
         GitCommand::Clone { url } => {

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -1,6 +1,6 @@
 use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Instant;
 
 use serde::Serialize;
@@ -495,26 +495,65 @@ pub(crate) fn classify_sync_status(
 
 static GET_PROJECTS_FIRST_CALL: AtomicBool = AtomicBool::new(true);
 
+pub fn get_projects_internal(store: &SkillStore) -> Result<Vec<ProjectDto>, AppError> {
+    let start = Instant::now();
+    let records = store.get_all_projects().map_err(AppError::db)?;
+    let all_managed = store.get_all_skills().map_err(AppError::db)?;
+    let configs = agent_skill_configs(store);
+    let count = records.len();
+    let dtos: Vec<ProjectDto> = records
+        .iter()
+        .map(|r| project_to_dto(r, &all_managed, &configs))
+        .collect();
+    let elapsed_ms = start.elapsed().as_millis();
+    if should_log_first_or_slow(&GET_PROJECTS_FIRST_CALL, elapsed_ms, 100) {
+        log::info!("get_projects: {count} projects in {elapsed_ms} ms");
+    }
+    Ok(dtos)
+}
+
 #[tauri::command]
 pub async fn get_projects(store: State<'_, Arc<SkillStore>>) -> Result<Vec<ProjectDto>, AppError> {
     let store = store.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        let start = Instant::now();
-        let records = store.get_all_projects().map_err(AppError::db)?;
-        let all_managed = store.get_all_skills().map_err(AppError::db)?;
-        let configs = agent_skill_configs(&store);
-        let count = records.len();
-        let dtos: Vec<ProjectDto> = records
-            .iter()
-            .map(|r| project_to_dto(r, &all_managed, &configs))
-            .collect();
-        let elapsed_ms = start.elapsed().as_millis();
-        if should_log_first_or_slow(&GET_PROJECTS_FIRST_CALL, elapsed_ms, 100) {
-            log::info!("get_projects: {count} projects in {elapsed_ms} ms");
-        }
-        Ok(dtos)
-    })
-    .await?
+    tauri::async_runtime::spawn_blocking(move || get_projects_internal(&store)).await?
+}
+
+pub fn add_project_internal(store: &SkillStore, path: String) -> Result<ProjectDto, AppError> {
+    let project_path = Path::new(&path);
+    if !project_path.is_dir() {
+        return Err(AppError::invalid_input("Directory does not exist"));
+    }
+    let claude_dir = project_path.join(".claude");
+    let skills_dir = claude_dir.join("skills");
+    let disabled_dir = claude_dir.join("skills-disabled");
+
+    // Support initializing an empty project directory as a managed project.
+    std::fs::create_dir_all(&skills_dir)?;
+    std::fs::create_dir_all(&disabled_dir)?;
+
+    let name = project_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let now = chrono::Utc::now().timestamp_millis();
+    let record = ProjectRecord {
+        id: uuid::Uuid::new_v4().to_string(),
+        name,
+        path: path.clone(),
+        workspace_type: "project".to_string(),
+        linked_agent_key: None,
+        linked_agent_name: None,
+        disabled_path: None,
+        sort_order: 0,
+        created_at: now,
+        updated_at: now,
+    };
+
+    store.insert_project(&record).map_err(AppError::db)?;
+    let all_managed = store.get_all_skills().map_err(AppError::db)?;
+    let configs = agent_skill_configs(store);
+    Ok(project_to_dto(&record, &all_managed, &configs))
 }
 
 #[tauri::command]
@@ -523,44 +562,7 @@ pub async fn add_project(
     path: String,
 ) -> Result<ProjectDto, AppError> {
     let store = store.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        let project_path = Path::new(&path);
-        if !project_path.is_dir() {
-            return Err(AppError::invalid_input("Directory does not exist"));
-        }
-        let claude_dir = project_path.join(".claude");
-        let skills_dir = claude_dir.join("skills");
-        let disabled_dir = claude_dir.join("skills-disabled");
-
-        // Support initializing an empty project directory as a managed project.
-        std::fs::create_dir_all(&skills_dir)?;
-        std::fs::create_dir_all(&disabled_dir)?;
-
-        let name = project_path
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "unknown".to_string());
-
-        let now = chrono::Utc::now().timestamp_millis();
-        let record = ProjectRecord {
-            id: uuid::Uuid::new_v4().to_string(),
-            name,
-            path: path.clone(),
-            workspace_type: "project".to_string(),
-            linked_agent_key: None,
-            linked_agent_name: None,
-            disabled_path: None,
-            sort_order: 0,
-            created_at: now,
-            updated_at: now,
-        };
-
-        store.insert_project(&record).map_err(AppError::db)?;
-        let all_managed = store.get_all_skills().map_err(AppError::db)?;
-        let configs = agent_skill_configs(&store);
-        Ok(project_to_dto(&record, &all_managed, &configs))
-    })
-    .await?
+    tauri::async_runtime::spawn_blocking(move || add_project_internal(&store, path)).await?
 }
 
 #[tauri::command]
@@ -662,17 +664,29 @@ pub async fn scan_projects(
     store: State<'_, Arc<SkillStore>>,
 ) -> Result<Vec<String>, AppError> {
     let store = store.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        let root_path = Path::new(&root);
-        if !root_path.is_dir() {
-            return Err(AppError::invalid_input("Directory does not exist"));
-        }
-        let configs = agent_skill_configs(&store);
-        Ok(project_scanner::scan_projects_in_dir(
-            root_path, 4, &configs,
-        ))
-    })
-    .await?
+    tauri::async_runtime::spawn_blocking(move || scan_projects_internal(&store, &root)).await?
+}
+
+pub fn scan_projects_internal(store: &SkillStore, root: &str) -> Result<Vec<String>, AppError> {
+    let root_path = Path::new(root);
+    if !root_path.is_dir() {
+        return Err(AppError::invalid_input("Directory does not exist"));
+    }
+    let configs = agent_skill_configs(store);
+    Ok(project_scanner::scan_projects_in_dir(
+        root_path, 4, &configs,
+    ))
+}
+
+pub fn project_agent_targets_internal(
+    store: &SkillStore,
+    project_id: &str,
+) -> Result<Vec<ProjectAgentTargetDto>, AppError> {
+    let record = store
+        .get_project_by_id(project_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Workspace not found"))?;
+    Ok(project_agent_targets_for_record(store, &record))
 }
 
 #[tauri::command]
@@ -682,13 +696,38 @@ pub async fn get_project_agent_targets(
 ) -> Result<Vec<ProjectAgentTargetDto>, AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        let record = store
-            .get_project_by_id(&project_id)
-            .map_err(AppError::db)?
-            .ok_or_else(|| AppError::not_found("Workspace not found"))?;
-        Ok(project_agent_targets_for_record(&store, &record))
+        project_agent_targets_internal(&store, &project_id)
     })
     .await?
+}
+
+pub fn get_project_skills_internal(
+    store: &SkillStore,
+    project_id: &str,
+) -> Result<Vec<project_scanner::ProjectSkillInfo>, AppError> {
+    let record = store
+        .get_project_by_id(project_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Workspace not found"))?;
+
+    let configs = agent_skill_configs(store);
+    let mut skills = read_workspace_skills(&record, &configs);
+
+    let all_managed = store.get_all_skills().unwrap_or_default();
+    let tags_map = store.get_tags_map().unwrap_or_default();
+    for skill in &mut skills {
+        let matched = find_best_center_match(skill, &all_managed);
+        skill.in_center = matched.is_some();
+        skill.center_skill_id = matched.map(|m| m.id.clone());
+        skill.tags = skill
+            .center_skill_id
+            .as_ref()
+            .and_then(|skill_id| tags_map.get(skill_id).cloned())
+            .unwrap_or_default();
+        skill.sync_status = classify_sync_status(skill, matched);
+    }
+
+    Ok(skills)
 }
 
 #[tauri::command]
@@ -697,32 +736,8 @@ pub async fn get_project_skills(
     project_id: String,
 ) -> Result<Vec<project_scanner::ProjectSkillInfo>, AppError> {
     let store = store.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        let record = store
-            .get_project_by_id(&project_id)
-            .map_err(AppError::db)?
-            .ok_or_else(|| AppError::not_found("Workspace not found"))?;
-
-        let configs = agent_skill_configs(&store);
-        let mut skills = read_workspace_skills(&record, &configs);
-
-        let all_managed = store.get_all_skills().unwrap_or_default();
-        let tags_map = store.get_tags_map().unwrap_or_default();
-        for skill in &mut skills {
-            let matched = find_best_center_match(skill, &all_managed);
-            skill.in_center = matched.is_some();
-            skill.center_skill_id = matched.map(|m| m.id.clone());
-            skill.tags = skill
-                .center_skill_id
-                .as_ref()
-                .and_then(|skill_id| tags_map.get(skill_id).cloned())
-                .unwrap_or_default();
-            skill.sync_status = classify_sync_status(skill, matched);
-        }
-
-        Ok(skills)
-    })
-    .await?
+    tauri::async_runtime::spawn_blocking(move || get_project_skills_internal(&store, &project_id))
+        .await?
 }
 
 #[tauri::command]
@@ -922,6 +937,90 @@ pub fn slugify_skill_names(names: Vec<String>) -> Vec<String> {
     names.iter().map(|n| slugify_skill_dir_name(n)).collect()
 }
 
+pub fn export_skill_to_project_internal(
+    store: &SkillStore,
+    skill_id: &str,
+    project_id: &str,
+    agents: Option<Vec<String>>,
+) -> Result<(), AppError> {
+    let project = store
+        .get_project_by_id(project_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Workspace not found"))?;
+
+    let skill = store
+        .get_skill_by_id(skill_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Skill not found"))?;
+
+    let dir_name = slugify_skill_dir_name(&skill.name);
+    ensure_safe_skill_relative_path(&dir_name)?;
+
+    let source = PathBuf::from(&skill.central_path);
+    let requested_agent_keys = agents.filter(|items| !items.is_empty()).unwrap_or_else(|| {
+        if project.workspace_type == "linked" {
+            vec![linked_workspace_agent_key(&project)]
+        } else {
+            vec!["claude_code".to_string()]
+        }
+    });
+    let agent_keys = if project.workspace_type == "linked" {
+        requested_agent_keys
+    } else {
+        let available_targets: std::collections::HashSet<String> =
+            project_agent_targets_for_record(store, &project)
+                .into_iter()
+                .filter(|target| target.installed && target.enabled)
+                .map(|target| target.key)
+                .collect();
+        let filtered = requested_agent_keys
+            .into_iter()
+            .filter(|key| available_targets.contains(key))
+            .collect::<Vec<_>>();
+        if filtered.is_empty() {
+            return Err(AppError::invalid_input(
+                "No enabled installed agents selected for this project",
+            ));
+        }
+        filtered
+    };
+
+    for agent_key in &agent_keys {
+        let (skills_root, disabled_root) =
+            resolve_agent_skills_roots(store, &project, agent_key)
+                .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent_key)))?;
+        let target_dir = skills_root.join(&dir_name);
+
+        if target_dir.strip_prefix(&skills_root).is_err() {
+            return Err(AppError::invalid_input("Invalid skill directory path"));
+        }
+
+        if target_dir.exists()
+            || disabled_root
+                .as_ref()
+                .map(|path| path.join(&dir_name).exists())
+                .unwrap_or(false)
+        {
+            return Err(AppError::invalid_input(format!(
+                "Skill \"{}\" already exists in this workspace for agent {}",
+                skill.name, agent_key
+            )));
+        }
+    }
+
+    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+    for agent_key in &agent_keys {
+        let (skills_root, _) = resolve_agent_skills_roots(store, &project, agent_key)
+            .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent_key)))?;
+        let target_dir = skills_root.join(&dir_name);
+        std::fs::create_dir_all(&skills_root)?;
+        let mode = sync_engine::sync_mode_for_tool(agent_key, configured_mode.as_deref());
+        sync_engine::sync_skill(&source, &target_dir, mode).map_err(AppError::io)?;
+    }
+
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn export_skill_to_project(
     store: State<'_, Arc<SkillStore>>,
@@ -931,82 +1030,7 @@ pub async fn export_skill_to_project(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        let project = store
-            .get_project_by_id(&project_id)
-            .map_err(AppError::db)?
-            .ok_or_else(|| AppError::not_found("Workspace not found"))?;
-
-        let skill = store
-            .get_skill_by_id(&skill_id)
-            .map_err(AppError::db)?
-            .ok_or_else(|| AppError::not_found("Skill not found"))?;
-
-        let dir_name = slugify_skill_dir_name(&skill.name);
-        ensure_safe_skill_relative_path(&dir_name)?;
-
-        let source = PathBuf::from(&skill.central_path);
-        let requested_agent_keys = agents.filter(|items| !items.is_empty()).unwrap_or_else(|| {
-            if project.workspace_type == "linked" {
-                vec![linked_workspace_agent_key(&project)]
-            } else {
-                vec!["claude_code".to_string()]
-            }
-        });
-        let agent_keys = if project.workspace_type == "linked" {
-            requested_agent_keys
-        } else {
-            let available_targets: std::collections::HashSet<String> =
-                project_agent_targets_for_record(&store, &project)
-                    .into_iter()
-                    .filter(|target| target.installed && target.enabled)
-                    .map(|target| target.key)
-                    .collect();
-            let filtered = requested_agent_keys
-                .into_iter()
-                .filter(|key| available_targets.contains(key))
-                .collect::<Vec<_>>();
-            if filtered.is_empty() {
-                return Err(AppError::invalid_input(
-                    "No enabled installed agents selected for this project",
-                ));
-            }
-            filtered
-        };
-
-        for agent_key in &agent_keys {
-            let (skills_root, disabled_root) =
-                resolve_agent_skills_roots(&store, &project, agent_key)
-                    .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent_key)))?;
-            let target_dir = skills_root.join(&dir_name);
-
-            if target_dir.strip_prefix(&skills_root).is_err() {
-                return Err(AppError::invalid_input("Invalid skill directory path"));
-            }
-
-            if target_dir.exists()
-                || disabled_root
-                    .as_ref()
-                    .map(|path| path.join(&dir_name).exists())
-                    .unwrap_or(false)
-            {
-                return Err(AppError::invalid_input(format!(
-                    "Skill \"{}\" already exists in this workspace for agent {}",
-                    skill.name, agent_key
-                )));
-            }
-        }
-
-        let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
-        for agent_key in &agent_keys {
-            let (skills_root, _) = resolve_agent_skills_roots(&store, &project, agent_key)
-                .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent_key)))?;
-            let target_dir = skills_root.join(&dir_name);
-            std::fs::create_dir_all(&skills_root)?;
-            let mode = sync_engine::sync_mode_for_tool(agent_key, configured_mode.as_deref());
-            sync_engine::sync_skill(&source, &target_dir, mode).map_err(AppError::io)?;
-        }
-
-        Ok(())
+        export_skill_to_project_internal(&store, &skill_id, &project_id, agents)
     })
     .await?
 }
@@ -1108,36 +1132,45 @@ pub async fn delete_project_skill(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        ensure_safe_skill_relative_path(&skill_relative_path)?;
-
-        let record = store
-            .get_project_by_id(&project_id)
-            .map_err(AppError::db)?
-            .ok_or_else(|| AppError::not_found("Workspace not found"))?;
-
-        let (skills_root, disabled_root) = resolve_agent_skills_roots(&store, &record, &agent)
-            .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent)))?;
-        let skills_dir = skills_root.join(&skill_relative_path);
-        let disabled_dir = disabled_root
-            .as_ref()
-            .map(|root| root.join(&skill_relative_path));
-
-        let (target, target_root) = if skills_dir.is_dir() {
-            (skills_dir, skills_root)
-        } else if let Some(disabled_dir) = disabled_dir.filter(|path| path.is_dir()) {
-            (
-                disabled_dir,
-                disabled_root.expect("present when disabled_dir exists"),
-            )
-        } else {
-            return Err(AppError::not_found("Skill directory not found"));
-        };
-
-        ensure_dir_within_root(&target, &target_root)?;
-        remove_workspace_skill_target(&target)?;
-        Ok(())
+        delete_project_skill_internal(&store, &project_id, &skill_relative_path, &agent)
     })
     .await?
+}
+
+pub fn delete_project_skill_internal(
+    store: &SkillStore,
+    project_id: &str,
+    skill_relative_path: &str,
+    agent: &str,
+) -> Result<(), AppError> {
+    ensure_safe_skill_relative_path(skill_relative_path)?;
+
+    let record = store
+        .get_project_by_id(project_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Workspace not found"))?;
+
+    let (skills_root, disabled_root) = resolve_agent_skills_roots(store, &record, agent)
+        .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent)))?;
+    let skills_dir = skills_root.join(skill_relative_path);
+    let disabled_dir = disabled_root
+        .as_ref()
+        .map(|root| root.join(skill_relative_path));
+
+    let (target, target_root) = if skills_dir.is_dir() {
+        (skills_dir, skills_root)
+    } else if let Some(disabled_dir) = disabled_dir.filter(|path| path.is_dir()) {
+        (
+            disabled_dir,
+            disabled_root.expect("present when disabled_dir exists"),
+        )
+    } else {
+        return Err(AppError::not_found("Skill directory not found"));
+    };
+
+    ensure_dir_within_root(&target, &target_root)?;
+    remove_workspace_skill_target(&target)?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -1021,6 +1021,44 @@ pub fn export_skill_to_project_internal(
     Ok(())
 }
 
+/// Return the on-disk directory that would collide with exporting a skill named
+/// `skill_name` to `agent` in `project_id`, or `None` when the export path is
+/// clear. This mirrors the "already exists" guard in
+/// [`export_skill_to_project_internal`] so a dry run can flag the case a real
+/// run would reject: a directory of the same slug already exists but isn't a
+/// matched central skill.
+pub fn project_export_conflict_path(
+    store: &SkillStore,
+    project_id: &str,
+    agent: &str,
+    skill_name: &str,
+) -> Result<Option<String>, AppError> {
+    let project = store
+        .get_project_by_id(project_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Workspace not found"))?;
+
+    let dir_name = slugify_skill_dir_name(skill_name);
+    ensure_safe_skill_relative_path(&dir_name)?;
+
+    let Some((skills_root, disabled_root)) = resolve_agent_skills_roots(store, &project, agent)
+    else {
+        return Ok(None);
+    };
+
+    let enabled_dir = skills_root.join(&dir_name);
+    if enabled_dir.exists() {
+        return Ok(Some(enabled_dir.to_string_lossy().to_string()));
+    }
+    if let Some(disabled_root) = disabled_root {
+        let disabled_dir = disabled_root.join(&dir_name);
+        if disabled_dir.exists() {
+            return Ok(Some(disabled_dir.to_string_lossy().to_string()));
+        }
+    }
+    Ok(None)
+}
+
 #[tauri::command]
 pub async fn export_skill_to_project(
     store: State<'_, Arc<SkillStore>>,


### PR DESCRIPTION
## Summary
- add `skills-manager-cli projects` commands for listing, adding, scanning, inspecting targets, and listing project skills
- add project-scoped preset apply/remove commands with `--tool` and `--dry-run` support
- expose reusable project command helpers so CLI and Tauri commands share the same workspace logic

## Testing
- `cargo check --bin skills-manager-cli`
- `npm run -s cli -- projects --help`
- `npm run -s cli -- projects apply-preset --help`
- `npm run -s cli -- projects skills --help`
- `npm run -s cli -- --json projects scan /Users/vincentt/Public/skills-manager`
- isolated `--skills-root` end-to-end test for install -> project add -> project apply-preset --tool codex -> project skills -> remove-preset
- `git diff --check`