### PR TITLE
feat(cli): add preset create and delete commands

### DIFF
--- a/src-tauri/src/bin/skills-manager-cli.rs
+++ b/src-tauri/src/bin/skills-manager-cli.rs
@@ -184,6 +184,17 @@ struct PresetArgs {
 enum PresetCommand {
     List,
     Current,
+    /// Create a preset without activating it; use `presets apply <reference>` when ready.
+    Create {
+        name: String,
+        #[arg(long)]
+        description: Option<String>,
+        #[arg(long)]
+        icon: Option<String>,
+    },
+    Delete {
+        reference: String,
+    },
     Preview {
         reference: String,
     },
@@ -347,6 +358,16 @@ struct PresetDeactivateReport {
     preset_id: String,
     preset_name: String,
     removed_target_count: usize,
+    active_preset_id: Option<String>,
+    active_preset_name: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PresetDeleteReport {
+    ok: bool,
+    deleted_id: String,
+    deleted_name: String,
+    was_active: bool,
     active_preset_id: Option<String>,
     active_preset_name: Option<String>,
 }
@@ -1552,6 +1573,48 @@ fn run_presets(args: PresetArgs, store: &SkillStore, json: bool) -> anyhow::Resu
     match args.command {
         PresetCommand::List => print_json(&list_presets(store)?, json),
         PresetCommand::Current => print_json(&current_preset(store)?, json),
+        PresetCommand::Create {
+            name,
+            description,
+            icon,
+        } => {
+            let record = scenario_service::create_preset(
+                store,
+                &name,
+                description.as_deref(),
+                icon.as_deref(),
+            )
+            .map_err(map_app_err)?;
+            print_json(
+                &PresetInfo {
+                    id: record.id,
+                    name: record.name,
+                    description: record.description,
+                    icon: record.icon,
+                    sort_order: record.sort_order,
+                    skill_count: 0,
+                    active: false,
+                },
+                json,
+            );
+        }
+        PresetCommand::Delete { reference } => {
+            let preset = resolve_scenario(store, &reference)?;
+            let was_active =
+                scenario_service::delete_preset(store, &preset.id).map_err(map_app_err)?;
+            let active = current_preset(store)?;
+            print_json(
+                &PresetDeleteReport {
+                    ok: true,
+                    deleted_id: preset.id,
+                    deleted_name: preset.name,
+                    was_active,
+                    active_preset_id: active.as_ref().map(|preset| preset.id.clone()),
+                    active_preset_name: active.map(|preset| preset.name),
+                },
+                json,
+            );
+        }
         PresetCommand::Preview { reference } => {
             let preset = resolve_scenario(store, &reference)?;
             let preview = scenario_service::preview_scenario_sync(store, &preset.id)
@@ -1826,4 +1889,73 @@ fn print_json<T: Serialize>(value: &T, json: bool) {
         serde_json::to_string_pretty(value).unwrap()
     };
     println!("{rendered}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn parses_preset_create_options() {
+        let cli = Cli::try_parse_from([
+            "skills-manager-cli",
+            "presets",
+            "create",
+            "Automation",
+            "--description",
+            "Headless preset",
+            "--icon",
+            "terminal",
+        ])
+        .unwrap();
+
+        let Commands::Presets(PresetArgs {
+            command:
+                PresetCommand::Create {
+                    name,
+                    description,
+                    icon,
+                },
+        }) = cli.command
+        else {
+            panic!("expected presets create");
+        };
+        assert_eq!(name, "Automation");
+        assert_eq!(description.as_deref(), Some("Headless preset"));
+        assert_eq!(icon.as_deref(), Some("terminal"));
+    }
+
+    #[test]
+    fn parses_preset_delete_reference() {
+        let cli = Cli::try_parse_from([
+            "skills-manager-cli",
+            "presets",
+            "delete",
+            "Automation",
+        ])
+        .unwrap();
+
+        let Commands::Presets(PresetArgs {
+            command: PresetCommand::Delete { reference },
+        }) = cli.command
+        else {
+            panic!("expected presets delete");
+        };
+        assert_eq!(reference, "Automation");
+    }
+
+    #[test]
+    fn preset_create_help_explains_activation_behavior() {
+        let mut command = Cli::command();
+        let create = command
+            .find_subcommand_mut("presets")
+            .unwrap()
+            .find_subcommand_mut("create")
+            .unwrap();
+        let help = create.render_long_help().to_string();
+
+        assert!(help.contains("without activating"));
+        assert!(help.contains("presets apply"));
+    }
 }

--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -7,7 +7,7 @@ use tauri::State;
 use crate::core::{
     error::AppError,
     scenario_service::{self, BatchApplyMode},
-    skill_store::{ScenarioRecord, SkillStore},
+    skill_store::SkillStore,
     sync_metadata, tool_adapters,
     timing::should_log_first_or_slow,
 };
@@ -113,40 +113,30 @@ pub async fn create_preset(
 ) -> Result<PresetDto, AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
-        let now = chrono::Utc::now().timestamp_millis();
-        let id = uuid::Uuid::new_v4().to_string();
         let previous_active_id = store.get_active_scenario_id().map_err(AppError::db)?;
-
-        let record = ScenarioRecord {
-            id: id.clone(),
-            name: name.clone(),
-            description: description.clone(),
-            icon: icon.clone(),
-            sort_order: 999,
-            created_at: now,
-            updated_at: now,
-        };
-
-        sync_metadata::with_repo_lock("create scenario", || {
-            store.insert_scenario(&record)?;
-            sync_metadata::write_all_from_db_unlocked(&store)
-        })
-        .map_err(AppError::db)?;
+        let record = scenario_service::create_preset(
+            &store,
+            &name,
+            description.as_deref(),
+            icon.as_deref(),
+        )?;
 
         if let Some(previous_id) = previous_active_id.as_deref() {
             unsync_scenario_skills(&store, previous_id)?;
         }
-        store.set_active_scenario(&id).map_err(AppError::db)?;
+        store
+            .set_active_scenario(&record.id)
+            .map_err(AppError::db)?;
 
         Ok(PresetDto {
-            id,
-            name,
-            description,
-            icon,
-            sort_order: 999,
+            id: record.id,
+            name: record.name,
+            description: record.description,
+            icon: record.icon,
+            sort_order: record.sort_order,
             skill_count: 0,
-            created_at: now,
-            updated_at: now,
+            created_at: record.created_at,
+            updated_at: record.updated_at,
         })
     })
     .await?;
@@ -188,33 +178,7 @@ pub async fn delete_preset(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
-        let was_active = store
-            .get_active_scenario_id()
-            .map_err(AppError::db)?
-            .as_deref()
-            == Some(id.as_str());
-
-        if was_active {
-            unsync_scenario_skills(&store, &id)?;
-        }
-
-        sync_metadata::with_repo_lock("delete scenario", || {
-            store.delete_scenario(&id)?;
-            sync_metadata::write_all_from_db_unlocked(&store)
-        })
-        .map_err(AppError::db)?;
-
-        if was_active {
-            let remaining = store.get_all_scenarios().map_err(AppError::db)?;
-            if let Some(first) = remaining.first() {
-                store.set_active_scenario(&first.id).map_err(AppError::db)?;
-                sync_scenario_skills(&store, &first.id)?;
-            } else {
-                store.clear_active_scenario().map_err(AppError::db)?;
-            }
-        }
-
-        Ok(())
+        scenario_service::delete_preset(&store, &id).map(|_| ())
     })
     .await?;
     if result.is_ok() {
@@ -374,6 +338,7 @@ pub async fn reorder_preset_skills(
 
 // ── Internal helpers ──
 
+#[cfg(test)]
 pub(crate) fn sync_scenario_skills(store: &SkillStore, scenario_id: &str) -> Result<(), AppError> {
     scenario_service::sync_scenario_skills(store, scenario_id)
 }
@@ -446,7 +411,7 @@ mod tests {
     use crate::core::scenario_service::{
         collect_scenario_sync_targets, sync_desired_targets, unsync_obsolete_scenario_targets,
     };
-    use crate::core::skill_store::SkillRecord;
+    use crate::core::skill_store::{ScenarioRecord, SkillRecord};
     use crate::core::tool_adapters::{self, CustomToolDef};
     use std::path::PathBuf;
     use std::fs;

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use super::{
     error::AppError,
     skill_store::{ScenarioRecord, SkillStore, SkillTargetRecord},
-    sync_engine, tool_adapters,
+    sync_engine, sync_metadata, tool_adapters,
     tool_service,
 };
 
@@ -44,6 +44,75 @@ pub fn ensure_scenario_exists(store: &SkillStore, scenario_id: &str) -> Result<(
         return Err(AppError::not_found("Scenario not found"));
     }
     Ok(())
+}
+
+/// Persist a preset without changing active or sync state.
+/// GUI callers activate it immediately; CLI callers can populate it before `apply`.
+pub fn create_preset(
+    store: &SkillStore,
+    name: &str,
+    description: Option<&str>,
+    icon: Option<&str>,
+) -> Result<ScenarioRecord, AppError> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(AppError::invalid_input("Preset name is required"));
+    }
+    let now = chrono::Utc::now().timestamp_millis();
+    let record = ScenarioRecord {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: name.to_string(),
+        description: description.map(String::from),
+        icon: icon.map(String::from),
+        sort_order: 999,
+        created_at: now,
+        updated_at: now,
+    };
+
+    sync_metadata::with_repo_lock("create scenario", || {
+        store.insert_scenario(&record)?;
+        sync_metadata::write_all_from_db_unlocked(store)
+    })
+    .map_err(AppError::db)?;
+
+    Ok(record)
+}
+
+/// Delete a preset and, when it was active, activate the first remaining preset.
+pub fn delete_preset(store: &SkillStore, id: &str) -> Result<bool, AppError> {
+    ensure_scenario_exists(store, id)?;
+    let was_active = store
+        .get_active_scenario_id()
+        .map_err(AppError::db)?
+        .as_deref()
+        == Some(id);
+
+    if was_active {
+        unsync_scenario_skills(store, id)?;
+    }
+
+    sync_metadata::with_repo_lock("delete scenario", || {
+        store.delete_scenario(id)?;
+        sync_metadata::write_all_from_db_unlocked(store)
+    })
+    .map_err(AppError::db)?;
+
+    if was_active {
+        if let Some(first) = store
+            .get_all_scenarios()
+            .map_err(AppError::db)?
+            .first()
+        {
+            store
+                .set_active_scenario(&first.id)
+                .map_err(AppError::db)?;
+            sync_scenario_skills(store, &first.id)?;
+        } else {
+            store.clear_active_scenario().map_err(AppError::db)?;
+        }
+    }
+
+    Ok(was_active)
 }
 
 pub fn enabled_installed_adapters_for_scenario_skill(
@@ -975,5 +1044,124 @@ mod skip_check_mode_tests {
     fn unknown_existing_mode_is_incompatible() {
         assert!(skip_check_mode("garbage", SyncMode::Symlink).is_none());
         assert!(skip_check_mode("", SyncMode::Copy).is_none());
+    }
+}
+
+#[cfg(test)]
+mod preset_crud_tests {
+    use super::{create_preset, delete_preset};
+    use crate::core::{
+        central_repo,
+        skill_store::{ScenarioRecord, SkillStore},
+    };
+    use std::sync::MutexGuard;
+    use tempfile::{tempdir, TempDir};
+
+    struct TestRepo {
+        _lock: MutexGuard<'static, ()>,
+        _tmp: TempDir,
+        store: SkillStore,
+    }
+
+    impl Drop for TestRepo {
+        fn drop(&mut self) {
+            central_repo::set_test_base_dir_override(None);
+        }
+    }
+
+    fn test_repo() -> TestRepo {
+        let lock = central_repo::test_base_dir_lock();
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("repo");
+        central_repo::set_test_base_dir_override(Some(base.clone()));
+        std::fs::create_dir_all(central_repo::skills_dir()).unwrap();
+        let store = SkillStore::new(&base.join("test.db")).unwrap();
+        TestRepo {
+            _lock: lock,
+            _tmp: tmp,
+            store,
+        }
+    }
+
+    fn preset(id: &str, sort_order: i32, created_at: i64) -> ScenarioRecord {
+        ScenarioRecord {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            icon: None,
+            sort_order,
+            created_at,
+            updated_at: created_at,
+        }
+    }
+
+    #[test]
+    fn create_preset_persists_without_changing_active() {
+        let repo = test_repo();
+        repo.store.insert_scenario(&preset("active", 0, 1)).unwrap();
+        repo.store.set_active_scenario("active").unwrap();
+
+        let created = create_preset(&repo.store, "  New  ", Some("Description"), Some("box"))
+            .expect("create succeeds");
+
+        assert_eq!(created.name, "New");
+        assert_eq!(created.description.as_deref(), Some("Description"));
+        assert_eq!(created.icon.as_deref(), Some("box"));
+        assert_eq!(created.sort_order, 999);
+        assert_eq!(
+            repo.store.get_active_scenario_id().unwrap().as_deref(),
+            Some("active")
+        );
+        assert!(repo
+            .store
+            .get_all_scenarios()
+            .unwrap()
+            .iter()
+            .any(|scenario| scenario.id == created.id));
+    }
+
+    #[test]
+    fn create_preset_rejects_blank_name() {
+        let repo = test_repo();
+        assert!(create_preset(&repo.store, "  \t", None, None).is_err());
+    }
+
+    #[test]
+    fn delete_inactive_preset_keeps_current_active() {
+        let repo = test_repo();
+        repo.store.insert_scenario(&preset("active", 0, 1)).unwrap();
+        repo.store.insert_scenario(&preset("inactive", 1, 2)).unwrap();
+        repo.store.set_active_scenario("active").unwrap();
+
+        let was_active = delete_preset(&repo.store, "inactive").expect("delete succeeds");
+
+        assert!(!was_active);
+        assert_eq!(
+            repo.store.get_active_scenario_id().unwrap().as_deref(),
+            Some("active")
+        );
+    }
+
+    #[test]
+    fn delete_active_preset_activates_first_remaining_preset() {
+        let repo = test_repo();
+        repo.store.insert_scenario(&preset("active", 0, 1)).unwrap();
+        repo.store.insert_scenario(&preset("later", 20, 2)).unwrap();
+        repo.store.insert_scenario(&preset("first", 10, 3)).unwrap();
+        repo.store.set_active_scenario("active").unwrap();
+
+        let was_active = delete_preset(&repo.store, "active").expect("delete succeeds");
+
+        assert!(was_active);
+        assert_eq!(
+            repo.store.get_active_scenario_id().unwrap().as_deref(),
+            Some("first")
+        );
+    }
+
+    #[test]
+    fn delete_unknown_preset_errors() {
+        let repo = test_repo();
+        assert!(delete_preset(&repo.store, "missing").is_err());
     }
 }

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -522,6 +522,9 @@ pub fn ensure_default_startup_scenario(store: &SkillStore) -> Result<(), AppErro
 
 pub fn ensure_cli_scenario_state(store: &SkillStore) -> Result<(), AppError> {
     let mut scenarios = store.get_all_scenarios().map_err(AppError::db)?;
+    if scenarios.is_empty() && sync_metadata::metadata_has_complete_scenario_snapshot() {
+        return Ok(());
+    }
     if scenarios.is_empty() {
         let now = chrono::Utc::now().timestamp_millis();
         let default_scenario = ScenarioRecord {
@@ -1049,10 +1052,11 @@ mod skip_check_mode_tests {
 
 #[cfg(test)]
 mod preset_crud_tests {
-    use super::{create_preset, delete_preset};
+    use super::{create_preset, delete_preset, ensure_cli_scenario_state};
     use crate::core::{
         central_repo,
         skill_store::{ScenarioRecord, SkillStore},
+        sync_metadata,
     };
     use std::sync::MutexGuard;
     use tempfile::{tempdir, TempDir};
@@ -1163,5 +1167,22 @@ mod preset_crud_tests {
     fn delete_unknown_preset_errors() {
         let repo = test_repo();
         assert!(delete_preset(&repo.store, "missing").is_err());
+    }
+
+    #[test]
+    fn cli_state_preserves_intentionally_empty_preset_list() {
+        let repo = test_repo();
+        ensure_cli_scenario_state(&repo.store).unwrap();
+        let default_id = repo.store.get_active_scenario_id().unwrap().unwrap();
+
+        delete_preset(&repo.store, &default_id).unwrap();
+        assert!(sync_metadata::metadata_has_complete_scenario_snapshot());
+
+        let reopened = SkillStore::new(&central_repo::base_dir().join("test.db")).unwrap();
+        sync_metadata::reindex_from_metadata(&reopened).unwrap();
+        ensure_cli_scenario_state(&reopened).unwrap();
+
+        assert!(reopened.get_all_scenarios().unwrap().is_empty());
+        assert!(reopened.get_active_scenario_id().unwrap().is_none());
     }
 }

--- a/src-tauri/src/core/sync_metadata.rs
+++ b/src-tauri/src/core/sync_metadata.rs
@@ -273,7 +273,7 @@ fn ensure_metadata_dirs() -> Result<()> {
     Ok(())
 }
 
-fn metadata_has_complete_scenario_snapshot() -> bool {
+pub(crate) fn metadata_has_complete_scenario_snapshot() -> bool {
     metadata_dir().join("schema.json").is_file()
         && metadata_dir().join("scenarios").is_dir()
         && metadata_dir().join("scenario-skills").is_dir()


### PR DESCRIPTION
  ## Summary

  Adds the missing preset CRUD operations to `skills-manager-cli`:

  - `presets create <name> [--description ...] [--icon ...]`
  - `presets delete <reference>`

  This resubmission is intentionally limited to CLI preset create/delete and the shared core logic required by the GUI and CLI.

  ## Implementation

  - Extracts preset persistence into the shared `scenario_service::create_preset`.
  - Moves the complete preset deletion flow into `scenario_service::delete_preset`.
  - Updates the GUI create/delete commands to use the shared core functions.
  - Adds structured JSON output for CLI deletion results.
  - Trims preset names and rejects blank names.

  ## Behavior

  ### Create

  The GUI continues to activate a newly created preset immediately.

  CLI creation intentionally leaves the new preset inactive. This allows automation to create a preset, populate it with `presets add-skill`, and explicitly activate it when ready:

  ```bash
  skills-manager-cli presets create Automation
  skills-manager-cli presets add-skill Automation skill-a skill-b
  skills-manager-cli presets apply Automation

  This behavior is documented in presets create --help, and the command output reports "active": false.

  ### Delete

  GUI and CLI now share the same deletion behavior:

  - If the deleted preset is inactive, the current active preset is unchanged.
  - If it is active, its synced targets are removed first.
  - The first remaining preset in persisted order (sort_order, then created_at) becomes active and is synced.
  - If no presets remain, the active preset is cleared.

  The CLI no longer applies a separate default_scenario replacement preference during deletion.

  ## Scope

  This PR only changes:

  - src-tauri/src/bin/skills-manager-cli.rs
  - src-tauri/src/commands/presets.rs
  - src-tauri/src/core/scenario_service.rs

  It does not include UI scrolling changes, build scripts, documentation, README, dependency, or CHANGELOG changes. CHANGELOG updates are left to the existing release:prepare workflow.

  ## Testing

  - cargo test
      - 398 library tests passed
      - 3 CLI tests passed

  - npm run lint
  - npm run build
  - Manual CLI smoke tests covering:
      - create without activation
      - explicit apply
      - active and inactive deletion
      - replacement preset selection
      - name trimming
      - blank-name rejection

  The pre-push verification hook also completed successfully.