### PR TITLE
perf: batch preset skill toggles

### DIFF
--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -43,9 +43,7 @@ pub struct PresetDto {
 static GET_PRESETS_FIRST_CALL: AtomicBool = AtomicBool::new(true);
 
 #[tauri::command]
-pub async fn get_presets(
-    store: State<'_, Arc<SkillStore>>,
-) -> Result<Vec<PresetDto>, AppError> {
+pub async fn get_presets(store: State<'_, Arc<SkillStore>>) -> Result<Vec<PresetDto>, AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
         let start = Instant::now();
@@ -293,6 +291,37 @@ pub async fn add_skill_to_preset(
     result
 }
 
+/// Batch add/remove skills from a preset in a single metadata write + single tray refresh.
+/// Eliminates the O(N) sequential IPC + O(N) metadata rewrite overhead of calling
+/// `add_skill_to_preset` / `remove_skill_from_preset` N times individually.
+#[tauri::command]
+pub async fn batch_toggle_preset_skills(
+    app: tauri::AppHandle,
+    preset_id: String,
+    skill_ids: Vec<String>,
+    enable: bool,
+    store: State<'_, Arc<SkillStore>>,
+) -> Result<usize, AppError> {
+    let store = store.inner().clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        sync_metadata::with_repo_lock("batch toggle scenario skills", || {
+            let count = if enable {
+                store.batch_add_skills_to_scenario(&preset_id, &skill_ids)?
+            } else {
+                store.batch_remove_skills_from_scenario(&preset_id, &skill_ids)?
+            };
+            sync_metadata::write_all_from_db_unlocked(&store)?;
+            Ok(count)
+        })
+        .map_err(AppError::db)
+    })
+    .await?;
+    if result.is_ok() {
+        refresh_tray_menu_best_effort(&app);
+    }
+    result
+}
+
 #[tauri::command]
 pub async fn remove_skill_from_preset(
     app: tauri::AppHandle,
@@ -448,10 +477,10 @@ mod tests {
     };
     use crate::core::skill_store::SkillRecord;
     use crate::core::tool_adapters::{self, CustomToolDef};
-    use std::path::PathBuf;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     fn sample_skill(id: &str, name: &str, central_path: &std::path::Path) -> SkillRecord {

--- a/src-tauri/src/core/skill_store.rs
+++ b/src-tauri/src/core/skill_store.rs
@@ -846,6 +846,45 @@ impl SkillStore {
         Ok(())
     }
 
+    pub fn batch_add_skills_to_scenario(
+        &self,
+        scenario_id: &str,
+        skill_ids: &[String],
+    ) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        let tx = conn.unchecked_transaction()?;
+        let mut count = 0usize;
+        for skill_id in skill_ids {
+            let rows = tx.execute(
+                "INSERT OR IGNORE INTO scenario_skills (scenario_id, skill_id, added_at) VALUES (?1, ?2, ?3)",
+                params![scenario_id, skill_id, now],
+            )?;
+            count += rows;
+        }
+        tx.commit()?;
+        Ok(count)
+    }
+
+    pub fn batch_remove_skills_from_scenario(
+        &self,
+        scenario_id: &str,
+        skill_ids: &[String],
+    ) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let tx = conn.unchecked_transaction()?;
+        let mut count = 0usize;
+        for skill_id in skill_ids {
+            let rows = tx.execute(
+                "DELETE FROM scenario_skills WHERE scenario_id = ?1 AND skill_id = ?2",
+                params![scenario_id, skill_id],
+            )?;
+            count += rows;
+        }
+        tx.commit()?;
+        Ok(count)
+    }
+
     pub fn reorder_scenario_skills(&self, scenario_id: &str, skill_ids: &[String]) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let tx = conn.unchecked_transaction()?;
@@ -1472,22 +1511,23 @@ mod scenario_membership_tests {
         let tmp = tempdir().unwrap();
         let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
 
-        store.insert_scenario(&ScenarioRecord {
-            id: "s1".to_string(),
-            name: "S1".to_string(),
-            description: None,
-            icon: None,
-            sort_order: 0,
-            created_at: 1,
-            updated_at: 1,
-        })
-        .unwrap();
+        store
+            .insert_scenario(&ScenarioRecord {
+                id: "s1".to_string(),
+                name: "S1".to_string(),
+                description: None,
+                icon: None,
+                sort_order: 0,
+                created_at: 1,
+                updated_at: 1,
+            })
+            .unwrap();
         store.upsert_skill(&sample_skill("k1")).unwrap();
 
         let memberships = vec![
-            membership("s1", "k1"),       // valid
-            membership("s1", "ghost"),    // skill missing
-            membership("ghost-s", "k1"),  // scenario missing
+            membership("s1", "k1"),      // valid
+            membership("s1", "ghost"),   // skill missing
+            membership("ghost-s", "k1"), // scenario missing
         ];
 
         // Must not panic with a FOREIGN KEY constraint failure.
@@ -1497,7 +1537,9 @@ mod scenario_membership_tests {
 
         assert_eq!(store.get_skill_ids_for_scenario("s1").unwrap(), vec!["k1"]);
         assert_eq!(
-            store.get_enabled_tools_for_scenario_skill("s1", "k1").unwrap(),
+            store
+                .get_enabled_tools_for_scenario_skill("s1", "k1")
+                .unwrap(),
             vec!["ToolA"]
         );
         assert!(store

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -206,8 +206,16 @@ fn collect_tray_menu_data(store: &core::skill_store::SkillStore) -> TrayMenuData
 }
 
 fn format_status_line(data: &TrayMenuData) -> String {
-    let skill_label = if data.total_skills == 1 { "skill" } else { "skills" };
-    let agent_label = if data.coding_agent_count == 1 { "agent" } else { "agents" };
+    let skill_label = if data.total_skills == 1 {
+        "skill"
+    } else {
+        "skills"
+    };
+    let agent_label = if data.coding_agent_count == 1 {
+        "agent"
+    } else {
+        "agents"
+    };
     format!(
         "{} {} · {} {} connected",
         data.total_skills, skill_label, data.coding_agent_count, agent_label
@@ -241,7 +249,11 @@ fn preset_menu_item_id(preset: &TrayPresetEntry) -> (String, &'static str) {
 }
 
 fn preset_menu_label(preset: &TrayPresetEntry) -> String {
-    let unit = if preset.skill_count == 1 { "skill" } else { "skills" };
+    let unit = if preset.skill_count == 1 {
+        "skill"
+    } else {
+        "skills"
+    };
     match preset.status() {
         TrayPresetStatus::Active => format!("✓ {} ({} {unit})", preset.name, preset.skill_count),
         TrayPresetStatus::Partial => format!(
@@ -561,7 +573,9 @@ fn check_updates_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
                 {
                     Ok(lock) => lock,
                     Err(err) => {
-                        log::warn!("Tray update check: failed to acquire repo lock for {skill_id}: {err}");
+                        log::warn!(
+                            "Tray update check: failed to acquire repo lock for {skill_id}: {err}"
+                        );
                         continue;
                     }
                 };
@@ -624,7 +638,8 @@ fn open_skills_folder_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
 
         let status = cmd.arg(&repo_path).status();
         match status {
-            Ok(_status) => {
+            Ok(_status) =>
+            {
                 #[cfg(not(target_os = "windows"))]
                 if !_status.success() {
                     log::warn!(
@@ -1069,6 +1084,7 @@ pub fn run() {
             commands::presets::apply_preset_to_coding_agents,
             commands::presets::add_skill_to_preset,
             commands::presets::remove_skill_from_preset,
+            commands::presets::batch_toggle_preset_skills,
             commands::presets::reorder_presets,
             commands::projects::reorder_projects,
             commands::presets::get_preset_skill_order,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -713,6 +713,12 @@ export const addSkillToPreset = (skillId: string, presetId: string) =>
 export const removeSkillFromPreset = (skillId: string, presetId: string) =>
   invoke<void>("remove_skill_from_preset", { skillId, presetId });
 
+export const batchTogglePresetSkills = (
+  presetId: string,
+  skillIds: string[],
+  enable: boolean
+) => invoke<number>("batch_toggle_preset_skills", { presetId, skillIds, enable });
+
 export const reorderPresets = (ids: string[]) =>
   invoke<void>("reorder_presets", { ids });
 

--- a/src/views/MySkills.tsx
+++ b/src/views/MySkills.tsx
@@ -563,32 +563,25 @@ export function MySkills() {
     if (!viewedPreset) return;
     const selectedSkillsList = skills.filter((s) => selectedIds.has(s.id));
     const enabling = anyDisabled;
-    let count = 0;
-    let failed = 0;
-    for (const skill of selectedSkillsList) {
-      try {
+    const toggledSkillIds = selectedSkillsList
+      .filter((skill) => {
         const enabledInPreset = skill.preset_ids.includes(viewedPreset.id);
-        if (enabling && !enabledInPreset) {
-          await api.addSkillToPreset(skill.id, viewedPreset.id);
-          count++;
-        } else if (!enabling && enabledInPreset) {
-          await api.removeSkillFromPreset(skill.id, viewedPreset.id);
-          count++;
-        }
-      } catch {
-        failed++;
-        // continue with remaining
-      }
+        return enabling ? !enabledInPreset : enabledInPreset;
+      })
+      .map((skill) => skill.id);
+    if (toggledSkillIds.length === 0) {
+      toast.info(enabling ? t("presetActions.nothingToAdd") : t("presetActions.nothingToRemove"));
+      return;
     }
-    if (count > 0) {
+    try {
+      const count = await api.batchTogglePresetSkills(viewedPreset.id, toggledSkillIds, enabling);
       toast.success(enabling
         ? t("mySkills.batchEnabled", { count })
         : t("mySkills.batchDisabled", { count }));
+      await Promise.all([refreshManagedSkills(), refreshPresets()]);
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, t("common.error")));
     }
-    if (failed > 0) {
-      toast.error(t("mySkills.batchToggleFailed", { count: failed }));
-    }
-    await Promise.all([refreshManagedSkills(), refreshPresets()]);
   };
 
   const handleBatchRefresh = async () => {


### PR DESCRIPTION
## Summary
- Add a batched preset membership toggle command so multi-select enable/disable uses one IPC call.
- Apply all membership changes in a single database transaction.
- Rewrite metadata once and refresh the tray once per batch instead of once per skill.
- Keep behavior membership-only, matching the existing single-skill add/remove commands.

## Why
The current multi-select preset action loops over selected skills and performs N sequential IPC calls. This change reduces that to one backend call and one metadata write while preserving semantics.

This addresses the batch operation portion of #295.

## Test plan
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- Manually enable and disable multiple selected skills in a preset and verify counts and membership refresh correctly.

## Context
Split from #289 per maintainer feedback. The sync-time same-name dedup changes are intentionally not included.