### PR TITLE
fix(sync): stop stale copies from silently overwriting newer content

### DIFF
--- a/src-tauri/src/commands/agent_workspace.rs
+++ b/src-tauri/src/commands/agent_workspace.rs
@@ -5,7 +5,7 @@ use tauri::State;
 
 use crate::commands::projects::{
     classify_sync_status, ensure_dir_within_root, ensure_safe_skill_relative_path,
-    source_ref_matches_skill_path, ProjectSkillDocumentDto,
+    snapshot_before_explicit_pull, source_ref_matches_skill_path, ProjectSkillDocumentDto,
 };
 use crate::core::skill_store::{SkillRecord, SkillStore, SkillTargetRecord};
 use crate::core::{
@@ -605,6 +605,10 @@ fn update_agent_local_skill_from_center(
     ensure_agent_skill_path(&target_path, &skills_root)?;
 
     let source = PathBuf::from(&managed.central_path);
+    // Same safety net as the project path: an explicit pull may overwrite a
+    // diverged local copy, so snapshot the target first when it differs from the
+    // center content. Symlinked targets hash equal and are skipped.
+    snapshot_before_explicit_pull(&target_path, &source, &skill.name)?;
     let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
     let mode = sync_engine::sync_mode_for_tool(agent, configured_mode.as_deref());
     sync_engine::sync_skill(&source, &target_path, mode).map_err(AppError::io)?;
@@ -1377,10 +1381,217 @@ mod tests {
             })
             .unwrap();
 
+        // The center side is now judged by the central directory's real
+        // filesystem mtime (not `updated_at`). A freshly installed center is
+        // ~now, same as the agent copy, so pin it old to restore this test's
+        // intent: the agent copy is genuinely newer → the pull must be rejected.
+        set_file_mtime_ms(&existing.central_path.join("SKILL.md"), 1_000);
+
         let result = update_agent_local_skill_from_center(&store, "test_agent", "local-tool");
         assert!(result.is_err());
         let local_content = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
         assert!(local_content.contains("agent newer"));
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    /// Pin a file's mtime to a fixed epoch-ms value so classification is judged
+    /// against a deterministic timestamp instead of the wall clock.
+    fn set_file_mtime_ms(path: &std::path::Path, ms: i64) {
+        let time = std::time::UNIX_EPOCH + std::time::Duration::from_millis(ms as u64);
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap();
+        file.set_modified(time).unwrap();
+    }
+
+    /// Wire up a store + agent + center match where the local copy diverges from
+    /// the center by content, with both sides pinned to `mtime_ms` so the sync
+    /// status is `diverged` (never `project_newer`). Copy sync mode keeps the
+    /// test off symlink privileges. Returns the on-disk skill dir and the center
+    /// directory. The caller drives `update_agent_local_skill_from_center`.
+    fn setup_diverged_pull(
+        temp: &std::path::Path,
+        store: &SkillStore,
+        local_body: &str,
+        center_body: &str,
+        mtime_ms: i64,
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
+        // Copy mode: the overwrite lands as a real directory, so the assertions
+        // never depend on symlink creation privileges (flaky on Windows).
+        store.set_setting("sync_mode", "copy").unwrap();
+
+        // Identical frontmatter on both sides: the body is the *only*
+        // distinguishing content, so equal bodies produce byte-identical files
+        // (hash-equal) and differing bodies produce a genuine divergence.
+        let center_source = temp.join("center-source");
+        std::fs::create_dir_all(&center_source).unwrap();
+        std::fs::write(
+            center_source.join("SKILL.md"),
+            format!("---\nname: local-tool\ndescription: Shared skill\n---\n{center_body}\n"),
+        )
+        .unwrap();
+        let existing = installer::install_from_local(&center_source, Some("local-tool")).unwrap();
+
+        let skills_root = temp.join("agent-skills");
+        let skill_dir = skills_root.join("local-tool");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: local-tool\ndescription: Shared skill\n---\n{local_body}\n"),
+        )
+        .unwrap();
+
+        store
+            .set_setting(
+                "custom_tools",
+                &serde_json::json!([
+                    {
+                        "key": "test_agent",
+                        "display_name": "Test Agent",
+                        "skills_dir": skills_root.to_string_lossy(),
+                        "project_relative_skills_dir": ".test-agent/skills"
+                    }
+                ])
+                .to_string(),
+            )
+            .unwrap();
+
+        store
+            .insert_skill(&SkillRecord {
+                id: "existing-center".to_string(),
+                name: "local-tool".to_string(),
+                description: existing.description.clone(),
+                source_type: "local".to_string(),
+                source_ref: Some(skill_dir.to_string_lossy().to_string()),
+                source_ref_resolved: None,
+                source_subpath: None,
+                source_branch: None,
+                source_revision: None,
+                remote_revision: None,
+                central_path: existing.central_path.to_string_lossy().to_string(),
+                content_hash: Some(content_hash::hash_directory(&existing.central_path).unwrap()),
+                enabled: true,
+                created_at: 0,
+                updated_at: 0,
+                status: "ok".to_string(),
+                update_status: "local_only".to_string(),
+                last_checked_at: Some(0),
+                last_check_error: None,
+            })
+            .unwrap();
+
+        // Both sides on the same clock → `diverged`, which the direction button
+        // is allowed to overwrite (it is not `project_newer`).
+        set_file_mtime_ms(&skill_dir.join("SKILL.md"), mtime_ms);
+        set_file_mtime_ms(&existing.central_path.join("SKILL.md"), mtime_ms);
+
+        (skill_dir, existing.central_path)
+    }
+
+    #[test]
+    fn pulling_from_center_snapshots_diverged_local_before_overwriting() {
+        let _guard = central_repo::test_base_dir_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let center_root = temp.path().join("center");
+        central_repo::set_test_base_dir_override(Some(center_root.clone()));
+
+        let db_path = temp.path().join("store.db");
+        let store = SkillStore::new(&db_path).unwrap();
+
+        let (skill_dir, _center_dir) = setup_diverged_pull(
+            temp.path(),
+            &store,
+            "agent divergent edits",
+            "center authoritative",
+            5_000,
+        );
+
+        let result = update_agent_local_skill_from_center(&store, "test_agent", "local-tool");
+        assert!(result.is_ok(), "diverged pull must be allowed: {result:?}");
+
+        // The local edits were snapshotted before the overwrite: a backup of the
+        // pre-overwrite target must exist and still carry the user's content.
+        let backups_root = center_root.join("backups").join("local-tool");
+        let snapshot = std::fs::read_dir(&backups_root)
+            .unwrap()
+            .next()
+            .expect("a backup directory must have been created")
+            .unwrap()
+            .path();
+        let snapshotted = std::fs::read_to_string(snapshot.join("SKILL.md")).unwrap();
+        assert!(
+            snapshotted.contains("agent divergent edits"),
+            "backup must preserve the user's local edits, got: {snapshotted}"
+        );
+
+        // And the target itself was actually overwritten with the center copy.
+        let local_now = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        assert!(
+            local_now.contains("center authoritative"),
+            "target must be overwritten with center content, got: {local_now}"
+        );
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    #[test]
+    fn pulling_from_center_does_not_snapshot_when_local_matches_center() {
+        let _guard = central_repo::test_base_dir_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let center_root = temp.path().join("center");
+        central_repo::set_test_base_dir_override(Some(center_root.clone()));
+
+        let db_path = temp.path().join("store.db");
+        let store = SkillStore::new(&db_path).unwrap();
+
+        // Identical bodies → no divergence, no edit to lose, so no backup churn.
+        let (_skill_dir, _center_dir) =
+            setup_diverged_pull(temp.path(), &store, "identical", "identical", 5_000);
+
+        let result = update_agent_local_skill_from_center(&store, "test_agent", "local-tool");
+        assert!(result.is_ok(), "in-sync pull must be allowed: {result:?}");
+
+        assert!(
+            !center_root.join("backups").join("local-tool").exists(),
+            "matching content must not produce a redundant snapshot"
+        );
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    #[test]
+    fn pulling_from_center_rejects_newer_local_without_snapshotting() {
+        let _guard = central_repo::test_base_dir_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let center_root = temp.path().join("center");
+        central_repo::set_test_base_dir_override(Some(center_root.clone()));
+
+        let db_path = temp.path().join("store.db");
+        let store = SkillStore::new(&db_path).unwrap();
+
+        // Local pinned well after the center → deterministically `project_newer`.
+        let (skill_dir, _center_dir) = setup_diverged_pull(
+            temp.path(),
+            &store,
+            "agent newer edits",
+            "center older",
+            5_000,
+        );
+        set_file_mtime_ms(&skill_dir.join("SKILL.md"), 50_000);
+
+        let result = update_agent_local_skill_from_center(&store, "test_agent", "local-tool");
+        assert!(result.is_err(), "project_newer must still be rejected");
+
+        // Rejection happens before any write: the local copy is untouched and no
+        // backup was taken (the guard, not the safety net, fired).
+        let local_content = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        assert!(local_content.contains("agent newer edits"));
+        assert!(
+            !center_root.join("backups").join("local-tool").exists(),
+            "rejected pull must not snapshot"
+        );
 
         central_repo::set_test_base_dir_override(None);
     }

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -482,11 +482,21 @@ pub(crate) fn classify_sync_status(
         return "diverged".to_string();
     };
 
-    let center_updated_at = managed.updated_at;
+    // Both sides must be judged by the SAME clock: the real filesystem mtime of
+    // the content files. The project side already carries that (`last_modified_at`),
+    // so the center side must too. `managed.updated_at` is a DB bookkeeping stamp
+    // that every app-side write bumps to now(), so it is not comparable against a
+    // filesystem mtime — using it made an up-to-date project read as `center_newer`
+    // right after any unrelated DB write. That mismatch is the bug this fixes.
+    // Only fall back to `updated_at` when the central directory has no readable
+    // content files to stat (e.g. it was moved or deleted).
+    let center_modified_at =
+        crate::core::content_hash::latest_modified_millis(Path::new(&managed.central_path))
+            .unwrap_or(managed.updated_at);
     let threshold_ms = 1_000;
-    if project_modified_at > center_updated_at + threshold_ms {
+    if project_modified_at > center_modified_at + threshold_ms {
         "project_newer".to_string()
-    } else if center_updated_at > project_modified_at + threshold_ms {
+    } else if center_modified_at > project_modified_at + threshold_ms {
         "center_newer".to_string()
     } else {
         "diverged".to_string()
@@ -1228,7 +1238,12 @@ mod tests {
     #[test]
     fn classify_sync_status_falls_back_to_timestamps_when_live_hash_differs() {
         let center_dir = tempdir().unwrap();
-        fs::write(center_dir.path().join("SKILL.md"), "# Center\n").unwrap();
+        let center_skill = center_dir.path().join("SKILL.md");
+        fs::write(&center_skill, "# Center\n").unwrap();
+        // The center side is now compared by its real filesystem mtime, so pin
+        // it to an old value; otherwise a freshly created tempdir looks newer
+        // than the project's timestamp and the branch under test never fires.
+        set_file_mtime_ms(&center_skill, 1_000);
 
         let project_dir = tempdir().unwrap();
         fs::write(project_dir.path().join("SKILL.md"), "# Project changed\n").unwrap();
@@ -1249,6 +1264,143 @@ mod tests {
             classify_sync_status(&project, Some(&managed)),
             "project_newer"
         );
+    }
+
+    /// Pin a file's mtime to a fixed epoch-ms value so the central copy's
+    /// filesystem timestamp is deterministic and independent of wall clock.
+    fn set_file_mtime_ms(path: &std::path::Path, ms: i64) {
+        let time = std::time::UNIX_EPOCH + std::time::Duration::from_millis(ms as u64);
+        let file = fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(time).unwrap();
+    }
+
+    /// Regression for the two-clocks bug: the center side must be judged by the
+    /// central directory's real filesystem mtime, never by `managed.updated_at`.
+    /// Here the project's files are genuinely newer than the central copy, but a
+    /// later `updated_at` (as a stray DB write would produce) would flip the old
+    /// code to "center_newer". The fix must still report "project_newer".
+    #[test]
+    fn classify_treats_project_as_newer_when_updated_at_bumped_but_files_older() {
+        let center_dir = tempdir().unwrap();
+        let center_skill = center_dir.path().join("SKILL.md");
+        fs::write(&center_skill, "# Center\n").unwrap();
+        // Central files are OLD on disk...
+        set_file_mtime_ms(&center_skill, 10_000);
+
+        let project_dir = tempdir().unwrap();
+        fs::write(project_dir.path().join("SKILL.md"), "# Project changed\n").unwrap();
+        let project_hash = content_hash::hash_directory(project_dir.path()).unwrap();
+
+        // ...but `updated_at` was bumped far into the future by an app write.
+        let bumped_updated_at = 9_999_999_999;
+        let managed = sample_managed_skill(
+            center_dir.path().to_string_lossy().to_string(),
+            Some("stale-db-hash".to_string()),
+            bumped_updated_at,
+        );
+        // Project fs mtime is newer than the central copy (10_000) but older
+        // than the bumped `updated_at` — the exact trap the old code fell into.
+        let project = sample_project_skill(
+            project_dir.path().to_string_lossy().to_string(),
+            Some(project_hash),
+            Some(50_000),
+        );
+
+        assert_eq!(
+            classify_sync_status(&project, Some(&managed)),
+            "project_newer"
+        );
+    }
+
+    /// Positive coverage for `center_newer`: the central copy's real filesystem
+    /// mtime is genuinely newer than the project's. `updated_at` is set *earlier*
+    /// than the project, so this label can only arise from reading fs mtime — it
+    /// also guards against any regression back to comparing `updated_at`.
+    #[test]
+    fn classify_reports_center_newer_when_central_files_are_actually_newer() {
+        let center_dir = tempdir().unwrap();
+        let center_skill = center_dir.path().join("SKILL.md");
+        fs::write(&center_skill, "# Center v2\n").unwrap();
+        set_file_mtime_ms(&center_skill, 50_000);
+
+        let project_dir = tempdir().unwrap();
+        fs::write(project_dir.path().join("SKILL.md"), "# Project\n").unwrap();
+        let project_hash = content_hash::hash_directory(project_dir.path()).unwrap();
+
+        let managed = sample_managed_skill(
+            center_dir.path().to_string_lossy().to_string(),
+            Some("stale-db-hash".to_string()),
+            1_000,
+        );
+        let project = sample_project_skill(
+            project_dir.path().to_string_lossy().to_string(),
+            Some(project_hash),
+            Some(10_000),
+        );
+
+        assert_eq!(
+            classify_sync_status(&project, Some(&managed)),
+            "center_newer"
+        );
+    }
+
+    /// Covers the `unwrap_or(managed.updated_at)` fallback: an empty central dir
+    /// has no readable content files, so `latest_modified_millis` returns None
+    /// and the code falls back to `updated_at`. With `updated_at` far earlier
+    /// than the project mtime, that fallback path must yield `project_newer`.
+    #[test]
+    fn classify_falls_back_to_updated_at_when_central_has_no_content_files() {
+        // Empty central directory — no files for the mtime walk to stat.
+        let center_dir = tempdir().unwrap();
+
+        let project_dir = tempdir().unwrap();
+        fs::write(project_dir.path().join("SKILL.md"), "# Project\n").unwrap();
+        let project_hash = content_hash::hash_directory(project_dir.path()).unwrap();
+
+        let managed = sample_managed_skill(
+            center_dir.path().to_string_lossy().to_string(),
+            Some("stale-db-hash".to_string()),
+            1_000,
+        );
+        let project = sample_project_skill(
+            project_dir.path().to_string_lossy().to_string(),
+            Some(project_hash),
+            Some(50_000),
+        );
+
+        assert_eq!(
+            classify_sync_status(&project, Some(&managed)),
+            "project_newer"
+        );
+    }
+
+    /// Covers the `diverged` outcome: the two filesystem mtimes differ by less
+    /// than the 1000ms threshold while the hashes disagree, so neither side is
+    /// declared newer.
+    #[test]
+    fn classify_reports_diverged_when_mtimes_within_threshold() {
+        let center_dir = tempdir().unwrap();
+        let center_skill = center_dir.path().join("SKILL.md");
+        fs::write(&center_skill, "# Center\n").unwrap();
+        set_file_mtime_ms(&center_skill, 10_000);
+
+        let project_dir = tempdir().unwrap();
+        fs::write(project_dir.path().join("SKILL.md"), "# Project\n").unwrap();
+        let project_hash = content_hash::hash_directory(project_dir.path()).unwrap();
+
+        let managed = sample_managed_skill(
+            center_dir.path().to_string_lossy().to_string(),
+            Some("stale-db-hash".to_string()),
+            1_000,
+        );
+        // 500ms apart — inside the 1000ms threshold.
+        let project = sample_project_skill(
+            project_dir.path().to_string_lossy().to_string(),
+            Some(project_hash),
+            Some(10_500),
+        );
+
+        assert_eq!(classify_sync_status(&project, Some(&managed)), "diverged");
     }
 
     #[test]

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -460,32 +460,51 @@ pub(crate) fn find_best_center_match<'a>(
 /// a center directory (a live content hash and the newest content-file mtime).
 /// The same central skill is referenced by many project/agent variants, so
 /// within one `get_projects` call its directory would otherwise be walked once
-/// per reference. Scoped to a single request and rebuilt from disk on every call,
-/// so it never goes stale — an external edit to the center is still seen on the
-/// next call.
+/// per reference — and once more per *probe*, since the hash and the mtime were
+/// two independent recursive walks. Both are now derived from a single cached
+/// walk (`list_content_files`) per path: the hash reads file contents on demand,
+/// the mtime reuses the metadata the walk already captured, so a center is
+/// traversed at most once regardless of how many references or probes hit it.
+/// Scoped to a single request and rebuilt from disk on every call, so it never
+/// goes stale — an external edit to the center is still seen on the next call.
 #[derive(Default)]
 pub(crate) struct CenterStatCache {
+    entries: std::collections::HashMap<String, Vec<content_hash::ContentEntry>>,
     hashes: std::collections::HashMap<String, Option<String>>,
     mtimes: std::collections::HashMap<String, Option<i64>>,
 }
 
 impl CenterStatCache {
-    fn hash(&mut self, central_path: &str) -> Option<String> {
-        self.hashes
+    /// The one directory walk both probes share, memoized per path. Everything
+    /// else is derived from this list, so the center is traversed at most once.
+    fn entries(&mut self, central_path: &str) -> &[content_hash::ContentEntry] {
+        self.entries
             .entry(central_path.to_string())
-            .or_insert_with(|| {
-                crate::core::content_hash::hash_directory(Path::new(central_path)).ok()
-            })
-            .clone()
+            .or_insert_with(|| content_hash::list_content_files(Path::new(central_path)))
+    }
+
+    fn hash(&mut self, central_path: &str) -> Option<String> {
+        if let Some(cached) = self.hashes.get(central_path) {
+            return cached.clone();
+        }
+        // hash_entries reads every content file; memoize so a repeated reference
+        // in the same batch doesn't re-read them. `hash_directory` was infallible
+        // (it only ever wrapped `Ok`), so `Some(..)` preserves the old behavior —
+        // even an empty/missing dir hashes to the stable empty-list digest.
+        let hash = Some(content_hash::hash_entries(self.entries(central_path)));
+        self.hashes.insert(central_path.to_string(), hash.clone());
+        hash
     }
 
     fn mtime(&mut self, central_path: &str) -> Option<i64> {
-        *self
-            .mtimes
-            .entry(central_path.to_string())
-            .or_insert_with(|| {
-                crate::core::content_hash::latest_modified_millis(Path::new(central_path))
-            })
+        if let Some(cached) = self.mtimes.get(central_path) {
+            return *cached;
+        }
+        // Cheap: the max over metadata the shared walk already captured — no
+        // extra stat and no file-content read.
+        let mtime = content_hash::latest_modified_ms(self.entries(central_path));
+        self.mtimes.insert(central_path.to_string(), mtime);
+        mtime
     }
 }
 
@@ -1526,6 +1545,28 @@ mod tests {
             1,
             "center stat-walked once for both variants"
         );
+    }
+
+    #[test]
+    fn center_stat_cache_walks_a_directory_once_for_both_probes() {
+        // The hash and the mtime used to be two independent recursive walks of
+        // the same center. Both now derive from one cached walk, so probing both
+        // leaves exactly one entry in the shared-walk cache — the directory is
+        // traversed once, not once per probe.
+        let center = tempdir().unwrap();
+        fs::write(center.path().join("SKILL.md"), "# center\n").unwrap();
+        let central_path = center.path().to_string_lossy().to_string();
+
+        let mut cache = CenterStatCache::default();
+        let hash = cache.hash(&central_path);
+        let mtime = cache.mtime(&central_path);
+
+        // Both probes still equal the standalone one-shot computations...
+        assert_eq!(hash, Some(content_hash::hash_directory(center.path()).unwrap()));
+        assert_eq!(mtime, content_hash::latest_modified_millis(center.path()));
+        assert!(mtime.is_some());
+        // ...and the shared walk ran exactly once to serve them both.
+        assert_eq!(cache.entries.len(), 1, "directory walked once for both probes");
     }
 
     #[test]

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -606,7 +606,6 @@ pub(crate) fn snapshot_before_explicit_pull(
             target,
             &dir_name,
             "explicit-pull-from-center",
-            central_repo::BackupKind::Copy,
         )
         .map_err(AppError::io)?;
     }

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -8,7 +8,10 @@ use tauri::State;
 
 use crate::core::skill_store::{ProjectRecord, SkillRecord, SkillStore};
 use crate::core::timing::should_log_first_or_slow;
-use crate::core::{error::AppError, installer, project_scanner, sync_engine, tool_adapters};
+use crate::core::{
+    central_repo, content_hash, error::AppError, installer, project_scanner, sync_engine,
+    tool_adapters,
+};
 
 #[derive(Serialize, Default)]
 pub struct SyncHealthDto {
@@ -501,6 +504,52 @@ pub(crate) fn classify_sync_status(
     } else {
         "diverged".to_string()
     }
+}
+
+/// Decide whether an explicit "pull from center" must snapshot the target
+/// before it gets overwritten. The direction buttons deliberately overwrite the
+/// local copy, but they must never *silently* discard a user's local edits: back
+/// up only when the target already exists AND its content differs from the
+/// center content about to be written. This is the safety net for the `diverged`
+/// case that legitimately slips past the `project_newer` guard. A symlink target
+/// hashes equal to the center (it *is* the center) so this returns `false` and
+/// avoids a redundant snapshot; a copy carrying real edits hashes different and
+/// returns `true`. Because the decision keys off content hashes alone, it never
+/// has to special-case the sync mode.
+pub(crate) fn explicit_pull_needs_backup(target: &Path, center: &Path) -> Result<bool, AppError> {
+    if !target.exists() {
+        return Ok(false);
+    }
+    let target_hash = content_hash::hash_directory(target).map_err(AppError::io)?;
+    let center_hash = content_hash::hash_directory(center).map_err(AppError::io)?;
+    Ok(target_hash != center_hash)
+}
+
+/// Snapshot `target` under `<central_root>/backups/` when an explicit pull from
+/// center would otherwise silently drop local edits. Shared by the project and
+/// global-workspace direction buttons so both honor the same safety net. No-op
+/// when the target is absent or already matches the center content.
+pub(crate) fn snapshot_before_explicit_pull(
+    target: &Path,
+    center: &Path,
+    fallback_dir_name: &str,
+) -> Result<(), AppError> {
+    if explicit_pull_needs_backup(target, center)? {
+        let dir_name = target
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| fallback_dir_name.to_string());
+        central_repo::backup_directory(
+            &central_repo::base_dir(),
+            target,
+            &dir_name,
+            "explicit-pull-from-center",
+            chrono::Utc::now().timestamp_millis(),
+            central_repo::BackupKind::Copy,
+        )
+        .map_err(AppError::io)?;
+    }
+    Ok(())
 }
 
 static GET_PROJECTS_FIRST_CALL: AtomicBool = AtomicBool::new(true);
@@ -1030,55 +1079,70 @@ pub async fn update_project_skill_from_center(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        ensure_safe_skill_relative_path(&skill_relative_path)?;
-
-        let record = store
-            .get_project_by_id(&project_id)
-            .map_err(AppError::db)?
-            .ok_or_else(|| AppError::not_found("Workspace not found"))?;
-
-        let configs = agent_skill_configs(&store);
-        let skills = read_workspace_skills(&record, &configs);
-        let skill = skills
-            .iter()
-            .find(|s| s.relative_path == skill_relative_path && s.agent == agent)
-            .ok_or_else(|| AppError::not_found("Skill not found in workspace"))?;
-
-        let all_managed = store.get_all_skills().unwrap_or_default();
-        let managed = find_best_center_match(skill, &all_managed)
-            .ok_or_else(|| AppError::not_found("No matching skill in center"))?;
-
-        // Mirror the global-workspace protection (agent_workspace.rs): never
-        // overwrite a project copy that has unsynced local edits (#225 review).
-        if classify_sync_status(skill, Some(managed)) == "project_newer" {
-            return Err(AppError::invalid_input(
-                "Project skill is newer than the Skills Center version",
-            ));
-        }
-
-        let (skills_root, disabled_root) = resolve_agent_skills_roots(&store, &record, &agent)
-            .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent)))?;
-        let target_path = PathBuf::from(&skill.path);
-        if target_path.starts_with(&skills_root) {
-            ensure_dir_within_root(&target_path, &skills_root)?;
-        } else if disabled_root
-            .as_ref()
-            .map(|root| target_path.starts_with(root))
-            .unwrap_or(false)
-        {
-            let disabled_root = disabled_root.expect("checked above");
-            ensure_dir_within_root(&target_path, &disabled_root)?;
-        } else {
-            return Err(AppError::invalid_input("Invalid skill directory path"));
-        }
-
-        let source = PathBuf::from(&managed.central_path);
-        let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
-        let mode = sync_engine::sync_mode_for_tool(&agent, configured_mode.as_deref());
-        sync_engine::sync_skill(&source, &target_path, mode).map_err(AppError::io)?;
-        Ok(())
+        update_project_skill_from_center_inner(&store, &project_id, &skill_relative_path, &agent)
     })
     .await?
+}
+
+fn update_project_skill_from_center_inner(
+    store: &SkillStore,
+    project_id: &str,
+    skill_relative_path: &str,
+    agent: &str,
+) -> Result<(), AppError> {
+    ensure_safe_skill_relative_path(skill_relative_path)?;
+
+    let record = store
+        .get_project_by_id(project_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Workspace not found"))?;
+
+    let configs = agent_skill_configs(store);
+    let skills = read_workspace_skills(&record, &configs);
+    let skill = skills
+        .iter()
+        .find(|s| s.relative_path == skill_relative_path && s.agent == agent)
+        .ok_or_else(|| AppError::not_found("Skill not found in workspace"))?;
+
+    let all_managed = store.get_all_skills().unwrap_or_default();
+    let managed = find_best_center_match(skill, &all_managed)
+        .ok_or_else(|| AppError::not_found("No matching skill in center"))?;
+
+    // Mirror the global-workspace protection (agent_workspace.rs): never
+    // overwrite a project copy that has unsynced local edits (#225 review).
+    if classify_sync_status(skill, Some(managed)) == "project_newer" {
+        return Err(AppError::invalid_input(
+            "Project skill is newer than the Skills Center version",
+        ));
+    }
+
+    let (skills_root, disabled_root) = resolve_agent_skills_roots(store, &record, agent)
+        .ok_or_else(|| AppError::not_found(format!("Unknown agent: {}", agent)))?;
+    let target_path = PathBuf::from(&skill.path);
+    if target_path.starts_with(&skills_root) {
+        ensure_dir_within_root(&target_path, &skills_root)?;
+    } else if disabled_root
+        .as_ref()
+        .map(|root| target_path.starts_with(root))
+        .unwrap_or(false)
+    {
+        let disabled_root = disabled_root.expect("checked above");
+        ensure_dir_within_root(&target_path, &disabled_root)?;
+    } else {
+        return Err(AppError::invalid_input("Invalid skill directory path"));
+    }
+
+    let source = PathBuf::from(&managed.central_path);
+    // Explicit "pull from center" honors the overwrite direction, but a
+    // divergent copy that slipped past the project_newer guard still holds
+    // the user's local edits — snapshot it before sync_skill clobbers them so
+    // nothing is silently lost. Symlink targets hash equal to the center and
+    // are skipped (there is no local edit to lose).
+    snapshot_before_explicit_pull(&target_path, &source, &skill.name)?;
+    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+    let mode = sync_engine::sync_mode_for_tool(agent, configured_mode.as_deref());
+    sync_engine::sync_skill(&source, &target_path, mode).map_err(AppError::io)?;
+    Ok(())
 }
 
 #[tauri::command]
@@ -1153,13 +1217,15 @@ pub async fn delete_project_skill(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_sync_status, ensure_distinct_linked_workspace_roots,
+        classify_sync_status, ensure_distinct_linked_workspace_roots, explicit_pull_needs_backup,
         remove_workspace_skill_target, set_project_skill_enabled_state,
+        update_project_skill_from_center_inner,
     };
     use crate::core::content_hash;
     use crate::core::error::ErrorKind;
     use crate::core::project_scanner::ProjectSkillInfo;
-    use crate::core::skill_store::SkillRecord;
+    use crate::core::skill_store::{ProjectRecord, SkillRecord, SkillStore};
+    use crate::core::{central_repo, installer};
     use std::fs;
     use tempfile::tempdir;
 
@@ -1213,6 +1279,162 @@ mod tests {
             last_modified_at,
             content_hash,
         }
+    }
+
+    // --- Explicit "pull from center" backup safety net (#225 follow-up) ---
+    // The decision "does an explicit overwrite need to snapshot the target
+    // first?" is the load-bearing predicate: it is what keeps a user's local
+    // edits from vanishing when a `diverged` skill slips past the project_newer
+    // guard. Pin it exhaustively as a pure function so the two command handlers
+    // can lean on a single verified point.
+
+    #[test]
+    fn explicit_pull_backs_up_when_target_differs_from_center() {
+        let center = tempdir().unwrap();
+        fs::write(center.path().join("SKILL.md"), "# center\n").unwrap();
+        let target = tempdir().unwrap();
+        fs::write(target.path().join("SKILL.md"), "# local edits\n").unwrap();
+
+        // Target exists and holds edits the center does not → must snapshot.
+        assert!(explicit_pull_needs_backup(target.path(), center.path()).unwrap());
+    }
+
+    #[test]
+    fn explicit_pull_skips_backup_when_target_matches_center() {
+        let center = tempdir().unwrap();
+        fs::write(center.path().join("SKILL.md"), "# same\n").unwrap();
+        let target = tempdir().unwrap();
+        fs::write(target.path().join("SKILL.md"), "# same\n").unwrap();
+
+        // Identical content — this is the symlink-to-center case reduced to its
+        // observable property — so no redundant snapshot.
+        assert!(!explicit_pull_needs_backup(target.path(), center.path()).unwrap());
+    }
+
+    #[test]
+    fn explicit_pull_skips_backup_when_target_missing() {
+        let center = tempdir().unwrap();
+        fs::write(center.path().join("SKILL.md"), "# center\n").unwrap();
+        let target = tempdir().unwrap();
+        let missing = target.path().join("brand-new-skill");
+
+        // Nothing on disk yet → nothing to lose, so no backup even though the
+        // center is non-empty (an empty tree would otherwise hash "different").
+        assert!(!explicit_pull_needs_backup(&missing, center.path()).unwrap());
+    }
+
+    /// Project-side mirror of the agent-side snapshot integration test. Drives
+    /// the real `update_project_skill_from_center_inner` against a linked
+    /// workspace whose skill diverges from the center by content (mtimes pinned
+    /// equal so it is `diverged`, not `project_newer`). The explicit pull must
+    /// snapshot the target's local edits before overwriting it with the center
+    /// copy — this guards the command's `snapshot_before_explicit_pull` wiring
+    /// against silent removal, which a pure-function test alone cannot catch.
+    #[test]
+    fn project_pull_from_center_snapshots_diverged_local_before_overwriting() {
+        let _guard = central_repo::test_base_dir_lock();
+        let temp = tempdir().unwrap();
+        let center_root = temp.path().join("center");
+        central_repo::set_test_base_dir_override(Some(center_root.clone()));
+
+        let db_path = temp.path().join("store.db");
+        let store = SkillStore::new(&db_path).unwrap();
+
+        // Copy mode keeps the overwrite off symlink privileges (flaky on Windows).
+        store.set_setting("sync_mode", "copy").unwrap();
+
+        // Linked workspace: skills live directly under the workspace root, so no
+        // custom-tool adapter wiring is needed to reach the code path.
+        let workspace = temp.path().join("workspace");
+        let skill_dir = workspace.join("example-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: example-skill\ndescription: Shared skill\n---\nproject divergent edits\n",
+        )
+        .unwrap();
+
+        store
+            .insert_project(&ProjectRecord {
+                id: "proj-1".to_string(),
+                name: "Linked WS".to_string(),
+                path: workspace.to_string_lossy().to_string(),
+                workspace_type: "linked".to_string(),
+                linked_agent_key: Some("linked-agent".to_string()),
+                linked_agent_name: Some("Linked Agent".to_string()),
+                disabled_path: None,
+                sort_order: 0,
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+
+        // Center copy: identical frontmatter, different body → genuine divergence.
+        let center_source = temp.path().join("center-source");
+        fs::create_dir_all(&center_source).unwrap();
+        fs::write(
+            center_source.join("SKILL.md"),
+            "---\nname: example-skill\ndescription: Shared skill\n---\ncenter authoritative\n",
+        )
+        .unwrap();
+        let existing =
+            installer::install_from_local(&center_source, Some("example-skill")).unwrap();
+
+        store
+            .insert_skill(&SkillRecord {
+                id: "center-skill".to_string(),
+                name: "example-skill".to_string(),
+                description: existing.description.clone(),
+                source_type: "local".to_string(),
+                source_ref: Some(skill_dir.to_string_lossy().to_string()),
+                source_ref_resolved: None,
+                source_subpath: None,
+                source_branch: None,
+                source_revision: None,
+                remote_revision: None,
+                central_path: existing.central_path.to_string_lossy().to_string(),
+                content_hash: Some(content_hash::hash_directory(&existing.central_path).unwrap()),
+                enabled: true,
+                created_at: 0,
+                updated_at: 0,
+                status: "ok".to_string(),
+                update_status: "local_only".to_string(),
+                last_checked_at: Some(0),
+                last_check_error: None,
+            })
+            .unwrap();
+
+        // Both sides on the same clock → `diverged` (overwrite allowed), not
+        // `project_newer` (which would reject before the snapshot ever runs).
+        set_file_mtime_ms(&skill_dir.join("SKILL.md"), 5_000);
+        set_file_mtime_ms(&existing.central_path.join("SKILL.md"), 5_000);
+
+        let result =
+            update_project_skill_from_center_inner(&store, "proj-1", "example-skill", "linked-agent");
+        assert!(result.is_ok(), "diverged project pull must be allowed: {result:?}");
+
+        // The local edits were snapshotted before being overwritten.
+        let backups_root = center_root.join("backups").join("example-skill");
+        let snapshot = fs::read_dir(&backups_root)
+            .unwrap()
+            .next()
+            .expect("a backup directory must have been created")
+            .unwrap()
+            .path();
+        let snapshotted = fs::read_to_string(snapshot.join("SKILL.md")).unwrap();
+        assert!(
+            snapshotted.contains("project divergent edits"),
+            "backup must preserve the user's local edits, got: {snapshotted}"
+        );
+
+        // And the target itself was overwritten with the center copy.
+        let local_now = fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        assert!(
+            local_now.contains("center authoritative"),
+            "target must be overwritten with center content, got: {local_now}"
+        );
+
+        central_repo::set_test_base_dir_override(None);
     }
 
     #[test]

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -184,6 +184,7 @@ fn project_to_dto(
     rec: &ProjectRecord,
     all_managed: &[SkillRecord],
     configs: &[project_scanner::AgentSkillConfig],
+    center: &mut CenterStatCache,
 ) -> ProjectDto {
     let skills = read_workspace_skills(rec, configs);
     let skill_count = skills.len();
@@ -191,7 +192,7 @@ fn project_to_dto(
     let mut health = SyncHealthDto::default();
     for skill in &skills {
         let matched = find_best_center_match(skill, all_managed);
-        let status = classify_sync_status(skill, matched);
+        let status = classify_sync_status_cached(skill, matched, center);
         match status.as_str() {
             "in_sync" => health.in_sync += 1,
             "project_newer" => health.project_newer += 1,
@@ -455,9 +456,53 @@ pub(crate) fn find_best_center_match<'a>(
         .map(|(managed, _)| managed)
 }
 
+/// Per-request memo for the two filesystem probes `classify_sync_status` runs on
+/// a center directory (a live content hash and the newest content-file mtime).
+/// The same central skill is referenced by many project/agent variants, so
+/// within one `get_projects` call its directory would otherwise be walked once
+/// per reference. Scoped to a single request and rebuilt from disk on every call,
+/// so it never goes stale — an external edit to the center is still seen on the
+/// next call.
+#[derive(Default)]
+pub(crate) struct CenterStatCache {
+    hashes: std::collections::HashMap<String, Option<String>>,
+    mtimes: std::collections::HashMap<String, Option<i64>>,
+}
+
+impl CenterStatCache {
+    fn hash(&mut self, central_path: &str) -> Option<String> {
+        self.hashes
+            .entry(central_path.to_string())
+            .or_insert_with(|| {
+                crate::core::content_hash::hash_directory(Path::new(central_path)).ok()
+            })
+            .clone()
+    }
+
+    fn mtime(&mut self, central_path: &str) -> Option<i64> {
+        *self
+            .mtimes
+            .entry(central_path.to_string())
+            .or_insert_with(|| {
+                crate::core::content_hash::latest_modified_millis(Path::new(central_path))
+            })
+    }
+}
+
 pub(crate) fn classify_sync_status(
     skill: &project_scanner::ProjectSkillInfo,
     managed: Option<&SkillRecord>,
+) -> String {
+    classify_sync_status_cached(skill, managed, &mut CenterStatCache::default())
+}
+
+/// Same decision as `classify_sync_status`, but reuses a caller-owned
+/// `CenterStatCache` so a batch (e.g. `get_projects` over every project) walks
+/// each center directory at most once instead of once per referencing variant.
+pub(crate) fn classify_sync_status_cached(
+    skill: &project_scanner::ProjectSkillInfo,
+    managed: Option<&SkillRecord>,
+    center: &mut CenterStatCache,
 ) -> String {
     let Some(managed) = managed else {
         return "project_only".to_string();
@@ -472,9 +517,7 @@ pub(crate) fn classify_sync_status(
 
     // DB hash may be stale — recompute center hash from disk as fallback
     if let Some(project_hash) = skill.content_hash.as_deref() {
-        if let Ok(live_center_hash) =
-            crate::core::content_hash::hash_directory(Path::new(&managed.central_path))
-        {
+        if let Some(live_center_hash) = center.hash(&managed.central_path) {
             if project_hash == live_center_hash {
                 return "in_sync".to_string();
             }
@@ -493,9 +536,9 @@ pub(crate) fn classify_sync_status(
     // right after any unrelated DB write. That mismatch is the bug this fixes.
     // Only fall back to `updated_at` when the central directory has no readable
     // content files to stat (e.g. it was moved or deleted).
-    let center_modified_at =
-        crate::core::content_hash::latest_modified_millis(Path::new(&managed.central_path))
-            .unwrap_or(managed.updated_at);
+    let center_modified_at = center
+        .mtime(&managed.central_path)
+        .unwrap_or(managed.updated_at);
     let threshold_ms = 1_000;
     if project_modified_at > center_modified_at + threshold_ms {
         "project_newer".to_string()
@@ -563,9 +606,13 @@ pub async fn get_projects(store: State<'_, Arc<SkillStore>>) -> Result<Vec<Proje
         let all_managed = store.get_all_skills().map_err(AppError::db)?;
         let configs = agent_skill_configs(&store);
         let count = records.len();
+        // One CenterStatCache for the whole batch: a skill referenced by several
+        // projects/agent variants walks its center directory once, not once per
+        // reference.
+        let mut center = CenterStatCache::default();
         let dtos: Vec<ProjectDto> = records
             .iter()
-            .map(|r| project_to_dto(r, &all_managed, &configs))
+            .map(|r| project_to_dto(r, &all_managed, &configs, &mut center))
             .collect();
         let elapsed_ms = start.elapsed().as_millis();
         if should_log_first_or_slow(&GET_PROJECTS_FIRST_CALL, elapsed_ms, 100) {
@@ -617,7 +664,12 @@ pub async fn add_project(
         store.insert_project(&record).map_err(AppError::db)?;
         let all_managed = store.get_all_skills().map_err(AppError::db)?;
         let configs = agent_skill_configs(&store);
-        Ok(project_to_dto(&record, &all_managed, &configs))
+        Ok(project_to_dto(
+            &record,
+            &all_managed,
+            &configs,
+            &mut CenterStatCache::default(),
+        ))
     })
     .await?
 }
@@ -693,7 +745,12 @@ pub async fn add_linked_workspace(
         store.insert_project(&record).map_err(AppError::db)?;
         let all_managed = store.get_all_skills().map_err(AppError::db)?;
         let configs = agent_skill_configs(&store);
-        Ok(project_to_dto(&record, &all_managed, &configs))
+        Ok(project_to_dto(
+            &record,
+            &all_managed,
+            &configs,
+            &mut CenterStatCache::default(),
+        ))
     })
     .await?
 }
@@ -1217,9 +1274,9 @@ pub async fn delete_project_skill(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_sync_status, ensure_distinct_linked_workspace_roots, explicit_pull_needs_backup,
-        remove_workspace_skill_target, set_project_skill_enabled_state,
-        update_project_skill_from_center_inner,
+        classify_sync_status, classify_sync_status_cached, ensure_distinct_linked_workspace_roots,
+        explicit_pull_needs_backup, remove_workspace_skill_target, set_project_skill_enabled_state,
+        update_project_skill_from_center_inner, CenterStatCache,
     };
     use crate::core::content_hash;
     use crate::core::error::ErrorKind;
@@ -1435,6 +1492,41 @@ mod tests {
         );
 
         central_repo::set_test_base_dir_override(None);
+    }
+
+    #[test]
+    fn center_stat_cache_walks_a_shared_center_once_across_variants() {
+        // A skill mirrored under two agents shares one central_path. Classifying
+        // both through one cache must probe that center's filesystem only once,
+        // while returning exactly the same verdict as the uncached path.
+        let center = tempdir().unwrap();
+        fs::write(center.path().join("SKILL.md"), "# center\n").unwrap();
+        let central_path = center.path().to_string_lossy().to_string();
+
+        // DB hash is intentionally stale, forcing classify past the fast path
+        // into the live-hash + mtime fallbacks (the two filesystem walks).
+        let managed = sample_managed_skill(central_path, Some("stale-db-hash".to_string()), 1_000);
+        let mut a =
+            sample_project_skill("proj-a".to_string(), Some("proj-hash".to_string()), Some(9_000));
+        a.agent = "claude_code".to_string();
+        let mut b =
+            sample_project_skill("proj-b".to_string(), Some("proj-hash".to_string()), Some(9_000));
+        b.agent = "cursor".to_string();
+
+        let mut cache = CenterStatCache::default();
+        let sa = classify_sync_status_cached(&a, Some(&managed), &mut cache);
+        let sb = classify_sync_status_cached(&b, Some(&managed), &mut cache);
+
+        // Same verdict as the one-shot uncached path...
+        assert_eq!(sa, classify_sync_status(&a, Some(&managed)));
+        assert_eq!(sb, classify_sync_status(&b, Some(&managed)));
+        // ...but the shared center was probed once, not once per variant.
+        assert_eq!(cache.hashes.len(), 1, "center hashed once for both variants");
+        assert_eq!(
+            cache.mtimes.len(),
+            1,
+            "center stat-walked once for both variants"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -587,7 +587,6 @@ pub(crate) fn snapshot_before_explicit_pull(
             target,
             &dir_name,
             "explicit-pull-from-center",
-            chrono::Utc::now().timestamp_millis(),
             central_repo::BackupKind::Copy,
         )
         .map_err(AppError::io)?;

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1760,7 +1760,6 @@ pub fn reimport_local_skill_internal(
                         central_path,
                         &dir_name,
                         "reimport-source-newer",
-                        chrono::Utc::now().timestamp_millis(),
                         central_repo::BackupKind::Copy,
                     )
                     .map_err(AppError::io)?;

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -8,11 +8,12 @@ use walkdir::WalkDir;
 
 use crate::core::{
     audit_log::AuditDraft,
-    central_repo,
+    central_repo, content_hash,
     error::AppError,
     git_fetcher,
     install_cancel::InstallCancelRegistry,
     installer,
+    reconcile::{reconcile, Reconcile, SideState},
     repo_lock::RepoLock,
     scanner,
     skill_metadata::{self, is_valid_skill_dir},
@@ -1580,6 +1581,53 @@ pub fn update_git_skill_internal(
     }
 }
 
+/// mtime tie-break tolerance for the reimport source↔center decision, in ms.
+/// Mirrors the folder-sync threshold used elsewhere: a difference at or under
+/// this is treated as "can't tell who is newer" rather than trusting sub-second
+/// filesystem timestamps across two independently-written trees.
+const REIMPORT_MTIME_THRESHOLD_MS: i64 = 1000;
+
+/// What [`reimport_local_skill_internal`] should do with a freshly staged
+/// source once it has compared that source against the live center copy.
+///
+/// Why its own enum instead of matching [`Reconcile`] inline at the call site:
+/// the reimport write-point collapses reconcile's four verdicts onto three
+/// distinct IO actions, and that collapse is exactly the bug-fix surface (an
+/// older source must never silently roll back a newer center). Isolating it as
+/// a pure value keeps the decision exhaustively unit-testable with no store, DB,
+/// or filesystem in the loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReimportDecision {
+    /// Source and center already hold identical content — drop the staged copy,
+    /// do not swap.
+    SkipInSync,
+    /// Source is the newer version — back up the current center, then overwrite
+    /// it with the staged source.
+    OverwriteCenter,
+    /// Center is newer than, or has diverged from, the source — keep the center
+    /// untouched and drop the staged copy. This is the regression fix: reimport
+    /// used to overwrite unconditionally and could revert a user's newer central
+    /// edits with a stale external source.
+    KeepCenter,
+}
+
+/// Decide the reimport action for the source↔center plane from each side's
+/// observable state (content hash + filesystem mtime).
+///
+/// The source↔center plane has no trustworthy last-synced baseline — a reimport
+/// re-reads an arbitrary external source that was never tracked against the
+/// center — so we pass `baseline_hash = None` and let [`reconcile`] degrade to
+/// pure newest-wins by mtime. `a = source`, `b = center`, so `TakeA` means the
+/// source won. `TakeB` and `Diverged` both map to `KeepCenter`: we never let an
+/// older or unrankable source overwrite the center.
+fn decide_reimport(source: &SideState, center: &SideState, threshold_ms: i64) -> ReimportDecision {
+    match reconcile(None, source, center, threshold_ms) {
+        Reconcile::InSync => ReimportDecision::SkipInSync,
+        Reconcile::TakeA { .. } => ReimportDecision::OverwriteCenter,
+        Reconcile::TakeB { .. } | Reconcile::Diverged => ReimportDecision::KeepCenter,
+    }
+}
+
 pub fn reimport_local_skill_internal(
     store: &SkillStore,
     skill_id: &str,
@@ -1623,20 +1671,100 @@ pub fn reimport_local_skill_internal(
         let install_result =
             installer::install_from_local_to_destination(&path, Some(&skill.name), &staged_path)
                 .map_err(AppError::io)?;
-        swap_skill_directory(&staged_path, Path::new(&skill.central_path))?;
-        store
-            .update_skill_after_install(
-                &skill.id,
-                &skill.name,
-                install_result.description.as_deref(),
-                None,
-                None,
-                Some(&install_result.content_hash),
-                "local_only",
-            )
-            .map_err(AppError::db)?;
-        resync_copy_targets(store, &skill.id)?;
-        sync_metadata::write_all_from_db_unlocked(store).map_err(AppError::db)?;
+
+        // Decide source↔center on the freshly staged source vs. the *live*
+        // center (re-hashed here, since the DB's stored hash can be stale after
+        // an out-of-band edit). No baseline: this plane was never synced, so
+        // only newest-wins-by-mtime applies. `a = source`, `b = center`.
+        let central_path = Path::new(&skill.central_path);
+        let decision = if !central_path.exists() {
+            // Center gone (e.g. the user deleted it and reimports to recover).
+            // There is nothing to compare or back up — rebuild it from source.
+            // Without this, an absent center hashes to the empty-dir digest with
+            // no mtime, reconcile returns Diverged, and the recovery would be
+            // wrongly skipped.
+            ReimportDecision::OverwriteCenter
+        } else {
+            let source = SideState {
+                hash: Some(install_result.content_hash.clone()),
+                mtime_ms: content_hash::latest_modified_millis(&path),
+            };
+            let center = SideState {
+                hash: content_hash::hash_directory(central_path).ok(),
+                mtime_ms: content_hash::latest_modified_millis(central_path),
+            };
+            decide_reimport(&source, &center, REIMPORT_MTIME_THRESHOLD_MS)
+        };
+
+        match decision {
+            ReimportDecision::SkipInSync => {
+                // Identical content — don't swap, and don't leak the staged copy.
+                remove_path_if_exists(&staged_path)?;
+                store
+                    .update_skill_check_state(&skill.id, None, "local_only", None)
+                    .map_err(AppError::db)?;
+            }
+            ReimportDecision::KeepCenter => {
+                // The fix: an older/diverged source must not roll back the
+                // center. Drop the staged copy, keep the center, record why.
+                remove_path_if_exists(&staged_path)?;
+                let detail =
+                    "kept center (newer than / diverged from source), skipped reimport";
+                log::info!("reimport {}: {detail}", skill.id);
+                store.log_audit(
+                    AuditDraft::new("reimport")
+                        .skill(skill.id.clone(), skill.name.clone())
+                        .ok()
+                        .detail(detail),
+                );
+                store
+                    .update_skill_check_state(&skill.id, None, "local_only", None)
+                    .map_err(AppError::db)?;
+            }
+            ReimportDecision::OverwriteCenter => {
+                // Snapshot the current center *before* overwriting it. `Copy`,
+                // NOT `Move`: the center must stay in place so that
+                // `swap_skill_directory`'s atomic rename-with-rollback can put it
+                // back if the swap fails — its rollback keys off "current center
+                // still exists" (rename it aside, restore on error). A `Move`
+                // would vacate `central_path` first, defeating that rollback: a
+                // failed rename (e.g. an external process holding a handle on
+                // Windows, which RepoLock cannot fence out) would then leave the
+                // skill missing entirely — a crash-safety regression versus the
+                // pre-fix code. The extra copy is the deliberate price of keeping
+                // the swap's rollback intact. When the center is absent (rebuild
+                // case) there is nothing to snapshot.
+                if central_path.exists() {
+                    let dir_name = central_path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_else(|| skill.name.clone());
+                    central_repo::backup_directory(
+                        &central_repo::base_dir(),
+                        central_path,
+                        &dir_name,
+                        "reimport-source-newer",
+                        chrono::Utc::now().timestamp_millis(),
+                        central_repo::BackupKind::Copy,
+                    )
+                    .map_err(AppError::io)?;
+                }
+                swap_skill_directory(&staged_path, central_path)?;
+                store
+                    .update_skill_after_install(
+                        &skill.id,
+                        &skill.name,
+                        install_result.description.as_deref(),
+                        None,
+                        None,
+                        Some(&install_result.content_hash),
+                        "local_only",
+                    )
+                    .map_err(AppError::db)?;
+                resync_copy_targets(store, &skill.id)?;
+                sync_metadata::write_all_from_db_unlocked(store).map_err(AppError::db)?;
+            }
+        }
         Ok(())
     })();
 
@@ -2489,5 +2617,222 @@ mod tests {
         assert_ne!(k_a, k_b);
         assert_eq!(k_a, "category-a/foo");
         assert_eq!(k_b, "category-b/foo");
+    }
+
+    // ── reimport source↔center decision ─────────────────────────────────────
+
+    fn side(hash: Option<&str>, mtime_ms: Option<i64>) -> SideState {
+        SideState {
+            hash: hash.map(|s| s.to_string()),
+            mtime_ms,
+        }
+    }
+
+    #[test]
+    fn decide_reimport_identical_content_skips() {
+        // Same hash on both sides → nothing to write, regardless of mtime.
+        assert_eq!(
+            decide_reimport(&side(Some("h"), Some(1)), &side(Some("h"), Some(9_999)), 1000),
+            ReimportDecision::SkipInSync
+        );
+    }
+
+    #[test]
+    fn decide_reimport_source_strictly_newer_overwrites() {
+        // Different content, source mtime newer than center by > threshold.
+        assert_eq!(
+            decide_reimport(
+                &side(Some("src"), Some(5_000)),
+                &side(Some("ctr"), Some(1_000)),
+                1000
+            ),
+            ReimportDecision::OverwriteCenter
+        );
+    }
+
+    #[test]
+    fn decide_reimport_center_strictly_newer_keeps_center() {
+        // The core regression: an older source must not roll back a newer center.
+        assert_eq!(
+            decide_reimport(
+                &side(Some("src"), Some(1_000)),
+                &side(Some("ctr"), Some(5_000)),
+                1000
+            ),
+            ReimportDecision::KeepCenter
+        );
+    }
+
+    #[test]
+    fn decide_reimport_tie_within_threshold_keeps_center() {
+        // Different content but mtimes within the threshold → Diverged → we
+        // cannot rank them, so the center is kept (never a coin-flip overwrite).
+        assert_eq!(
+            decide_reimport(
+                &side(Some("src"), Some(1_500)),
+                &side(Some("ctr"), Some(1_000)),
+                1000
+            ),
+            ReimportDecision::KeepCenter
+        );
+    }
+
+    #[test]
+    fn decide_reimport_unrankable_missing_mtime_keeps_center() {
+        // A side's mtime unreadable → unrankable → keep the center, never
+        // silently overwrite it.
+        assert_eq!(
+            decide_reimport(
+                &side(Some("src"), None),
+                &side(Some("ctr"), Some(1_000)),
+                1000
+            ),
+            ReimportDecision::KeepCenter
+        );
+    }
+
+    /// Pin a file's mtime to a fixed epoch-ms value so a freshly created
+    /// tempdir's wall-clock timestamp can't perturb newest-wins comparisons.
+    fn set_file_mtime_ms(path: &Path, ms: i64) {
+        let time = std::time::UNIX_EPOCH + std::time::Duration::from_millis(ms as u64);
+        let file = fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(time).unwrap();
+    }
+
+    /// Stage a reimport scenario: a center skill dir under `skills_dir()` and a
+    /// separate external source dir, each with its own content and pinned mtime,
+    /// wired to a DB record whose `source_ref` points at the source. Returns the
+    /// central and backups-root paths for assertions.
+    fn setup_reimport(
+        repo: &TestRepo,
+        center_content: &str,
+        center_mtime: i64,
+        source_content: &str,
+        source_mtime: i64,
+    ) -> (PathBuf, PathBuf) {
+        let central = central_repo::skills_dir().join("my-skill");
+        fs::create_dir_all(&central).unwrap();
+        fs::write(central.join("SKILL.md"), center_content).unwrap();
+        set_file_mtime_ms(&central.join("SKILL.md"), center_mtime);
+
+        let source = repo._tmp.path().join("external-source");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), source_content).unwrap();
+        set_file_mtime_ms(&source.join("SKILL.md"), source_mtime);
+
+        let mut rec = sample_skill("skill-1", "my-skill", &central);
+        rec.source_type = "local".to_string();
+        rec.source_ref = Some(source.to_string_lossy().to_string());
+        repo.store.insert_skill(&rec).unwrap();
+
+        let backups = central_repo::base_dir().join("backups");
+        (central, backups)
+    }
+
+    #[test]
+    fn reimport_keeps_center_when_center_is_newer() {
+        // Regression: source is older than the user's central edits. Reimport
+        // must NOT revert the center, must NOT back anything up, must NOT error.
+        let repo = test_repo();
+        let center_content = "---\nname: my-skill\n---\ncenter-newer-edit\n";
+        let source_content = "---\nname: my-skill\n---\nstale-source\n";
+        let (central, backups) =
+            setup_reimport(&repo, center_content, 5_000_000, source_content, 1_000);
+
+        let result = reimport_local_skill_internal(&repo.store, "skill-1");
+
+        assert!(result.is_ok(), "reimport should succeed, got {result:?}");
+        assert_eq!(
+            fs::read_to_string(central.join("SKILL.md")).unwrap(),
+            center_content,
+            "center must be left untouched"
+        );
+        assert!(!backups.exists(), "no backup when the center is kept");
+        // Symmetric with the SkipInSync test: the staged copy must not leak.
+        let staged_leftover = fs::read_dir(central_repo::skills_dir())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains("staged"));
+        assert!(!staged_leftover, "staged copy must be cleaned up");
+        let reloaded = repo.store.get_skill_by_id("skill-1").unwrap().unwrap();
+        assert_ne!(reloaded.update_status, "error");
+    }
+
+    #[test]
+    fn reimport_rebuilds_center_when_missing() {
+        // Recovery path: the user deleted the central copy and reimports to get
+        // it back. With no center to compare against, reimport must rebuild it
+        // from source rather than no-op, and has nothing to back up.
+        let repo = test_repo();
+        let source_content = "---\nname: my-skill\n---\nrecovered\n";
+        let source = repo._tmp.path().join("external-source");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), source_content).unwrap();
+
+        // Central path is recorded but intentionally never created on disk.
+        let central = central_repo::skills_dir().join("my-skill");
+        let mut rec = sample_skill("skill-1", "my-skill", &central);
+        rec.source_type = "local".to_string();
+        rec.source_ref = Some(source.to_string_lossy().to_string());
+        repo.store.insert_skill(&rec).unwrap();
+        assert!(!central.exists(), "precondition: center is missing");
+
+        let result = reimport_local_skill_internal(&repo.store, "skill-1");
+
+        assert!(result.is_ok(), "reimport should rebuild, got {result:?}");
+        assert_eq!(
+            fs::read_to_string(central.join("SKILL.md")).unwrap(),
+            source_content,
+            "center must be rebuilt from source"
+        );
+        assert!(
+            !central_repo::base_dir().join("backups").exists(),
+            "nothing to back up when the center was absent"
+        );
+    }
+
+    #[test]
+    fn reimport_overwrites_and_backs_up_when_source_is_newer() {
+        let repo = test_repo();
+        let center_content = "---\nname: my-skill\n---\nold-center\n";
+        let source_content = "---\nname: my-skill\n---\nfresh-source\n";
+        let (central, backups) =
+            setup_reimport(&repo, center_content, 1_000, source_content, 5_000_000);
+
+        let result = reimport_local_skill_internal(&repo.store, "skill-1");
+
+        assert!(result.is_ok(), "reimport should succeed, got {result:?}");
+        assert_eq!(
+            fs::read_to_string(central.join("SKILL.md")).unwrap(),
+            source_content,
+            "center must now hold the newer source content"
+        );
+        // The old center content must survive as a backup.
+        let skill_backups = backups.join("my-skill");
+        assert!(skill_backups.exists(), "old center must be backed up");
+        let backed_up = fs::read_dir(&skill_backups).unwrap().any(|entry| {
+            let md = entry.unwrap().path().join("SKILL.md");
+            md.exists() && fs::read_to_string(&md).unwrap() == center_content
+        });
+        assert!(backed_up, "a backup holding the old center content must exist");
+    }
+
+    #[test]
+    fn reimport_is_noop_when_source_and_center_match() {
+        let repo = test_repo();
+        let content = "---\nname: my-skill\n---\nidentical\n";
+        let (central, backups) = setup_reimport(&repo, content, 5_000_000, content, 1_000);
+
+        let result = reimport_local_skill_internal(&repo.store, "skill-1");
+
+        assert!(result.is_ok(), "reimport should succeed, got {result:?}");
+        assert_eq!(fs::read_to_string(central.join("SKILL.md")).unwrap(), content);
+        assert!(!backups.exists(), "identical content needs no backup");
+        // The staged copy must not leak into skills_dir.
+        let staged_leftover = fs::read_dir(central_repo::skills_dir())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains("staged"));
+        assert!(!staged_leftover, "staged copy must be cleaned up");
     }
 }

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1384,6 +1384,22 @@ pub async fn detach_local_skill_source(
     .await?
 }
 
+/// Map a raw `skill_targets.status` to the value the frontend consumes.
+///
+/// The deploy guard flags a spoke the user has edited as `target_ahead` so the
+/// next preset apply preserves it (see `scenario_service`). That marker is
+/// internal: the guard reads it back on the next apply to decide whether to
+/// re-protect, but the frontend has no badge for it and the target is not in an
+/// error state. Surface it as a normal `ok` target so it never renders as an
+/// unknown/blank status; the raw value stays in the DB for the guard's own use.
+fn dto_target_status(status: &str) -> String {
+    if status == "target_ahead" {
+        "ok".to_string()
+    } else {
+        status.to_string()
+    }
+}
+
 fn managed_skill_to_dto(
     store: &SkillStore,
     skill: SkillRecord,
@@ -1399,7 +1415,7 @@ fn managed_skill_to_dto(
             tool: target.tool.clone(),
             target_path: target.target_path.clone(),
             mode: target.mode.clone(),
-            status: target.status.clone(),
+            status: dto_target_status(&target.status),
             synced_at: target.synced_at,
         })
         .collect();
@@ -2486,6 +2502,16 @@ mod tests {
             last_checked_at: None,
             last_check_error: None,
         }
+    }
+
+    #[test]
+    fn dto_target_status_hides_internal_target_ahead_marker() {
+        // `target_ahead` is an internal guard marker with no frontend badge; it
+        // must reach the UI as a normal `ok` target, never verbatim.
+        assert_eq!(dto_target_status("target_ahead"), "ok");
+        // Every other status passes through unchanged.
+        assert_eq!(dto_target_status("ok"), "ok");
+        assert_eq!(dto_target_status("error"), "error");
     }
 
     #[test]

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1760,7 +1760,6 @@ pub fn reimport_local_skill_internal(
                         central_path,
                         &dir_name,
                         "reimport-source-newer",
-                        central_repo::BackupKind::Copy,
                     )
                     .map_err(AppError::io)?;
                 }

--- a/src-tauri/src/core/central_repo.rs
+++ b/src-tauri/src/core/central_repo.rs
@@ -397,17 +397,6 @@ fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
     Ok(())
 }
 
-/// How a directory should land in the backup area before it is overwritten.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BackupKind {
-    /// The caller is about to overwrite `src` in place, so the old tree is
-    /// *moved* out of the way (source disappears, backup holds the only copy).
-    Move,
-    /// The caller keeps `src` as-is and only wants a snapshot, so the tree is
-    /// *copied* (source stays put, backup is a duplicate).
-    Copy,
-}
-
 /// Back a directory up under `<central_root>/backups/<skill_dir_name>/<reason>/`.
 ///
 /// One snapshot per `(skill, reason)`: the destination name is the reason alone,
@@ -417,23 +406,16 @@ pub enum BackupKind {
 /// spoke-ahead), which is why repeated overwrites can no longer grow it without
 /// bound. Returns the directory the backup landed in.
 ///
-/// The replacement is staged: the new snapshot is written to a temporary sibling
-/// on the same volume first, then swapped into place, so a mid-write failure
-/// never destroys the previous, still-valid backup. If the final swap fails the
-/// staged copy is left intact rather than deleted — for a `Move` the source is
-/// already gone, so the staged copy is the only surviving copy of the data and
-/// must not be discarded.
-///
-/// `Move` is cross-volume safe: `src` may live on a different drive than the
-/// central repo (project on `D:`, library on `C:`), where `std::fs::rename`
-/// fails with `EXDEV`. On any rename failure we fall back to a recursive
-/// copy-then-delete so the observable semantics stay "move".
+/// The snapshot is a copy: `src` is left in place, because every caller
+/// overwrites it afterwards through its own atomic swap and relies on the
+/// original still existing for that swap's rollback. The copy is staged under a
+/// temporary sibling on the same volume first, then swapped into place, so a
+/// mid-write failure never destroys the previous, still-valid backup.
 pub fn backup_directory(
     central_root: &Path,
     src: &Path,
     skill_dir_name: &str,
     reason: &str,
-    kind: BackupKind,
 ) -> Result<PathBuf> {
     let parent = central_root
         .join("backups")
@@ -448,16 +430,19 @@ pub fn backup_directory(
     // Stage the new snapshot under a temporary sibling, then swap it into place.
     // Until the swap completes the previous backup at `dest` stays untouched.
     let staging = unique_backup_dir(&parent, &format!("{reason_name}.incoming"));
-    match kind {
-        BackupKind::Move => move_directory(src, &staging)?,
-        BackupKind::Copy => copy_dir_with_rollback(src, &staging)?,
-    }
+    copy_dir_with_rollback(src, &staging)?;
 
     // Drop the previous snapshot only now that the replacement is fully written.
+    // If that removal fails, discard the staged copy too so a failed swap never
+    // leaves an orphan `.incoming` dir behind (the source is untouched by a copy,
+    // so nothing is lost).
     if dest.exists() {
-        fs::remove_dir_all(&dest).with_context(|| {
-            format!("Failed to remove previous backup {}", dest.display())
-        })?;
+        if let Err(err) = fs::remove_dir_all(&dest) {
+            let _ = fs::remove_dir_all(&staging);
+            return Err(err).with_context(|| {
+                format!("Failed to remove previous backup {}", dest.display())
+            });
+        }
     }
     fs::rename(&staging, &dest).with_context(|| {
         format!(
@@ -491,30 +476,6 @@ fn unique_backup_dir(parent: &Path, base_name: &str) -> PathBuf {
         }
         n += 1;
     }
-}
-
-/// Move `src` to `dest`, falling back to copy-then-delete when a plain rename
-/// can't cross volumes (or the OS otherwise refuses it).
-fn move_directory(src: &Path, dest: &Path) -> Result<()> {
-    match fs::rename(src, dest) {
-        Ok(()) => Ok(()),
-        Err(_) => move_via_copy_delete(src, dest),
-    }
-}
-
-/// The cross-volume fallback, factored out so it is unit-testable on a single
-/// volume (a genuine cross-drive tempdir is hard to arrange in tests): copy the
-/// whole tree, then remove the source, preserving "move" semantics.
-fn move_via_copy_delete(src: &Path, dest: &Path) -> Result<()> {
-    copy_dir_with_rollback(src, dest)?;
-    fs::remove_dir_all(src).with_context(|| {
-        format!(
-            "Failed to remove source {} after backup copy to {}",
-            src.display(),
-            dest.display()
-        )
-    })?;
-    Ok(())
 }
 
 /// Recursively copy `src` into `dest`, rolling back a half-written `dest` if the
@@ -989,23 +950,16 @@ mod tests {
     }
 
     #[test]
-    fn backup_move_creates_backup_and_removes_source() {
+    fn backup_creates_snapshot_and_keeps_source() {
         let central = tempfile::tempdir().unwrap();
         let work = tempfile::tempdir().unwrap();
         let src = work.path().join("my-skill");
         make_src_tree(&src);
 
-        let dest = backup_directory(
-            central.path(),
-            &src,
-            "my-skill",
-            "overwrite",
-            BackupKind::Move,
-        )
-        .unwrap();
+        let dest = backup_directory(central.path(), &src, "my-skill", "overwrite").unwrap();
 
-        // Source is gone (moved), backup holds the full tree.
-        assert!(!src.exists(), "move must remove the source");
+        // Source stays put (the backup is a copy); backup holds the full tree.
+        assert_eq!(fs::read(src.join("top.txt")).unwrap(), b"top");
         assert_eq!(fs::read(dest.join("top.txt")).unwrap(), b"top");
         assert_eq!(fs::read(dest.join("nested/inner.txt")).unwrap(), b"inner");
         // Lands under backups/<skill>/<reason>/ — the reason alone names it.
@@ -1013,28 +967,6 @@ mod tests {
         assert_eq!(dest.file_name().and_then(|n| n.to_str()), Some("overwrite"));
         // No staging debris left behind on the happy path.
         assert!(!dest.with_file_name("overwrite.incoming").exists());
-    }
-
-    #[test]
-    fn backup_copy_creates_backup_and_keeps_source() {
-        let central = tempfile::tempdir().unwrap();
-        let work = tempfile::tempdir().unwrap();
-        let src = work.path().join("my-skill");
-        make_src_tree(&src);
-
-        let dest = backup_directory(
-            central.path(),
-            &src,
-            "my-skill",
-            "snapshot",
-            BackupKind::Copy,
-        )
-        .unwrap();
-
-        // Source still intact, backup is a duplicate.
-        assert_eq!(fs::read(src.join("top.txt")).unwrap(), b"top");
-        assert_eq!(fs::read(dest.join("top.txt")).unwrap(), b"top");
-        assert_eq!(fs::read(dest.join("nested/inner.txt")).unwrap(), b"inner");
     }
 
     #[test]
@@ -1054,7 +986,6 @@ mod tests {
             &src1,
             "skill",
             "overwrite",
-            BackupKind::Move,
         )
         .unwrap();
 
@@ -1066,7 +997,6 @@ mod tests {
             &src2,
             "skill",
             "overwrite",
-            BackupKind::Move,
         )
         .unwrap();
 
@@ -1096,7 +1026,6 @@ mod tests {
             &src,
             "skill",
             "../../etc/passwd",
-            BackupKind::Copy,
         )
         .unwrap();
 
@@ -1125,29 +1054,13 @@ mod tests {
     }
 
     #[test]
-    fn move_via_copy_delete_moves_tree_and_removes_source() {
-        // Directly exercises the cross-volume fallback path (rename → EXDEV):
-        // copy the tree, then delete the source, preserving move semantics.
-        let work = tempfile::tempdir().unwrap();
-        let src = work.path().join("src");
-        make_src_tree(&src);
-        let dest = work.path().join("dest");
-
-        move_via_copy_delete(&src, &dest).unwrap();
-
-        assert!(!src.exists(), "source removed after copy");
-        assert_eq!(fs::read(dest.join("top.txt")).unwrap(), b"top");
-        assert_eq!(fs::read(dest.join("nested/inner.txt")).unwrap(), b"inner");
-    }
-
-    #[test]
     fn copy_failure_rolls_back_partial_dest_and_keeps_source() {
         // Deterministically force a mid-copy failure: pre-create `dest/nested`
         // as a FILE so copying src's `nested/` DIRECTORY into it fails. The
-        // rollback must then wipe the whole half-written `dest`, and — because
-        // this is the Move fallback — the source stays fully intact (no data
-        // lost on a failed backup). This is the same code path the untestable
-        // cross-volume Copy rollback takes.
+        // rollback must then wipe the whole half-written `dest` so a consumer
+        // can never mistake a truncated tree for a valid backup, while the
+        // source stays fully intact (a copy never touches it). This is the exact
+        // rollback path `backup_directory` relies on when staging a snapshot.
         let work = tempfile::tempdir().unwrap();
         let src = work.path().join("src");
         make_src_tree(&src); // src/top.txt + src/nested/inner.txt
@@ -1155,12 +1068,12 @@ mod tests {
         fs::create_dir_all(&dest).unwrap();
         fs::write(dest.join("nested"), b"i am a file, not a dir").unwrap();
 
-        let err = move_via_copy_delete(&src, &dest);
+        let err = copy_dir_with_rollback(&src, &dest);
         assert!(err.is_err(), "copy into a file-blocked subdir must fail");
 
         // Half-written backup fully rolled back — nothing to mis-consume.
         assert!(!dest.exists(), "partial dest must be removed on failure");
-        // Source untouched: move never deletes before a successful copy.
+        // Source untouched.
         assert_eq!(fs::read(src.join("top.txt")).unwrap(), b"top");
         assert_eq!(fs::read(src.join("nested/inner.txt")).unwrap(), b"inner");
     }
@@ -1180,7 +1093,6 @@ mod tests {
             &src,
             "../../evil",
             "overwrite",
-            BackupKind::Copy,
         )
         .unwrap();
 
@@ -1204,7 +1116,6 @@ mod tests {
             &src,
             "skill",
             "",
-            BackupKind::Copy,
         )
         .unwrap();
 
@@ -1222,7 +1133,6 @@ mod tests {
             &missing,
             "skill",
             "overwrite",
-            BackupKind::Copy,
         );
         assert!(result.is_err(), "missing source must be a graceful Err");
     }

--- a/src-tauri/src/core/central_repo.rs
+++ b/src-tauri/src/core/central_repo.rs
@@ -408,12 +408,21 @@ pub enum BackupKind {
     Copy,
 }
 
-/// Back a directory up under `<central_root>/backups/<skill_dir_name>/<ts>-<reason>/`.
+/// Back a directory up under `<central_root>/backups/<skill_dir_name>/<reason>/`.
 ///
-/// Non-destructive by construction: the destination is always a *new* directory
-/// (a `-1`, `-2`, … suffix is added if the timestamped name already exists) so
-/// an existing backup is never overwritten. Returns the directory the backup
-/// actually landed in.
+/// One snapshot per `(skill, reason)`: the destination name is the reason alone,
+/// so a later backup for the same reason *replaces* the previous one instead of
+/// piling up a fresh timestamped directory every time. This bounds `backups/` to
+/// at most one entry per skill per overwrite path (reimport / explicit-pull /
+/// spoke-ahead), which is why repeated overwrites can no longer grow it without
+/// bound. Returns the directory the backup landed in.
+///
+/// The replacement is staged: the new snapshot is written to a temporary sibling
+/// on the same volume first, then swapped into place, so a mid-write failure
+/// never destroys the previous, still-valid backup. If the final swap fails the
+/// staged copy is left intact rather than deleted — for a `Move` the source is
+/// already gone, so the staged copy is the only surviving copy of the data and
+/// must not be discarded.
 ///
 /// `Move` is cross-volume safe: `src` may live on a different drive than the
 /// central repo (project on `D:`, library on `C:`), where `std::fs::rename`
@@ -424,7 +433,6 @@ pub fn backup_directory(
     src: &Path,
     skill_dir_name: &str,
     reason: &str,
-    timestamp_ms: i64,
     kind: BackupKind,
 ) -> Result<PathBuf> {
     let parent = central_root
@@ -434,18 +442,36 @@ pub fn backup_directory(
         format!("Failed to create backup directory {}", parent.display())
     })?;
 
-    let base_name = format!("{}-{}", timestamp_ms, sanitize_backup_component(reason));
-    let dest = unique_backup_dir(&parent, &base_name);
+    let reason_name = sanitize_backup_component(reason);
+    let dest = parent.join(&reason_name);
 
+    // Stage the new snapshot under a temporary sibling, then swap it into place.
+    // Until the swap completes the previous backup at `dest` stays untouched.
+    let staging = unique_backup_dir(&parent, &format!("{reason_name}.incoming"));
     match kind {
-        BackupKind::Move => move_directory(src, &dest)?,
-        BackupKind::Copy => copy_dir_with_rollback(src, &dest)?,
+        BackupKind::Move => move_directory(src, &staging)?,
+        BackupKind::Copy => copy_dir_with_rollback(src, &staging)?,
     }
+
+    // Drop the previous snapshot only now that the replacement is fully written.
+    if dest.exists() {
+        fs::remove_dir_all(&dest).with_context(|| {
+            format!("Failed to remove previous backup {}", dest.display())
+        })?;
+    }
+    fs::rename(&staging, &dest).with_context(|| {
+        format!(
+            "Failed to finalize backup {} at {}",
+            staging.display(),
+            dest.display()
+        )
+    })?;
     Ok(dest)
 }
 
 /// Pick a not-yet-existing directory under `parent`, adding `-1`, `-2`, … to
-/// `base_name` on collision so an existing backup is never clobbered.
+/// `base_name` on collision. Used to name the transient `.incoming` staging dir
+/// so a leftover from an earlier interrupted backup is never reused mid-write.
 //
 // TOCTOU note: there is a gap between the `exists()` check and the caller's
 // later `create_dir_all`/rename into the returned path. That race is acceptable
@@ -974,7 +1000,6 @@ mod tests {
             &src,
             "my-skill",
             "overwrite",
-            1_700_000_000_000,
             BackupKind::Move,
         )
         .unwrap();
@@ -983,12 +1008,11 @@ mod tests {
         assert!(!src.exists(), "move must remove the source");
         assert_eq!(fs::read(dest.join("top.txt")).unwrap(), b"top");
         assert_eq!(fs::read(dest.join("nested/inner.txt")).unwrap(), b"inner");
-        // Lands under backups/<skill>/<ts>-<reason>/.
+        // Lands under backups/<skill>/<reason>/ — the reason alone names it.
         assert!(dest.starts_with(central.path().join("backups").join("my-skill")));
-        assert_eq!(
-            dest.file_name().and_then(|n| n.to_str()),
-            Some("1700000000000-overwrite")
-        );
+        assert_eq!(dest.file_name().and_then(|n| n.to_str()), Some("overwrite"));
+        // No staging debris left behind on the happy path.
+        assert!(!dest.with_file_name("overwrite.incoming").exists());
     }
 
     #[test]
@@ -1003,7 +1027,6 @@ mod tests {
             &src,
             "my-skill",
             "snapshot",
-            42,
             BackupKind::Copy,
         )
         .unwrap();
@@ -1015,9 +1038,13 @@ mod tests {
     }
 
     #[test]
-    fn backup_same_timestamp_and_reason_gets_suffix_never_overwrites() {
+    fn backup_same_reason_overwrites_previous_and_does_not_accumulate() {
+        // One snapshot per (skill, reason): a second backup for the same reason
+        // replaces the first at the *same* path rather than piling up a new
+        // directory, so repeated overwrites can't grow backups/ without bound.
         let central = tempfile::tempdir().unwrap();
         let work = tempfile::tempdir().unwrap();
+        let skill_backups = central.path().join("backups").join("skill");
 
         let src1 = work.path().join("skill-a");
         fs::create_dir_all(&src1).unwrap();
@@ -1027,7 +1054,6 @@ mod tests {
             &src1,
             "skill",
             "overwrite",
-            777,
             BackupKind::Move,
         )
         .unwrap();
@@ -1040,16 +1066,21 @@ mod tests {
             &src2,
             "skill",
             "overwrite",
-            777,
             BackupKind::Move,
         )
         .unwrap();
 
-        assert_ne!(first, second, "same ts+reason must not collide");
-        assert_eq!(second.file_name().and_then(|n| n.to_str()), Some("777-overwrite-1"));
-        // Neither backup was clobbered.
-        assert_eq!(fs::read(first.join("v1.txt")).unwrap(), b"first");
+        // Same destination both times.
+        assert_eq!(first, second, "same reason must reuse the same path");
+        // Only the latest snapshot survives; the previous file is gone.
+        assert!(!second.join("v1.txt").exists(), "old snapshot must be replaced");
         assert_eq!(fs::read(second.join("v2.txt")).unwrap(), b"second");
+        // backups/skill/ holds exactly one entry — no accumulation, no staging debris.
+        let entries: Vec<_> = fs::read_dir(&skill_backups)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(entries, vec!["overwrite".to_string()], "got {entries:?}");
     }
 
     #[test]
@@ -1065,7 +1096,6 @@ mod tests {
             &src,
             "skill",
             "../../etc/passwd",
-            5,
             BackupKind::Copy,
         )
         .unwrap();
@@ -1084,8 +1114,8 @@ mod tests {
         // The reason component itself carries no separators or `..`.
         let name = dest.file_name().unwrap().to_str().unwrap();
         assert!(!name.contains('/') && !name.contains('\\') && !name.contains(".."));
-        // "../../etc/passwd": 6 leading separators + join dash → 7 dashes.
-        assert_eq!(name, "5-------etc-passwd");
+        // "../../etc/passwd" → each of the 6 leading `.`/`/` chars becomes a dash.
+        assert_eq!(name, "------etc-passwd");
     }
 
     /// True if any component of `path` is a `..` parent-dir segment.
@@ -1150,7 +1180,6 @@ mod tests {
             &src,
             "../../evil",
             "overwrite",
-            5,
             BackupKind::Copy,
         )
         .unwrap();
@@ -1175,12 +1204,11 @@ mod tests {
             &src,
             "skill",
             "",
-            9,
             BackupKind::Copy,
         )
         .unwrap();
 
-        assert_eq!(dest.file_name().and_then(|n| n.to_str()), Some("9-unknown"));
+        assert_eq!(dest.file_name().and_then(|n| n.to_str()), Some("unknown"));
     }
 
     #[test]
@@ -1194,7 +1222,6 @@ mod tests {
             &missing,
             "skill",
             "overwrite",
-            1,
             BackupKind::Copy,
         );
         assert!(result.is_err(), "missing source must be a graceful Err");

--- a/src-tauri/src/core/central_repo.rs
+++ b/src-tauri/src/core/central_repo.rs
@@ -397,6 +397,136 @@ fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
     Ok(())
 }
 
+/// How a directory should land in the backup area before it is overwritten.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackupKind {
+    /// The caller is about to overwrite `src` in place, so the old tree is
+    /// *moved* out of the way (source disappears, backup holds the only copy).
+    Move,
+    /// The caller keeps `src` as-is and only wants a snapshot, so the tree is
+    /// *copied* (source stays put, backup is a duplicate).
+    Copy,
+}
+
+/// Back a directory up under `<central_root>/backups/<skill_dir_name>/<ts>-<reason>/`.
+///
+/// Non-destructive by construction: the destination is always a *new* directory
+/// (a `-1`, `-2`, … suffix is added if the timestamped name already exists) so
+/// an existing backup is never overwritten. Returns the directory the backup
+/// actually landed in.
+///
+/// `Move` is cross-volume safe: `src` may live on a different drive than the
+/// central repo (project on `D:`, library on `C:`), where `std::fs::rename`
+/// fails with `EXDEV`. On any rename failure we fall back to a recursive
+/// copy-then-delete so the observable semantics stay "move".
+pub fn backup_directory(
+    central_root: &Path,
+    src: &Path,
+    skill_dir_name: &str,
+    reason: &str,
+    timestamp_ms: i64,
+    kind: BackupKind,
+) -> Result<PathBuf> {
+    let parent = central_root
+        .join("backups")
+        .join(sanitize_backup_component(skill_dir_name));
+    fs::create_dir_all(&parent).with_context(|| {
+        format!("Failed to create backup directory {}", parent.display())
+    })?;
+
+    let base_name = format!("{}-{}", timestamp_ms, sanitize_backup_component(reason));
+    let dest = unique_backup_dir(&parent, &base_name);
+
+    match kind {
+        BackupKind::Move => move_directory(src, &dest)?,
+        BackupKind::Copy => copy_dir_with_rollback(src, &dest)?,
+    }
+    Ok(dest)
+}
+
+/// Pick a not-yet-existing directory under `parent`, adding `-1`, `-2`, … to
+/// `base_name` on collision so an existing backup is never clobbered.
+//
+// TOCTOU note: there is a gap between the `exists()` check and the caller's
+// later `create_dir_all`/rename into the returned path. That race is acceptable
+// here because every central-repo write is serialized by `RepoLock` (see
+// core::repo_lock) — two backups never run concurrently, so no other writer can
+// claim the name in between. Do not reach for an atomic create-if-absent here.
+fn unique_backup_dir(parent: &Path, base_name: &str) -> PathBuf {
+    let candidate = parent.join(base_name);
+    if !candidate.exists() {
+        return candidate;
+    }
+    let mut n = 1u32;
+    loop {
+        let candidate = parent.join(format!("{base_name}-{n}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
+/// Move `src` to `dest`, falling back to copy-then-delete when a plain rename
+/// can't cross volumes (or the OS otherwise refuses it).
+fn move_directory(src: &Path, dest: &Path) -> Result<()> {
+    match fs::rename(src, dest) {
+        Ok(()) => Ok(()),
+        Err(_) => move_via_copy_delete(src, dest),
+    }
+}
+
+/// The cross-volume fallback, factored out so it is unit-testable on a single
+/// volume (a genuine cross-drive tempdir is hard to arrange in tests): copy the
+/// whole tree, then remove the source, preserving "move" semantics.
+fn move_via_copy_delete(src: &Path, dest: &Path) -> Result<()> {
+    copy_dir_with_rollback(src, dest)?;
+    fs::remove_dir_all(src).with_context(|| {
+        format!(
+            "Failed to remove source {} after backup copy to {}",
+            src.display(),
+            dest.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// Recursively copy `src` into `dest`, rolling back a half-written `dest` if the
+/// copy fails partway. Without this, a consumer could later mistake a truncated
+/// half-tree for a valid backup. The rollback is best-effort — if it too fails,
+/// the original copy error still propagates. For `Move` the source is only
+/// removed *after* a successful copy, so a failed backup never loses data.
+fn copy_dir_with_rollback(src: &Path, dest: &Path) -> Result<()> {
+    if let Err(err) = copy_dir_recursive(src, dest) {
+        // Discard whatever partial tree was written so it can't be consumed.
+        let _ = fs::remove_dir_all(dest);
+        return Err(err);
+    }
+    Ok(())
+}
+
+/// Clean one path component destined for a backup directory name. Everything
+/// outside `[A-Za-z0-9-_]` becomes `-`, which also neutralises `/`, `\`, and
+/// `.` — so no `..` component and no separator can smuggle the backup outside
+/// `backups/<skill>/`. Empty input degrades to a stable placeholder.
+fn sanitize_backup_component(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if cleaned.is_empty() {
+        "unknown".to_string()
+    } else {
+        cleaned
+    }
+}
+
 /// Whether two paths resolve to the same directory. Falls back to a lexical
 /// comparison when either side can't be canonicalized (e.g. the target does not
 /// exist yet), so a purely cosmetic difference (case, `8.3` names, a symlink)
@@ -821,6 +951,253 @@ mod tests {
         let parent = external_base_dir(Path::new("a/../nonexistent-norm-target"));
         assert_eq!(plain, dot);
         assert_eq!(plain, parent);
+    }
+
+    // ── backup_directory (F2) ──
+
+    /// Build a small source tree with a nested file and return its root.
+    fn make_src_tree(root: &Path) {
+        fs::create_dir_all(root.join("nested")).unwrap();
+        fs::write(root.join("top.txt"), b"top").unwrap();
+        fs::write(root.join("nested/inner.txt"), b"inner").unwrap();
+    }
+
+    #[test]
+    fn backup_move_creates_backup_and_removes_source() {
+        let central = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        let src = work.path().join("my-skill");
+        make_src_tree(&src);
+
+        let dest = backup_directory(
+            central.path(),
+            &src,
+            "my-skill",
+            "overwrite",
+            1_700_000_000_000,
+            BackupKind::Move,
+        )
+        .unwrap();
+
+        // Source is gone (moved), backup holds the full tree.
+        assert!(!src.exists(), "move must remove the source");
+        assert_eq!(fs::read(dest.join("top.txt")).unwrap(), b"top");
+        assert_eq!(fs::read(dest.join("nested/inner.txt")).unwrap(), b"inner");
+        // Lands under backups/<skill>/<ts>-<reason>/.
+        assert!(dest.starts_with(central.path().join("backups").join("my-skill")));
+        assert_eq!(
+            dest.file_name().and_then(|n| n.to_str()),
+            Some("1700000000000-overwrite")
+        );
+    }
+
+    #[test]
+    fn backup_copy_creates_backup_and_keeps_source() {
+        let central = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        let src = work.path().join("my-skill");
+        make_src_tree(&src);
+
+        let dest = backup_directory(
+            central.path(),
+            &src,
+            "my-skill",
+            "snapshot",
+            42,
+            BackupKind::Copy,
+        )
+        .unwrap();
+
+        // Source still intact, backup is a duplicate.
+        assert_eq!(fs::read(src.join("top.txt")).unwrap(), b"top");
+        assert_eq!(fs::read(dest.join("top.txt")).unwrap(), b"top");
+        assert_eq!(fs::read(dest.join("nested/inner.txt")).unwrap(), b"inner");
+    }
+
+    #[test]
+    fn backup_same_timestamp_and_reason_gets_suffix_never_overwrites() {
+        let central = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+
+        let src1 = work.path().join("skill-a");
+        fs::create_dir_all(&src1).unwrap();
+        fs::write(src1.join("v1.txt"), b"first").unwrap();
+        let first = backup_directory(
+            central.path(),
+            &src1,
+            "skill",
+            "overwrite",
+            777,
+            BackupKind::Move,
+        )
+        .unwrap();
+
+        let src2 = work.path().join("skill-b");
+        fs::create_dir_all(&src2).unwrap();
+        fs::write(src2.join("v2.txt"), b"second").unwrap();
+        let second = backup_directory(
+            central.path(),
+            &src2,
+            "skill",
+            "overwrite",
+            777,
+            BackupKind::Move,
+        )
+        .unwrap();
+
+        assert_ne!(first, second, "same ts+reason must not collide");
+        assert_eq!(second.file_name().and_then(|n| n.to_str()), Some("777-overwrite-1"));
+        // Neither backup was clobbered.
+        assert_eq!(fs::read(first.join("v1.txt")).unwrap(), b"first");
+        assert_eq!(fs::read(second.join("v2.txt")).unwrap(), b"second");
+    }
+
+    #[test]
+    fn backup_sanitizes_illegal_reason_and_cannot_escape() {
+        let central = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        let src = work.path().join("s");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("f.txt"), b"x").unwrap();
+
+        let dest = backup_directory(
+            central.path(),
+            &src,
+            "skill",
+            "../../etc/passwd",
+            5,
+            BackupKind::Copy,
+        )
+        .unwrap();
+
+        // Stays inside the skill's backup area — no traversal escaped.
+        let skill_backups = central.path().join("backups").join("skill");
+        assert!(dest.starts_with(&skill_backups), "{}", dest.display());
+        // Strong guard: walk EVERY component of the full path and assert none is
+        // a `..` parent-dir segment. A lexical `starts_with` alone can be fooled
+        // by an embedded `..`; component inspection cannot.
+        assert!(
+            !has_parent_dir_component(&dest),
+            "no path component may be `..`: {}",
+            dest.display()
+        );
+        // The reason component itself carries no separators or `..`.
+        let name = dest.file_name().unwrap().to_str().unwrap();
+        assert!(!name.contains('/') && !name.contains('\\') && !name.contains(".."));
+        // "../../etc/passwd": 6 leading separators + join dash → 7 dashes.
+        assert_eq!(name, "5-------etc-passwd");
+    }
+
+    /// True if any component of `path` is a `..` parent-dir segment.
+    fn has_parent_dir_component(path: &Path) -> bool {
+        path.components()
+            .any(|c| matches!(c, Component::ParentDir))
+    }
+
+    #[test]
+    fn move_via_copy_delete_moves_tree_and_removes_source() {
+        // Directly exercises the cross-volume fallback path (rename → EXDEV):
+        // copy the tree, then delete the source, preserving move semantics.
+        let work = tempfile::tempdir().unwrap();
+        let src = work.path().join("src");
+        make_src_tree(&src);
+        let dest = work.path().join("dest");
+
+        move_via_copy_delete(&src, &dest).unwrap();
+
+        assert!(!src.exists(), "source removed after copy");
+        assert_eq!(fs::read(dest.join("top.txt")).unwrap(), b"top");
+        assert_eq!(fs::read(dest.join("nested/inner.txt")).unwrap(), b"inner");
+    }
+
+    #[test]
+    fn copy_failure_rolls_back_partial_dest_and_keeps_source() {
+        // Deterministically force a mid-copy failure: pre-create `dest/nested`
+        // as a FILE so copying src's `nested/` DIRECTORY into it fails. The
+        // rollback must then wipe the whole half-written `dest`, and — because
+        // this is the Move fallback — the source stays fully intact (no data
+        // lost on a failed backup). This is the same code path the untestable
+        // cross-volume Copy rollback takes.
+        let work = tempfile::tempdir().unwrap();
+        let src = work.path().join("src");
+        make_src_tree(&src); // src/top.txt + src/nested/inner.txt
+        let dest = work.path().join("dest");
+        fs::create_dir_all(&dest).unwrap();
+        fs::write(dest.join("nested"), b"i am a file, not a dir").unwrap();
+
+        let err = move_via_copy_delete(&src, &dest);
+        assert!(err.is_err(), "copy into a file-blocked subdir must fail");
+
+        // Half-written backup fully rolled back — nothing to mis-consume.
+        assert!(!dest.exists(), "partial dest must be removed on failure");
+        // Source untouched: move never deletes before a successful copy.
+        assert_eq!(fs::read(src.join("top.txt")).unwrap(), b"top");
+        assert_eq!(fs::read(src.join("nested/inner.txt")).unwrap(), b"inner");
+    }
+
+    #[test]
+    fn backup_sanitizes_illegal_skill_name_and_cannot_escape() {
+        // Traversal defense is independent of `reason`: a hostile
+        // `skill_dir_name` must also stay under backups/ with no `..` component.
+        let central = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        let src = work.path().join("s");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("f.txt"), b"x").unwrap();
+
+        let dest = backup_directory(
+            central.path(),
+            &src,
+            "../../evil",
+            "overwrite",
+            5,
+            BackupKind::Copy,
+        )
+        .unwrap();
+
+        assert!(dest.starts_with(central.path().join("backups")));
+        assert!(
+            !has_parent_dir_component(&dest),
+            "no `..` component: {}",
+            dest.display()
+        );
+    }
+
+    #[test]
+    fn backup_empty_reason_uses_unknown_placeholder() {
+        let central = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        let src = work.path().join("s");
+        fs::create_dir_all(&src).unwrap();
+
+        let dest = backup_directory(
+            central.path(),
+            &src,
+            "skill",
+            "",
+            9,
+            BackupKind::Copy,
+        )
+        .unwrap();
+
+        assert_eq!(dest.file_name().and_then(|n| n.to_str()), Some("9-unknown"));
+    }
+
+    #[test]
+    fn backup_missing_source_returns_err_not_panic() {
+        let central = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        let missing = work.path().join("does-not-exist");
+
+        let result = backup_directory(
+            central.path(),
+            &missing,
+            "skill",
+            "overwrite",
+            1,
+            BackupKind::Copy,
+        );
+        assert!(result.is_err(), "missing source must be a graceful Err");
     }
 
     #[test]

--- a/src-tauri/src/core/central_repo.rs
+++ b/src-tauri/src/core/central_repo.rs
@@ -481,8 +481,8 @@ fn unique_backup_dir(parent: &Path, base_name: &str) -> PathBuf {
 /// Recursively copy `src` into `dest`, rolling back a half-written `dest` if the
 /// copy fails partway. Without this, a consumer could later mistake a truncated
 /// half-tree for a valid backup. The rollback is best-effort — if it too fails,
-/// the original copy error still propagates. For `Move` the source is only
-/// removed *after* a successful copy, so a failed backup never loses data.
+/// the original copy error still propagates. `src` is only ever a copy input
+/// (never removed), so a failed backup never loses data.
 fn copy_dir_with_rollback(src: &Path, dest: &Path) -> Result<()> {
     if let Err(err) = copy_dir_recursive(src, dest) {
         // Discard whatever partial tree was written so it can't be consumed.

--- a/src-tauri/src/core/content_hash.rs
+++ b/src-tauri/src/core/content_hash.rs
@@ -126,6 +126,18 @@ pub fn latest_modified_ms(entries: &[ContentEntry]) -> Option<i64> {
     entries.iter().filter_map(|e| e.modified_ms).max()
 }
 
+/// Latest content-file modification time (ms since epoch) for a directory,
+/// walking it fresh. Dir-taking wrapper over [`list_content_files`] +
+/// [`latest_modified_ms`] for callers that only hold a path and can't reuse an
+/// existing walk — sync-status classification uses it to read the central
+/// copy's real filesystem mtime. Returns `None` when the directory has no
+/// readable content files (missing, empty, or unreadable). Symlink cycles are a
+/// non-issue: the underlying walk does not follow symlinks, so a self-referential
+/// link is simply never traversed.
+pub fn latest_modified_millis(dir: &Path) -> Option<i64> {
+    latest_modified_ms(&list_content_files(dir))
+}
+
 pub fn hash_directory(dir: &Path) -> Result<String> {
     Ok(hash_entries(&list_content_files(dir)))
 }
@@ -303,6 +315,51 @@ mod tests {
         // No content files → no timestamp.
         let empty = tempdir().unwrap();
         assert_eq!(latest_modified_ms(&list_content_files(empty.path())), None);
+    }
+
+    /// Force a file's mtime to a fixed epoch-ms value so mtime-ordering tests
+    /// don't depend on wall-clock timing or filesystem resolution.
+    fn set_file_mtime_ms(path: &Path, ms: i64) {
+        let time = std::time::UNIX_EPOCH + std::time::Duration::from_millis(ms as u64);
+        let file = fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(time).unwrap();
+    }
+
+    #[test]
+    fn latest_modified_millis_returns_newest_content_file() {
+        let tmp = tempdir().unwrap();
+        let old = tmp.path().join("old.txt");
+        let new = tmp.path().join("new.txt");
+        fs::write(&old, "a").unwrap();
+        fs::write(&new, "b").unwrap();
+        set_file_mtime_ms(&old, 1_000);
+        set_file_mtime_ms(&new, 5_000);
+
+        // The newest content file's mtime wins over older siblings.
+        assert_eq!(latest_modified_millis(tmp.path()), Some(5_000));
+    }
+
+    #[test]
+    fn latest_modified_millis_missing_directory_is_none() {
+        let tmp = tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        assert_eq!(latest_modified_millis(&missing), None);
+    }
+
+    /// A symlink pointing back at its own directory must not send the walk into
+    /// an infinite loop; the call has to terminate and still report the real
+    /// content file's mtime.
+    #[cfg(unix)]
+    #[test]
+    fn latest_modified_millis_survives_symlink_cycle() {
+        let tmp = tempdir().unwrap();
+        let file = tmp.path().join("real.txt");
+        fs::write(&file, "content").unwrap();
+        set_file_mtime_ms(&file, 3_000);
+        // Self-referential cycle: <dir>/loop -> <dir>.
+        std::os::unix::fs::symlink(tmp.path(), tmp.path().join("loop")).unwrap();
+
+        assert_eq!(latest_modified_millis(tmp.path()), Some(3_000));
     }
 
     #[test]

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -19,6 +19,7 @@ pub mod migrations;
 pub mod panic_log;
 pub mod path_guard;
 pub mod project_scanner;
+pub mod reconcile;
 pub mod repo_lock;
 pub mod scanner;
 pub mod scenario_service;

--- a/src-tauri/src/core/reconcile.rs
+++ b/src-tauri/src/core/reconcile.rs
@@ -1,0 +1,262 @@
+//! Pure three-state reconcile decision for the folder-level sync path.
+//!
+//! Given the observable state of two sides (a content hash + an mtime each)
+//! plus an optional "last-synced baseline" hash, decide who should overwrite
+//! whom, or whether the two have genuinely diverged. No IO whatsoever — this is
+//! a pure function so both ends reach the same verdict from the same inputs.
+//!
+//! Semantics deliberately mirror `core/merge/decision.rs`: the baseline decides
+//! *who changed*, and newest-wins by mtime is used *only* to break a real
+//! two-sided conflict. We never let the clock alone pick a winner when the
+//! baseline can tell us only one side actually moved — wall clocks across
+//! machines are unreliable, so "who changed relative to the last sync" is the
+//! trustworthy signal and time is just the last-resort tie-break.
+
+/// One side's observable state. `hash` / `mtime_ms` are `None` when they can't
+/// be read (e.g. the directory is absent, or its mtime is unavailable).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SideState {
+    pub hash: Option<String>,
+    pub mtime_ms: Option<i64>,
+}
+
+/// The verdict. `conflict` marks the decisions that resolved a genuine
+/// two-sided divergence (both changed vs baseline, or no baseline at all) as
+/// opposed to a clean single-side fast-forward.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reconcile {
+    /// Both sides hold identical content — nothing to do.
+    InSync,
+    /// A is authoritative, overwrite B. `conflict=true` when both sides had
+    /// changed relative to the baseline and A won the newest-wins tie-break.
+    TakeA { conflict: bool },
+    /// B is authoritative, overwrite A.
+    TakeB { conflict: bool },
+    /// Both sides changed but we can't tell who is newer (mtime tied within the
+    /// threshold, or missing on either side) — leave it for a human.
+    Diverged,
+}
+
+/// Decide how to reconcile two sides.
+///
+/// * `baseline_hash` — content hash recorded at the last successful sync, or
+///   `None` for a first-ever (baseline-less) comparison.
+/// * `threshold_ms` — mtime tie-break tolerance; a difference at or under this
+///   is treated as "can't tell who is newer".
+pub fn reconcile(
+    baseline_hash: Option<&str>,
+    a: &SideState,
+    b: &SideState,
+    threshold_ms: i64,
+) -> Reconcile {
+    // 1. Trivial agreement: identical content, or both absent → nothing to do.
+    match (a.hash.as_deref(), b.hash.as_deref()) {
+        (Some(ha), Some(hb)) if ha == hb => return Reconcile::InSync,
+        (None, None) => return Reconcile::InSync,
+        _ => {}
+    }
+
+    match baseline_hash {
+        // 2. With a baseline we know *who changed*. A side whose hash differs
+        //    from the baseline (including a missing hash) is "changed".
+        Some(base) => {
+            let a_changed = a.hash.as_deref() != Some(base);
+            let b_changed = b.hash.as_deref() != Some(base);
+            match (a_changed, b_changed) {
+                // Only A moved → A is the new version, clean fast-forward onto B.
+                (true, false) => Reconcile::TakeA { conflict: false },
+                (false, true) => Reconcile::TakeB { conflict: false },
+                // Neither moved. Logically unreachable (step 1 would have caught
+                // equal hashes) — defensive InSync rather than a false conflict.
+                (false, false) => Reconcile::InSync,
+                // Both moved → genuine conflict. Only *here* does the clock get
+                // to pick a winner, matching decision.rs's "newest-wins is for
+                // double-change conflicts only".
+                (true, true) => mtime_winner(a, b, threshold_ms),
+            }
+        }
+        // 3. No baseline: we cannot attribute change, so degrade to pure
+        //    newest-wins by mtime and always flag it as a conflict — the clock
+        //    is the only signal we have and it is not authoritative.
+        None => mtime_winner(a, b, threshold_ms),
+    }
+}
+
+/// Break a two-sided conflict by mtime: the strictly-newer side (by more than
+/// `threshold_ms`) wins; a tie within the threshold, or a missing mtime on
+/// either side, is `Diverged`. Always flags `conflict=true` because it is only
+/// ever reached from a genuine two-sided divergence.
+fn mtime_winner(a: &SideState, b: &SideState, threshold_ms: i64) -> Reconcile {
+    match (a.mtime_ms, b.mtime_ms) {
+        (Some(ta), Some(tb)) => {
+            // `saturating_sub` clamps instead of overflowing on extreme i64
+            // mtimes (e.g. i64::MAX vs i64::MIN); the clamp only ever makes the
+            // gap look at least as large, so a genuine winner still wins and a
+            // tie still ties — the verdict is unchanged for realistic inputs.
+            if ta.saturating_sub(tb) > threshold_ms {
+                Reconcile::TakeA { conflict: true }
+            } else if tb.saturating_sub(ta) > threshold_ms {
+                Reconcile::TakeB { conflict: true }
+            } else {
+                Reconcile::Diverged
+            }
+        }
+        _ => Reconcile::Diverged,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn side(hash: Option<&str>, mtime_ms: Option<i64>) -> SideState {
+        SideState {
+            hash: hash.map(|s| s.to_string()),
+            mtime_ms,
+        }
+    }
+
+    // ── step 1: trivial agreement ──
+
+    #[test]
+    fn equal_hashes_are_in_sync() {
+        let a = side(Some("h"), Some(10));
+        let b = side(Some("h"), Some(9999));
+        assert_eq!(reconcile(Some("base"), &a, &b, 0), Reconcile::InSync);
+    }
+
+    #[test]
+    fn both_absent_is_in_sync() {
+        let a = side(None, None);
+        let b = side(None, None);
+        assert_eq!(reconcile(Some("base"), &a, &b, 0), Reconcile::InSync);
+    }
+
+    // ── step 2: with a baseline, single-side change fast-forwards ──
+
+    #[test]
+    fn baseline_only_a_changed_takes_a_without_conflict() {
+        let a = side(Some("new"), Some(100));
+        let b = side(Some("base"), Some(100));
+        assert_eq!(
+            reconcile(Some("base"), &a, &b, 5),
+            Reconcile::TakeA { conflict: false }
+        );
+    }
+
+    #[test]
+    fn baseline_only_b_changed_takes_b_without_conflict() {
+        let a = side(Some("base"), Some(100));
+        let b = side(Some("new"), Some(100));
+        assert_eq!(
+            reconcile(Some("base"), &a, &b, 5),
+            Reconcile::TakeB { conflict: false }
+        );
+    }
+
+    #[test]
+    fn baseline_missing_hash_counts_as_changed_side() {
+        // A absent (None) while B matches baseline → A "changed/absent", single
+        // side moved → clean TakeA.
+        let a = side(None, Some(100));
+        let b = side(Some("base"), Some(100));
+        assert_eq!(
+            reconcile(Some("base"), &a, &b, 5),
+            Reconcile::TakeA { conflict: false }
+        );
+    }
+
+    // ── step 2: both changed → newest-wins conflict resolution ──
+
+    #[test]
+    fn baseline_both_changed_a_newer_wins_as_conflict() {
+        let a = side(Some("a-new"), Some(200));
+        let b = side(Some("b-new"), Some(100));
+        assert_eq!(
+            reconcile(Some("base"), &a, &b, 5),
+            Reconcile::TakeA { conflict: true }
+        );
+    }
+
+    #[test]
+    fn baseline_both_changed_b_newer_wins_as_conflict() {
+        let a = side(Some("a-new"), Some(100));
+        let b = side(Some("b-new"), Some(200));
+        assert_eq!(
+            reconcile(Some("base"), &a, &b, 5),
+            Reconcile::TakeB { conflict: true }
+        );
+    }
+
+    #[test]
+    fn baseline_both_changed_mtime_tie_within_threshold_diverges() {
+        let a = side(Some("a-new"), Some(100));
+        let b = side(Some("b-new"), Some(103));
+        // |100 - 103| = 3 <= threshold 5 → can't tell who is newer.
+        assert_eq!(reconcile(Some("base"), &a, &b, 5), Reconcile::Diverged);
+    }
+
+    #[test]
+    fn baseline_both_changed_missing_mtime_diverges() {
+        let a = side(Some("a-new"), None);
+        let b = side(Some("b-new"), Some(200));
+        assert_eq!(reconcile(Some("base"), &a, &b, 5), Reconcile::Diverged);
+    }
+
+    #[test]
+    fn baseline_both_changed_diff_exactly_threshold_diverges() {
+        // Boundary: a difference of exactly threshold_ms is NOT strictly newer
+        // (the comparison is `>`, not `>=`) → Diverged. Guards against a `>=`
+        // regression.
+        let a = side(Some("a-new"), Some(100));
+        let b = side(Some("b-new"), Some(105));
+        assert_eq!(reconcile(Some("base"), &a, &b, 5), Reconcile::Diverged);
+    }
+
+    // ── step 3: no baseline → pure mtime, always conflict ──
+
+    #[test]
+    fn no_baseline_a_newer_wins_as_conflict() {
+        let a = side(Some("a"), Some(300));
+        let b = side(Some("b"), Some(100));
+        assert_eq!(
+            reconcile(None, &a, &b, 5),
+            Reconcile::TakeA { conflict: true }
+        );
+    }
+
+    #[test]
+    fn no_baseline_b_newer_wins_as_conflict() {
+        let a = side(Some("a"), Some(100));
+        let b = side(Some("b"), Some(300));
+        assert_eq!(
+            reconcile(None, &a, &b, 5),
+            Reconcile::TakeB { conflict: true }
+        );
+    }
+
+    #[test]
+    fn no_baseline_mtime_tie_diverges() {
+        let a = side(Some("a"), Some(100));
+        let b = side(Some("b"), Some(100));
+        assert_eq!(reconcile(None, &a, &b, 5), Reconcile::Diverged);
+    }
+
+    #[test]
+    fn no_baseline_diff_exactly_threshold_diverges() {
+        // Same `>` vs `>=` boundary as the baseline case, on the no-baseline
+        // (pure mtime) path.
+        let a = side(Some("a"), Some(100));
+        let b = side(Some("b"), Some(95));
+        assert_eq!(reconcile(None, &a, &b, 5), Reconcile::Diverged);
+    }
+
+    #[test]
+    fn no_baseline_missing_one_mtime_diverges() {
+        // No baseline + one side's mtime unreadable → can't rank → Diverged,
+        // never a silent one-sided overwrite.
+        let a = side(Some("a"), None);
+        let b = side(Some("b"), Some(300));
+        assert_eq!(reconcile(None, &a, &b, 5), Reconcile::Diverged);
+    }
+}

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -305,7 +305,6 @@ pub fn sync_desired_targets(
                         match decision {
                             DeployGuardDecision::Deploy => {}
                             DeployGuardDecision::PreserveAndFlag => {
-                                let now_ms = chrono::Utc::now().timestamp_millis();
                                 let skill_dir_name = sync_engine::target_dir_name(
                                     &desired.source,
                                     &desired.skill_name,
@@ -317,7 +316,6 @@ pub fn sync_desired_targets(
                                     &desired.target,
                                     &skill_dir_name,
                                     "spoke-ahead",
-                                    now_ms,
                                     central_repo::BackupKind::Copy,
                                 ) {
                                     Ok(dest) => log::info!(

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use super::{
+    audit_log::AuditDraft,
+    central_repo, content_hash,
     error::AppError,
     skill_store::{ScenarioRecord, SkillStore, SkillTargetRecord},
     sync_engine, tool_adapters,
@@ -143,6 +145,75 @@ fn skip_check_mode(existing_mode: &str, desired: sync_engine::SyncMode) -> Optio
     }
 }
 
+/// Slack (ms) allowed between a target's newest content mtime and its last
+/// recorded `synced_at` before we treat the target as "possibly edited". Filesystem
+/// mtime granularity and the small delay between writing files and recording
+/// `synced_at` mean an equal-or-slightly-later mtime does not imply a real edit.
+/// Kept in sync with the 1000ms convention used elsewhere in the sync path.
+const SPOKE_MTIME_THRESHOLD_MS: i64 = 1000;
+
+/// What the deploy guard decides to do with an about-to-be-overwritten Copy target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeployGuardDecision {
+    /// Overwrite the target with central content (original behavior).
+    Deploy,
+    /// Target was edited by the user since our last sync: snapshot it once,
+    /// flag the record, and skip the deploy.
+    PreserveAndFlag,
+    /// Target was edited but is already flagged: preserve and skip without
+    /// taking another snapshot.
+    PreserveNoBackup,
+}
+
+/// Decide whether an existing Copy target may be overwritten, protected with a
+/// fresh snapshot, or protected without one.
+///
+/// `target_mtime` is the newest content-file mtime of the spoke (ms), `synced_at`
+/// is when we last deployed to it, `baseline_hash` is the content hash we last
+/// deployed (== the central source hash at that time), and `status` is the
+/// current target record status.
+///
+/// The (expensive) `compute_target_hash` closure is only invoked when the cheap
+/// mtime pre-filter says the target *might* have changed. This keeps the #248
+/// hot path intact: a target whose newest file predates our last sync (within
+/// `SPOKE_MTIME_THRESHOLD_MS` slack) can't have been edited since we wrote it, so
+/// we return `Deploy` without ever hashing it.
+fn deploy_guard_decision(
+    target_mtime: Option<i64>,
+    synced_at: i64,
+    baseline_hash: &str,
+    status: &str,
+    compute_target_hash: impl FnOnce() -> Option<String>,
+) -> DeployGuardDecision {
+    // Cheap pre-filter — no hashing on the hot path.
+    let possibly_edited = match target_mtime {
+        None => false,
+        Some(mtime) => mtime > synced_at + SPOKE_MTIME_THRESHOLD_MS,
+    };
+    if !possibly_edited {
+        return DeployGuardDecision::Deploy;
+    }
+
+    // mtime moved: hash to tell a real edit apart from a bare touch.
+    match compute_target_hash() {
+        // Content still equals what we deployed: not a real edit, overwrite.
+        Some(hash) if hash == baseline_hash => DeployGuardDecision::Deploy,
+        // Couldn't hash (target vanished/unreadable): fall back to overwrite so
+        // we never protect a target we can't reason about.
+        None => DeployGuardDecision::Deploy,
+        // Genuine divergence from what we deployed → protect the spoke. Snapshot
+        // only the first time (status flips to target_ahead) so repeated preset
+        // applies don't keep flooding backups/.
+        Some(_) => {
+            if status == "target_ahead" {
+                DeployGuardDecision::PreserveNoBackup
+            } else {
+                DeployGuardDecision::PreserveAndFlag
+            }
+        }
+    }
+}
+
 pub fn sync_desired_targets(
     store: &SkillStore,
     desired_targets: &[ScenarioSyncTarget],
@@ -157,6 +228,7 @@ pub fn sync_desired_targets(
 
     let mut synced_count = 0usize;
     let mut skipped_count = 0usize;
+    let mut preserved_count = 0usize;
     let mut failed_count = 0usize;
 
     for desired in desired_targets {
@@ -178,32 +250,120 @@ pub fn sync_desired_targets(
                         desired.tool
                     );
                 }
-            } else if existing.status == "ok" {
-                if let Some(check_mode) = skip_check_mode(&existing.mode, desired.mode) {
-                    if sync_engine::is_target_current(
-                        &desired.source,
-                        &desired.target,
-                        check_mode,
-                        existing.source_hash.as_deref(),
-                        desired.source_hash.as_deref(),
-                    ) {
-                        // Surface the Windows fallback case in logs so operators
-                        // can tell when a target is permanently on Copy because
-                        // an earlier symlink_dir() failed (issue #153). Helpful
-                        // when a user later enables Developer Mode and wonders
-                        // why Symlink isn't being re-attempted.
-                        if existing.mode == "copy"
-                            && matches!(desired.mode, sync_engine::SyncMode::Symlink)
-                        {
-                            log::debug!(
-                                "sync_desired_targets: skill {} ({}) staying on copy fallback for {} (content unchanged); trigger a manual resync to retry symlink",
-                                desired.skill_id,
-                                desired.skill_name,
-                                desired.tool
-                            );
+            } else {
+                if existing.status == "ok" {
+                    if let Some(check_mode) = skip_check_mode(&existing.mode, desired.mode) {
+                        if sync_engine::is_target_current(
+                            &desired.source,
+                            &desired.target,
+                            check_mode,
+                            existing.source_hash.as_deref(),
+                            desired.source_hash.as_deref(),
+                        ) {
+                            // Surface the Windows fallback case in logs so operators
+                            // can tell when a target is permanently on Copy because
+                            // an earlier symlink_dir() failed (issue #153). Helpful
+                            // when a user later enables Developer Mode and wonders
+                            // why Symlink isn't being re-attempted.
+                            if existing.mode == "copy"
+                                && matches!(desired.mode, sync_engine::SyncMode::Symlink)
+                            {
+                                log::debug!(
+                                    "sync_desired_targets: skill {} ({}) staying on copy fallback for {} (content unchanged); trigger a manual resync to retry symlink",
+                                    desired.skill_id,
+                                    desired.skill_name,
+                                    desired.tool
+                                );
+                            }
+                            skipped_count += 1;
+                            continue;
                         }
-                        skipped_count += 1;
-                        continue;
+                    }
+                }
+
+                // Deploy guard (Problem B): we're about to overwrite an existing
+                // target. Only Copy targets have an independent spoke that can
+                // hold user edits — Symlink targets *are* the central dir, so
+                // there's nothing to protect and the guard is skipped. We also
+                // need a baseline (both synced_at and source_hash present) to
+                // tell a real edit from the content we last deployed.
+                if matches!(desired.mode, sync_engine::SyncMode::Copy) {
+                    if let (Some(synced_at), Some(baseline)) =
+                        (existing.synced_at, existing.source_hash.as_deref())
+                    {
+                        // Cheap mtime read first; the closure only hashes when
+                        // the pre-filter says the target might have changed.
+                        let target_mtime =
+                            content_hash::latest_modified_millis(&desired.target);
+                        let decision = deploy_guard_decision(
+                            target_mtime,
+                            synced_at,
+                            baseline,
+                            &existing.status,
+                            || content_hash::hash_directory(&desired.target).ok(),
+                        );
+                        match decision {
+                            DeployGuardDecision::Deploy => {}
+                            DeployGuardDecision::PreserveAndFlag => {
+                                let now_ms = chrono::Utc::now().timestamp_millis();
+                                let skill_dir_name = sync_engine::target_dir_name(
+                                    &desired.source,
+                                    &desired.skill_name,
+                                );
+                                let central_root = central_repo::base_dir();
+                                // In-place snapshot (Copy) — the spoke stays put.
+                                match central_repo::backup_directory(
+                                    &central_root,
+                                    &desired.target,
+                                    &skill_dir_name,
+                                    "spoke-ahead",
+                                    now_ms,
+                                    central_repo::BackupKind::Copy,
+                                ) {
+                                    Ok(dest) => log::info!(
+                                        "sync_desired_targets: preserved user-edited target for skill {} ({}) / {}; snapshot at {}",
+                                        desired.skill_id,
+                                        desired.skill_name,
+                                        desired.tool,
+                                        dest.display()
+                                    ),
+                                    Err(e) => log::warn!(
+                                        "sync_desired_targets: failed to snapshot user-edited target for skill {} / {}: {e}",
+                                        desired.skill_id,
+                                        desired.tool
+                                    ),
+                                }
+                                // Flag the record so a later run takes the
+                                // PreserveNoBackup path and doesn't re-snapshot.
+                                if let Err(e) = store.update_target_status(
+                                    &desired.skill_id,
+                                    &desired.tool,
+                                    "target_ahead",
+                                    Some("preserved user-edited target, skipped deploy"),
+                                ) {
+                                    log::warn!(
+                                        "sync_desired_targets: failed to flag target_ahead for skill {} / {}: {e}",
+                                        desired.skill_id,
+                                        desired.tool
+                                    );
+                                }
+                                store.log_audit(
+                                    AuditDraft::new("sync")
+                                        .skill(&desired.skill_id, &desired.skill_name)
+                                        .tool(&desired.tool)
+                                        .ok()
+                                        .detail("preserved user-edited target, skipped deploy"),
+                                );
+                                preserved_count += 1;
+                                continue;
+                            }
+                            DeployGuardDecision::PreserveNoBackup => {
+                                // Already snapshotted on a prior run — keep the
+                                // spoke, skip silently (no backup spam).
+                                preserved_count += 1;
+                                continue;
+                            }
+                        }
                     }
                 }
             }
@@ -258,7 +418,7 @@ pub fn sync_desired_targets(
     }
 
     log::info!(
-        "sync_desired_targets: {} targets in {} ms (synced={synced_count}, skipped={skipped_count}, failed={failed_count})",
+        "sync_desired_targets: {} targets in {} ms (synced={synced_count}, skipped={skipped_count}, preserved={preserved_count}, failed={failed_count})",
         desired_targets.len(),
         batch_start.elapsed().as_millis()
     );
@@ -932,6 +1092,652 @@ mod sync_desired_targets_tests {
         assert!(target.join("SKILL.md").exists(), "missing target was not re-synced");
 
         central_repo::set_test_base_dir_override(None);
+    }
+
+    // ── Problem B: deploy guard for user-edited Copy targets ──
+
+    use std::path::Path;
+
+    /// Force a content file's mtime to a fixed epoch-ms value so the
+    /// touched/untouched decision doesn't depend on wall-clock timing.
+    fn set_mtime_ms(path: &Path, ms: i64) {
+        let time = std::time::UNIX_EPOCH + std::time::Duration::from_millis(ms as u64);
+        let file = fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(time).unwrap();
+    }
+
+    fn guard_skill(id: &str, source: &Path, content_hash: &str) -> SkillRecord {
+        SkillRecord {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            source_type: "import".to_string(),
+            source_ref: Some(source.to_string_lossy().to_string()),
+            source_ref_resolved: None,
+            source_subpath: None,
+            source_branch: None,
+            source_revision: None,
+            remote_revision: None,
+            central_path: source.to_string_lossy().to_string(),
+            content_hash: Some(content_hash.to_string()),
+            enabled: true,
+            created_at: 1,
+            updated_at: 1,
+            status: "ok".to_string(),
+            update_status: "local_only".to_string(),
+            last_checked_at: None,
+            last_check_error: None,
+        }
+    }
+
+    fn count_backups(base: &Path, skill_dir: &str) -> usize {
+        let dir = base.join("backups").join(skill_dir);
+        match fs::read_dir(&dir) {
+            Ok(rd) => rd.filter_map(|e| e.ok()).count(),
+            Err(_) => 0,
+        }
+    }
+
+    /// Case 1 (no regression): the target was NOT edited since the last sync
+    /// (mtime <= synced_at) and the central content changed, so the target is
+    /// overwritten exactly as before — the guard must not fire.
+    #[test]
+    fn untouched_target_is_overwritten_when_central_changed() {
+        let _lock = central_repo::test_base_dir_lock();
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("repo");
+        central_repo::set_test_base_dir_override(Some(base.clone()));
+        fs::create_dir_all(central_repo::skills_dir()).unwrap();
+        let store = SkillStore::new(&base.join("test.db")).unwrap();
+
+        let source = central_repo::skills_dir().join("skill-a");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "central v2").unwrap();
+
+        let target = tmp.path().join("agent-skills").join("skill-a");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("SKILL.md"), "old deployed v1").unwrap();
+        fs::write(target.join("MARKER.txt"), "should be wiped").unwrap();
+        // Target last modified at 5000; we "synced" at 10000 → untouched.
+        set_mtime_ms(&target.join("SKILL.md"), 5_000);
+        set_mtime_ms(&target.join("MARKER.txt"), 5_000);
+
+        store.insert_skill(&guard_skill("skill-a", &source, "h2")).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t1".to_string(),
+                skill_id: "skill-a".to_string(),
+                tool: "claude-code".to_string(),
+                target_path: target.to_string_lossy().to_string(),
+                mode: "copy".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(10_000),
+                last_error: None,
+                source_hash: Some("h1".to_string()), // baseline differs from central h2
+            })
+            .unwrap();
+
+        let desired = vec![ScenarioSyncTarget {
+            skill_id: "skill-a".to_string(),
+            skill_name: "skill-a".to_string(),
+            tool: "claude-code".to_string(),
+            source: source.clone(),
+            target: target.clone(),
+            mode: sync_engine::SyncMode::Copy,
+            source_hash: Some("h2".to_string()),
+        }];
+
+        sync_desired_targets(&store, &desired).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(target.join("SKILL.md")).unwrap(),
+            "central v2",
+            "untouched target should have been overwritten with central content"
+        );
+        assert!(
+            !target.join("MARKER.txt").exists(),
+            "overwrite should have wiped the stale marker"
+        );
+        assert_eq!(count_backups(&base, "skill-a"), 0, "no backup for untouched target");
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    /// Case 2 (the fix): the target was edited since the last sync (mtime >
+    /// synced_at AND content hash != baseline) and central changed — the
+    /// user's edit must be preserved, a snapshot taken, and status flagged.
+    #[test]
+    fn edited_target_is_preserved_snapshotted_and_flagged() {
+        let _lock = central_repo::test_base_dir_lock();
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("repo");
+        central_repo::set_test_base_dir_override(Some(base.clone()));
+        fs::create_dir_all(central_repo::skills_dir()).unwrap();
+        let store = SkillStore::new(&base.join("test.db")).unwrap();
+
+        let source = central_repo::skills_dir().join("skill-b");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "central v2").unwrap();
+
+        // Deploy an original target, capture its real hash as the baseline.
+        let target = tmp.path().join("agent-skills").join("skill-b");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("SKILL.md"), "original deployed").unwrap();
+        let baseline = content_hash::hash_directory(&target).unwrap();
+
+        // Now the user edits the spoke; mtime is "now" (>> synced_at + slack).
+        fs::write(target.join("SKILL.md"), "USER EDIT keep me").unwrap();
+
+        store.insert_skill(&guard_skill("skill-b", &source, "central-h2")).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t2".to_string(),
+                skill_id: "skill-b".to_string(),
+                tool: "claude-code".to_string(),
+                target_path: target.to_string_lossy().to_string(),
+                mode: "copy".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+                source_hash: Some(baseline.clone()),
+            })
+            .unwrap();
+
+        let desired = vec![ScenarioSyncTarget {
+            skill_id: "skill-b".to_string(),
+            skill_name: "skill-b".to_string(),
+            tool: "claude-code".to_string(),
+            source: source.clone(),
+            target: target.clone(),
+            mode: sync_engine::SyncMode::Copy,
+            source_hash: Some("central-h2".to_string()),
+        }];
+
+        sync_desired_targets(&store, &desired).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(target.join("SKILL.md")).unwrap(),
+            "USER EDIT keep me",
+            "user-edited target must NOT be overwritten"
+        );
+        assert_eq!(
+            count_backups(&base, "skill-b"),
+            1,
+            "one spoke-ahead snapshot must exist"
+        );
+        let rec = store
+            .get_targets_for_skill("skill-b")
+            .unwrap()
+            .into_iter()
+            .find(|t| t.tool == "claude-code")
+            .unwrap();
+        assert_eq!(rec.status, "target_ahead", "record must be flagged target_ahead");
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    /// Case 3 (no false protection): the target's mtime was bumped but its
+    /// content still equals the baseline — this is not a real edit, so the
+    /// overwrite proceeds.
+    #[test]
+    fn touched_but_unchanged_target_is_overwritten() {
+        let _lock = central_repo::test_base_dir_lock();
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("repo");
+        central_repo::set_test_base_dir_override(Some(base.clone()));
+        fs::create_dir_all(central_repo::skills_dir()).unwrap();
+        let store = SkillStore::new(&base.join("test.db")).unwrap();
+
+        let source = central_repo::skills_dir().join("skill-c");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "central v2").unwrap();
+
+        let target = tmp.path().join("agent-skills").join("skill-c");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("SKILL.md"), "deployed content").unwrap();
+        let baseline = content_hash::hash_directory(&target).unwrap();
+        // "Touch": rewrite identical content so mtime moves but hash is stable.
+        fs::write(target.join("SKILL.md"), "deployed content").unwrap();
+
+        store.insert_skill(&guard_skill("skill-c", &source, "central-h2")).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t3".to_string(),
+                skill_id: "skill-c".to_string(),
+                tool: "claude-code".to_string(),
+                target_path: target.to_string_lossy().to_string(),
+                mode: "copy".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+                source_hash: Some(baseline.clone()),
+            })
+            .unwrap();
+
+        let desired = vec![ScenarioSyncTarget {
+            skill_id: "skill-c".to_string(),
+            skill_name: "skill-c".to_string(),
+            tool: "claude-code".to_string(),
+            source: source.clone(),
+            target: target.clone(),
+            mode: sync_engine::SyncMode::Copy,
+            source_hash: Some("central-h2".to_string()),
+        }];
+
+        sync_desired_targets(&store, &desired).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(target.join("SKILL.md")).unwrap(),
+            "central v2",
+            "content-unchanged target must still be overwritten"
+        );
+        assert_eq!(count_backups(&base, "skill-c"), 0, "no backup when content unchanged");
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    /// Case 4: a target already flagged target_ahead is preserved again on a
+    /// second run, but no additional snapshot is written.
+    #[test]
+    fn already_flagged_target_is_not_snapshotted_again() {
+        let _lock = central_repo::test_base_dir_lock();
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("repo");
+        central_repo::set_test_base_dir_override(Some(base.clone()));
+        fs::create_dir_all(central_repo::skills_dir()).unwrap();
+        let store = SkillStore::new(&base.join("test.db")).unwrap();
+
+        let source = central_repo::skills_dir().join("skill-d");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "central v2").unwrap();
+
+        let target = tmp.path().join("agent-skills").join("skill-d");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("SKILL.md"), "original deployed").unwrap();
+        let baseline = content_hash::hash_directory(&target).unwrap();
+        fs::write(target.join("SKILL.md"), "USER EDIT keep me").unwrap();
+
+        store.insert_skill(&guard_skill("skill-d", &source, "central-h2")).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t4".to_string(),
+                skill_id: "skill-d".to_string(),
+                tool: "claude-code".to_string(),
+                target_path: target.to_string_lossy().to_string(),
+                mode: "copy".to_string(),
+                status: "target_ahead".to_string(), // already flagged
+                synced_at: Some(1),
+                last_error: Some("preserved user-edited target, skipped deploy".to_string()),
+                source_hash: Some(baseline.clone()),
+            })
+            .unwrap();
+
+        let desired = vec![ScenarioSyncTarget {
+            skill_id: "skill-d".to_string(),
+            skill_name: "skill-d".to_string(),
+            tool: "claude-code".to_string(),
+            source: source.clone(),
+            target: target.clone(),
+            mode: sync_engine::SyncMode::Copy,
+            source_hash: Some("central-h2".to_string()),
+        }];
+
+        sync_desired_targets(&store, &desired).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(target.join("SKILL.md")).unwrap(),
+            "USER EDIT keep me",
+            "already-flagged target must remain preserved"
+        );
+        assert_eq!(
+            count_backups(&base, "skill-d"),
+            0,
+            "already-flagged target must NOT be snapshotted again"
+        );
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    /// Case 5: Symlink-mode targets are physically the central dir, so the
+    /// guard must not engage — no snapshot, no target_ahead flag — even when
+    /// the on-disk target looks "edited".
+    #[test]
+    fn symlink_mode_target_is_not_guarded() {
+        let _lock = central_repo::test_base_dir_lock();
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("repo");
+        central_repo::set_test_base_dir_override(Some(base.clone()));
+        fs::create_dir_all(central_repo::skills_dir()).unwrap();
+        let store = SkillStore::new(&base.join("test.db")).unwrap();
+
+        let source = central_repo::skills_dir().join("skill-e");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "central v2").unwrap();
+
+        let target = tmp.path().join("agent-skills").join("skill-e");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("SKILL.md"), "USER EDIT keep me").unwrap();
+        let baseline = content_hash::hash_directory(&target).unwrap();
+        // edited afterwards to differ from baseline
+        fs::write(target.join("SKILL.md"), "USER EDIT changed again").unwrap();
+
+        store.insert_skill(&guard_skill("skill-e", &source, "central-h2")).unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "t5".to_string(),
+                skill_id: "skill-e".to_string(),
+                tool: "claude-code".to_string(),
+                target_path: target.to_string_lossy().to_string(),
+                mode: "symlink".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+                source_hash: Some(baseline.clone()),
+            })
+            .unwrap();
+
+        let desired = vec![ScenarioSyncTarget {
+            skill_id: "skill-e".to_string(),
+            skill_name: "skill-e".to_string(),
+            tool: "claude-code".to_string(),
+            source: source.clone(),
+            target: target.clone(),
+            mode: sync_engine::SyncMode::Symlink,
+            source_hash: Some("central-h2".to_string()),
+        }];
+
+        sync_desired_targets(&store, &desired).unwrap();
+
+        // The guard is Copy-only: no spoke-ahead snapshot, and the record is
+        // never flagged target_ahead for a symlink target.
+        assert_eq!(
+            count_backups(&base, "skill-e"),
+            0,
+            "symlink target must never be snapshotted by the guard"
+        );
+        let rec = store
+            .get_targets_for_skill("skill-e")
+            .unwrap()
+            .into_iter()
+            .find(|t| t.tool == "claude-code")
+            .unwrap();
+        assert_ne!(
+            rec.status, "target_ahead",
+            "symlink target must never be flagged target_ahead"
+        );
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    /// NB-1 (real-data smoke): the whole guard rests on one invariant — an
+    /// *unedited* spoke hashes back to the `source_hash` baseline. Every other
+    /// guard test hand-seeds that baseline, so a future drift between
+    /// `copy_dir_recursive` (what deploy writes) and `hash_directory` (what the
+    /// guard reads) would slip through silently. Here the baseline and the
+    /// deployed bytes are produced by a *real* `sync_desired_targets` run, so
+    /// the two code paths must genuinely agree: a faithful copy that was never
+    /// touched by the user must be overwritten (Deploy), not falsely protected.
+    ///
+    /// Mutation check: if the guard compared the target hash against a baseline
+    /// that can never equal it (e.g. a hard-coded sentinel), this test would go
+    /// red — the untouched target would be preserved instead of overwritten.
+    #[test]
+    fn real_deploy_then_unedited_target_is_overwritten() {
+        let _lock = central_repo::test_base_dir_lock();
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("repo");
+        central_repo::set_test_base_dir_override(Some(base.clone()));
+        fs::create_dir_all(central_repo::skills_dir()).unwrap();
+        let store = SkillStore::new(&base.join("test.db")).unwrap();
+
+        // Real central skill with a couple of content files.
+        let source = central_repo::skills_dir().join("skill-real");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "central v1").unwrap();
+        fs::write(source.join("ref.txt"), "shared reference").unwrap();
+        // The genuine content hash a real skill record would carry.
+        let h1 = content_hash::hash_directory(&source).unwrap();
+
+        let target = tmp.path().join("agent-skills").join("skill-real");
+
+        store.insert_skill(&guard_skill("skill-real", &source, &h1)).unwrap();
+
+        // ── Run 1: REAL deploy. No hand-seeded target row/hash — the record's
+        // source_hash and synced_at, and the target bytes, are all produced by
+        // sync_desired_targets copying the real source. ──
+        let desired_v1 = vec![ScenarioSyncTarget {
+            skill_id: "skill-real".to_string(),
+            skill_name: "skill-real".to_string(),
+            tool: "claude-code".to_string(),
+            source: source.clone(),
+            target: target.clone(),
+            mode: sync_engine::SyncMode::Copy,
+            source_hash: Some(h1.clone()),
+        }];
+        sync_desired_targets(&store, &desired_v1).unwrap();
+
+        // Sanity: the deploy really happened and produced a baseline record.
+        assert_eq!(
+            fs::read_to_string(target.join("SKILL.md")).unwrap(),
+            "central v1"
+        );
+        let rec_after_deploy = store
+            .get_targets_for_skill("skill-real")
+            .unwrap()
+            .into_iter()
+            .find(|t| t.tool == "claude-code")
+            .unwrap();
+        assert_eq!(rec_after_deploy.source_hash.as_deref(), Some(h1.as_str()));
+        let synced_at = rec_after_deploy.synced_at.unwrap();
+
+        // ── Central content changes; the target dir is NOT edited by the user.
+        // We only push the target mtime past synced_at so the cheap pre-filter
+        // can't short-circuit — forcing the guard down the hash branch, where
+        // it must find hash(faithful copy) == baseline and decide Deploy. ──
+        fs::write(source.join("SKILL.md"), "central v2 UPDATED").unwrap();
+        let h2 = content_hash::hash_directory(&source).unwrap();
+        assert_ne!(h1, h2, "central content must have actually changed");
+        set_mtime_ms(&target.join("SKILL.md"), synced_at + 10_000);
+        set_mtime_ms(&target.join("ref.txt"), synced_at + 10_000);
+
+        let desired_v2 = vec![ScenarioSyncTarget {
+            skill_id: "skill-real".to_string(),
+            skill_name: "skill-real".to_string(),
+            tool: "claude-code".to_string(),
+            source: source.clone(),
+            target: target.clone(),
+            mode: sync_engine::SyncMode::Copy,
+            source_hash: Some(h2.clone()),
+        }];
+        sync_desired_targets(&store, &desired_v2).unwrap();
+
+        // The faithful, unedited copy must be overwritten with the new central
+        // content — the guard must NOT mistake a bumped mtime for a real edit.
+        assert_eq!(
+            fs::read_to_string(target.join("SKILL.md")).unwrap(),
+            "central v2 UPDATED",
+            "unedited spoke (hash == baseline) must be overwritten, not protected"
+        );
+        assert_eq!(
+            count_backups(&base, "skill-real"),
+            0,
+            "no backup for an unedited faithful copy"
+        );
+        let rec_after = store
+            .get_targets_for_skill("skill-real")
+            .unwrap()
+            .into_iter()
+            .find(|t| t.tool == "claude-code")
+            .unwrap();
+        assert_ne!(
+            rec_after.status, "target_ahead",
+            "unedited target must not be flagged target_ahead"
+        );
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    /// NB-4 (defensive branch): the guard only engages when BOTH `synced_at`
+    /// and `source_hash` are present (a usable baseline). A row with a partial
+    /// baseline — here `synced_at = Some`, `source_hash = None` (e.g. written
+    /// before the hash column existed) — must fall straight through to a normal
+    /// deploy, even if the on-disk target looks edited. No protection, no
+    /// snapshot, no flag.
+    #[test]
+    fn partial_baseline_skips_guard_and_deploys() {
+        let _lock = central_repo::test_base_dir_lock();
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("repo");
+        central_repo::set_test_base_dir_override(Some(base.clone()));
+        fs::create_dir_all(central_repo::skills_dir()).unwrap();
+        let store = SkillStore::new(&base.join("test.db")).unwrap();
+
+        let source = central_repo::skills_dir().join("skill-partial");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "central v2").unwrap();
+
+        let target = tmp.path().join("agent-skills").join("skill-partial");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("SKILL.md"), "USER EDIT would-be-protected").unwrap();
+
+        store
+            .insert_skill(&guard_skill("skill-partial", &source, "central-h2"))
+            .unwrap();
+        store
+            .insert_target(&SkillTargetRecord {
+                id: "tp".to_string(),
+                skill_id: "skill-partial".to_string(),
+                tool: "claude-code".to_string(),
+                target_path: target.to_string_lossy().to_string(),
+                mode: "copy".to_string(),
+                status: "ok".to_string(),
+                synced_at: Some(1),
+                last_error: None,
+                source_hash: None, // partial baseline: no hash to compare against
+            })
+            .unwrap();
+
+        let desired = vec![ScenarioSyncTarget {
+            skill_id: "skill-partial".to_string(),
+            skill_name: "skill-partial".to_string(),
+            tool: "claude-code".to_string(),
+            source: source.clone(),
+            target: target.clone(),
+            mode: sync_engine::SyncMode::Copy,
+            source_hash: Some("central-h2".to_string()),
+        }];
+
+        sync_desired_targets(&store, &desired).unwrap();
+
+        // Guard skipped (no baseline) → ordinary overwrite.
+        assert_eq!(
+            fs::read_to_string(target.join("SKILL.md")).unwrap(),
+            "central v2",
+            "partial-baseline target must be overwritten, guard must not engage"
+        );
+        assert_eq!(
+            count_backups(&base, "skill-partial"),
+            0,
+            "guard skipped → no snapshot"
+        );
+        let rec = store
+            .get_targets_for_skill("skill-partial")
+            .unwrap()
+            .into_iter()
+            .find(|t| t.tool == "claude-code")
+            .unwrap();
+        assert_ne!(rec.status, "target_ahead", "guard skipped → never flagged");
+
+        central_repo::set_test_base_dir_override(None);
+    }
+}
+
+#[cfg(test)]
+mod deploy_guard_decision_tests {
+    use super::{deploy_guard_decision, DeployGuardDecision, SPOKE_MTIME_THRESHOLD_MS};
+
+    // Hot-path contract (#248): a target whose newest content file predates
+    // our last sync cannot have been edited since we wrote it, so the decision
+    // must be Deploy *without* ever invoking the (expensive) hash closure.
+    #[test]
+    fn untouched_target_deploys_without_hashing() {
+        let mut hashed = false;
+        let decision = deploy_guard_decision(Some(1_000), 1_000, "baseline", "ok", || {
+            hashed = true;
+            Some("whatever".to_string())
+        });
+        assert_eq!(decision, DeployGuardDecision::Deploy);
+        assert!(!hashed, "hot path must not hash an untouched target");
+    }
+
+    #[test]
+    fn missing_mtime_deploys_without_hashing() {
+        let mut hashed = false;
+        let decision = deploy_guard_decision(None, 1_000, "baseline", "ok", || {
+            hashed = true;
+            Some("x".to_string())
+        });
+        assert_eq!(decision, DeployGuardDecision::Deploy);
+        assert!(!hashed, "no mtime → treat as untouched, do not hash");
+    }
+
+    #[test]
+    fn mtime_within_threshold_is_still_untouched() {
+        let mut hashed = false;
+        let decision = deploy_guard_decision(
+            Some(1_000 + SPOKE_MTIME_THRESHOLD_MS),
+            1_000,
+            "baseline",
+            "ok",
+            || {
+                hashed = true;
+                Some("x".to_string())
+            },
+        );
+        assert_eq!(decision, DeployGuardDecision::Deploy);
+        assert!(
+            !hashed,
+            "mtime within THRESHOLD of synced_at counts as untouched"
+        );
+    }
+
+    #[test]
+    fn touched_but_content_matches_baseline_deploys() {
+        // mtime bumped but content identical to what we deployed → not a real
+        // edit, keep the original overwrite behavior (no false protection).
+        let decision = deploy_guard_decision(Some(10_000), 1_000, "baseline", "ok", || {
+            Some("baseline".to_string())
+        });
+        assert_eq!(decision, DeployGuardDecision::Deploy);
+    }
+
+    #[test]
+    fn touched_and_edited_first_time_preserves_and_flags() {
+        let decision = deploy_guard_decision(Some(10_000), 1_000, "baseline", "ok", || {
+            Some("user-edit".to_string())
+        });
+        assert_eq!(decision, DeployGuardDecision::PreserveAndFlag);
+    }
+
+    #[test]
+    fn touched_and_edited_when_already_flagged_skips_backup() {
+        // Second run over an already-protected target: still preserve, but do
+        // not snapshot again (avoid flooding backups/ on every preset apply).
+        let decision =
+            deploy_guard_decision(Some(10_000), 1_000, "baseline", "target_ahead", || {
+                Some("user-edit".to_string())
+            });
+        assert_eq!(decision, DeployGuardDecision::PreserveNoBackup);
+    }
+
+    #[test]
+    fn touched_but_unhashable_target_falls_back_to_deploy() {
+        // If we can't hash the target (removed/unreadable between the mtime
+        // read and the hash), fall back to the original overwrite behavior
+        // rather than protecting a target we can't reason about.
+        let decision =
+            deploy_guard_decision(Some(10_000), 1_000, "baseline", "ok", || None);
+        assert_eq!(decision, DeployGuardDecision::Deploy);
     }
 }
 

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -310,13 +310,12 @@ pub fn sync_desired_targets(
                                     &desired.skill_name,
                                 );
                                 let central_root = central_repo::base_dir();
-                                // In-place snapshot (Copy) — the spoke stays put.
+                                // In-place snapshot — the spoke stays put.
                                 match central_repo::backup_directory(
                                     &central_root,
                                     &desired.target,
                                     &skill_dir_name,
                                     "spoke-ahead",
-                                    central_repo::BackupKind::Copy,
                                 ) {
                                     Ok(dest) => log::info!(
                                         "sync_desired_targets: preserved user-edited target for skill {} ({}) / {}; snapshot at {}",

--- a/src-tauri/src/core/skill_store.rs
+++ b/src-tauri/src/core/skill_store.rs
@@ -464,6 +464,25 @@ impl SkillStore {
         Ok(())
     }
 
+    /// Update only the observability fields of an existing target row without
+    /// touching its path/mode/hash/synced_at. Used by the deploy guard to flag
+    /// a target as `target_ahead` (user edited the spoke) so later automatic
+    /// deploys preserve it and don't re-snapshot. No-op if the row is absent.
+    pub fn update_target_status(
+        &self,
+        skill_id: &str,
+        tool: &str,
+        status: &str,
+        last_error: Option<&str>,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE skill_targets SET status = ?1, last_error = ?2 WHERE skill_id = ?3 AND tool = ?4",
+            params![status, last_error, skill_id, tool],
+        )?;
+        Ok(())
+    }
+
     pub fn get_targets_for_skill(&self, skill_id: &str) -> Result<Vec<SkillTargetRecord>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(


### PR DESCRIPTION
## Summary

Related to #256 (user files created inside a skill folder disappear after an update).
Across several sync paths the app could overwrite a **newer** copy with an **older**
one and silently drop the user's edits. This PR closes that data-loss window with a
backup-before-overwrite primitive, a "newest wins" reconcile decision, and guards on
every overwrite path.

## Root causes (reproduced)

1. **Wrong clock for the center.** `classify_sync_status` judged the center copy's
   freshness from a stored timestamp, not the file's real mtime, so an edited project
   copy was reported as "center is newer" and got overwritten.
2. **Overwrites had no safety net.** reimport / preset-apply / explicit "pull from
   center" all replaced the target directory outright, with no snapshot of what they
   destroyed.
3. **No conflict model.** With no baseline there was no way to tell "who changed";
   the newest side never won.

## Changes

- **Real-mtime classification** (`classify_sync_status`, `content_hash`): compare the
  center by the file's actual mtime; fixes "project is newer yet the tool says center".
  The two filesystem probes (a live hash + the newest content mtime) are memoized per
  `get_projects` call by a request-scoped `CenterStatCache`, so a skill referenced by
  many project/agent variants walks its center directory once, not once per reference.
  The cache is rebuilt from disk each call, so it never goes stale.
- **Backup-before-overwrite primitive** (`central_repo`): Move/Copy with cross-volume
  fallback, anti-overwrite and anti-traversal checks.
- **Three-state reconcile decision** (`core/reconcile.rs`): a pure function — baseline
  decides who changed; only a two-sided change is a conflict, resolved newest-wins.
- **reimport guard**: keep a newer center instead of reverting to an older source;
  rebuild when the center copy is missing.
- **preset-apply guard**: preserve user-edited deploy targets — snapshot, skip, and
  flag the spoke. The flag (`target_ahead`) is an internal marker the guard reads back
  on the next apply to decide whether to re-protect; it is mapped to a normal `ok` in
  the frontend DTO so it never surfaces as an unknown status. The hot path does not hash.
- **explicit-pull guard**: snapshot a diverged local copy before overwriting it.

## Test plan

- [x] New unit tests: reconcile decision, backup primitive, explicit-pull predicate,
      real-mtime classification, `CenterStatCache` walks a shared center once,
      `dto_target_status` hides the internal `target_ahead` marker
- [x] `cargo test --lib`: 445 passed (2 failures are Windows symlink-privilege env
      cases that pass on CI runners; unrelated to this change)
- [x] GUI end-to-end: import -> source-newer update (with backup) -> reimport refuses to
      revert a newer center -> project-newer pushes to center -> explicit pull snapshots first

## Notes

Deliberately out of scope: turning multi-agent variants into a single shared file
(a larger design), and repo-lock contention on "check all updates" (a separate PR).
