### PR TITLE
feat: add ZCode tool adapter

### DIFF
--- a/public/agent-icons/zcode.svg
+++ b/public/agent-icons/zcode.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2">
+  <rect x="32" y="32" width="448" height="448" rx="96" ry="96" fill="#000000"/>
+  <path d="M360 160 L360 196 L204 352 L360 352 L360 392 L152 392 L152 356 L308 200 L152 200 L152 160 L360 160 Z" fill="#FFFFFF"/>
+</svg>

--- a/src-tauri/src/core/tool_adapters.rs
+++ b/src-tauri/src/core/tool_adapters.rs
@@ -211,6 +211,20 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             project_relative_skills_dir: None,
         },
         ToolAdapter {
+            // ZCode reads user-level skills from `~/.zcode/skills/` and
+            // project-level skills from `<repo>/.zcode/skills/`.
+            key: "zcode".into(),
+            display_name: "ZCode".into(),
+            relative_skills_dir: ".zcode/skills".into(),
+            relative_detect_dir: ".zcode".into(),
+            additional_scan_dirs: vec![],
+            override_skills_dir: None,
+            category: ToolCategory::Coding,
+            is_custom: false,
+            recursive_scan: false,
+            project_relative_skills_dir: None,
+        },
+        ToolAdapter {
             // Grok reads user-level skills from `~/.grok/skills/` and
             // project-level skills from `<repo>/.grok/skills/`.
             // See https://docs.x.ai/build/features/skills-plugins-marketplaces

--- a/src/lib/agentIcons.ts
+++ b/src/lib/agentIcons.ts
@@ -45,6 +45,7 @@ const AGENT_ICON_FILES: Record<string, string> = {
   trae_cn: "trae_cn.svg",
   warp: "warp.svg",
   windsurf: "windsurf.svg",
+  zcode: "zcode.svg",
   zencoder: "zencoder.png",
 };
 


### PR DESCRIPTION
## Summary

Adds built-in support for **ZCode** (an AI coding tool / IDE). ZCode uses the standard `~/.<tool>/skills` convention, so this is a minimal adapter addition with no special path handling.

## Changes

- **`src-tauri/src/core/tool_adapters.rs`** — register a `zcode` `ToolAdapter` reading skills from `~/.zcode/skills` (global) and `<repo>/.zcode/skills` (project-level).
- **`src/lib/agentIcons.ts`** — register `zcode` → `zcode.svg` icon mapping.
- **`public/agent-icons/zcode.svg`** — ZCode icon (black rounded square with a white Z), redrawn as a clean vector based on the logo shipped in the official `ZCode.app` bundle.

## Verification

- ✅ `cargo test` — all existing adapter tests pass
- ✅ `npm run lint` — no errors
- ✅ Manual: app launches, recognizes `~/.zcode` as installed, and backfills existing stranded skills under the ZCode tool on startup.

## Notes

ZCode follows the same `~/.<tool>/skills` pattern as Cursor / Claude Code / Codex, so no `.config` prefix, `additional_scan_dirs`, `recursive_scan`, or `project_relative_skills_dir` overrides are needed. Scanning, sync, project workspaces, the CLI, and the file watcher all pick it up automatically via `all_tool_adapters()`.