### PR TITLE
fix(tags): clear stale tag filters when a tag's last skill is removed (#318)

### DIFF
--- a/src/lib/skillTags.ts
+++ b/src/lib/skillTags.ts
@@ -1,5 +1,22 @@
 export const UNTAGGED_FILTER = "__untagged__";
 
+/**
+ * Drop tag filters that no longer match any existing tag.
+ * When the last skill carrying a tag is deleted the tag vanishes from the
+ * available set, but a filter still selecting it would linger and silently
+ * hide every remaining skill (the list looks empty for no visible reason).
+ * The always-valid UNTAGGED sentinel is never pruned.
+ * Returns `prev` unchanged (same reference) when nothing is stale, so it is
+ * safe to return directly from a `setState` updater without causing a loop.
+ */
+export function pruneStaleTagFilters(prev: Set<string>, availableTags: string[]): Set<string> {
+  if (prev.size === 0) return prev;
+  const available = new Set(availableTags);
+  available.add(UNTAGGED_FILTER);
+  const cleaned = new Set([...prev].filter((tag) => available.has(tag)));
+  return cleaned.size === prev.size ? prev : cleaned;
+}
+
 const TAG_COLOR_CLASSES = [
   "bg-blue-500/15 text-blue-600 dark:text-blue-400",
   "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",

--- a/src/views/MySkills.tsx
+++ b/src/views/MySkills.tsx
@@ -38,7 +38,7 @@ import { MultiSelectToolbar } from "../components/MultiSelectToolbar";
 import { BatchTagDialog } from "../components/BatchTagDialog";
 import { SyncDots } from "../components/SyncDots";
 import * as api from "../lib/tauri";
-import { getTagActiveColor, getTagColor, UNTAGGED_FILTER } from "../lib/skillTags";
+import { getTagActiveColor, getTagColor, pruneStaleTagFilters, UNTAGGED_FILTER } from "../lib/skillTags";
 import type {
   ManagedSkill,
   ToolInfo,
@@ -191,6 +191,12 @@ export function MySkills() {
   useEffect(() => {
     refreshAllTags();
   }, [skills]);
+
+  // Prune tag filters whose tag disappeared (e.g. its last skill was deleted),
+  // otherwise a stale filter silently hides everything.
+  useEffect(() => {
+    setTagFilters((prev) => pruneStaleTagFilters(prev, allTags));
+  }, [allTags]);
 
   // Close the tag context menu on Escape (click-outside is handled by its backdrop).
   useEffect(() => {

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -32,7 +32,7 @@ import { ProjectAgentDots } from "../components/ProjectAgentDots";
 import { PresetBar } from "../components/PresetBar";
 import { SkillMarkdown } from "../components/SkillMarkdown";
 import { DocumentDiffViewer } from "../components/DocumentDiffViewer";
-import { getTagActiveColor, getTagColor, UNTAGGED_FILTER } from "../lib/skillTags";
+import { getTagActiveColor, getTagColor, pruneStaleTagFilters, UNTAGGED_FILTER } from "../lib/skillTags";
 import { cn } from "../utils";
 import * as api from "../lib/tauri";
 import type { ProjectSkill, ManagedSkill, ProjectAgentTarget } from "../lib/tauri";
@@ -456,6 +456,13 @@ export function ProjectDetail() {
     }
     return Array.from(tags).sort((a, b) => a.localeCompare(b));
   }, [groupedSkills]);
+
+  // Prune tag filters whose tag disappeared (e.g. its last skill was deleted),
+  // otherwise a stale filter silently hides everything.
+  useEffect(() => {
+    setTagFilters((prev) => pruneStaleTagFilters(prev, allTags));
+  }, [allTags]);
+
   const selectedSkills = useMemo(
     () => groupedSkills.filter((skill) => selectedIds.has(getSkillKey(skill))),
     [getSkillKey, groupedSkills, selectedIds]

--- a/src/views/WorkspaceView.tsx
+++ b/src/views/WorkspaceView.tsx
@@ -28,7 +28,7 @@ import { DocumentDiffViewer } from "../components/DocumentDiffViewer";
 import * as api from "../lib/tauri";
 import type { ManagedSkill, ProjectSkill } from "../lib/tauri";
 import { getErrorMessage } from "../lib/error";
-import { getTagActiveColor, getTagColor, UNTAGGED_FILTER } from "../lib/skillTags";
+import { getTagActiveColor, getTagColor, pruneStaleTagFilters, UNTAGGED_FILTER } from "../lib/skillTags";
 import { AddSkillsSheet } from "../components/AddSkillsSheet";
 import type { WorkspaceConfig } from "./workspaceConfigs";
 
@@ -395,6 +395,12 @@ export function WorkspaceView({ config }: { config: WorkspaceConfig }) {
     }
     return Array.from(tags).sort((a, b) => a.localeCompare(b));
   }, [localSkills]);
+
+  // Prune tag filters whose tag disappeared (e.g. its last skill was deleted),
+  // otherwise a stale filter silently hides everything.
+  useEffect(() => {
+    setTagFilters((prev) => pruneStaleTagFilters(prev, allLocalTags));
+  }, [allLocalTags]);
 
   const visibleLocalSkills = useMemo(() => {
     const q = search.trim().toLowerCase();


### PR DESCRIPTION
## Summary

Fixes #318. After deleting every skill that carried a tag, the tag pill disappears but
its filter stays active, so the list renders empty and the user can't see their
remaining skills.

## Root cause (reproduced)

Repro: Library -> click a tag to filter -> delete every skill under that tag. Tag pills
derive from the available tag set; once the last skill is gone the tag leaves that set,
but `tagFilters` still selects it, so the filter matches nothing and the list goes
blank. Nothing reclaimed the stale filter on tag-set changes. (#238's right-click
tag-delete clears it; the "last skill deleted" path doesn't go through that.)

## Changes

- **Shared `pruneStaleTagFilters` helper** (`skillTags.ts`): drops filters whose tag no
  longer exists; returns the **same Set reference** when nothing is stale (no re-render
  loop); never prunes the `UNTAGGED` sentinel.
- Wired into all three tag-filter surfaces: `MySkills`, `ProjectDetail`, `WorkspaceView`
  (`WorkspaceView` has the same latent bug and is covered too).

## Test plan

- [x] `tsc --noEmit` clean
- [x] Manual repro on all three surfaces: after deleting the tagged skills, the filter
      clears and the list recovers
- [ ] No frontend unit test — repo has no vitest/jest harness

## Notes

Out of scope: broader tag/preset grouping improvements (#300).
