### PR TITLE
fix(presets): wrap pills and queue workspace applies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,17 +4,61 @@ on:
   push:
     branches: [main]
     paths:
+      - 'src/**'
       - 'src-tauri/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vitest.config.ts'
+      - 'vite.config.ts'
+      - 'tsconfig.json'
+      - 'tsconfig.app.json'
+      - 'tsconfig.node.json'
+      - 'eslint.config.js'
       - '.github/workflows/test.yml'
   pull_request:
     paths:
+      - 'src/**'
       - 'src-tauri/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vitest.config.ts'
+      - 'vite.config.ts'
+      - 'tsconfig.json'
+      - 'tsconfig.app.json'
+      - 'tsconfig.node.json'
+      - 'eslint.config.js'
       - '.github/workflows/test.yml'
 
 permissions:
   contents: read
 
 jobs:
+  frontend-checks:
+    runs-on: ubuntu-latest
+    name: Frontend checks
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
   rust-tests:
     strategy:
       fail-fast: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skills-manager",
-  "version": "1.22.1",
+  "version": "1.28.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skills-manager",
-      "version": "1.22.1",
+      "version": "1.28.3",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -34,6 +34,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -43,12 +45,21 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^29.1.1",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.19",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -62,6 +73,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -352,6 +414,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -1006,6 +1221,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@hello-pangea/dnd": {
       "version": "18.0.1",
       "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
@@ -1520,6 +1753,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -1780,6 +2020,93 @@
         "@tauri-apps/api": "^2.10.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1825,6 +2152,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1833,6 +2171,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2243,6 +2588,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2281,6 +2739,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2347,6 +2816,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -2412,6 +2901,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2534,6 +3033,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2731,6 +3240,27 @@
         "tiny-invariant": "^1.0.6"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2750,6 +3280,20 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2766,6 +3310,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -2823,12 +3374,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -3079,6 +3658,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3087,6 +3676,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -3393,6 +3992,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -3478,6 +4090,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inline-style-parser": {
@@ -3604,6 +4226,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3639,6 +4268,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3782,6 +4462,27 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-table": {
@@ -4075,6 +4776,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4676,6 +5384,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -4770,6 +5488,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4858,6 +5590,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4882,6 +5627,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5098,6 +5850,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -5192,6 +5974,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -5327,6 +6117,20 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -5397,6 +6201,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5510,6 +6324,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -5555,6 +6382,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -5585,6 +6419,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -5597,6 +6445,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5679,6 +6540,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
@@ -5756,6 +6624,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5773,6 +6658,36 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5784,6 +6699,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -5881,6 +6822,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -6137,6 +7088,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -6144,6 +7185,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -6162,6 +7251,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6171,6 +7277,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview",
     "release:prepare": "node scripts/prepare-release.mjs",
     "tauri": "tauri",
@@ -43,6 +44,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -52,10 +55,12 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.19",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.1.10"
   }
 }

--- a/src-tauri/src/commands/agent_workspace.rs
+++ b/src-tauri/src/commands/agent_workspace.rs
@@ -233,6 +233,9 @@ fn import_agent_local_skill_to_center(
     agent: &str,
     skill_relative_path: &str,
 ) -> Result<(), AppError> {
+    // 上传会同时改写中央记录、Agent 目录和 skill_targets，必须与 Preset
+    // 批量应用串行，避免失败恢复覆盖刚完成的卡片操作。
+    let _guard = scenario_service::lock_preset_apply();
     let adapter = adapter_for_agent(store, agent)?;
     let skill = find_agent_skill(&adapter, skill_relative_path)?;
 
@@ -422,6 +425,9 @@ fn stranded_candidate_signature(
 }
 
 pub fn backfill_stranded_agent_targets(store: &SkillStore) -> usize {
+    // 启动修复最终也会写入 Agent 目录和 skill_targets；即使它在后台运行，
+    // 也必须与用户触发的工作区写操作共用同一把锁。
+    let _guard = scenario_service::lock_preset_apply();
     let all_managed = store.get_all_skills().unwrap_or_default();
     let all_targets = store.get_all_targets().unwrap_or_default();
 
@@ -587,6 +593,7 @@ fn update_agent_local_skill_from_center(
     agent: &str,
     skill_relative_path: &str,
 ) -> Result<(), AppError> {
+    let _guard = scenario_service::lock_preset_apply();
     let adapter = adapter_for_agent(store, agent)?;
     let skill = find_agent_skill(&adapter, skill_relative_path)?;
     let all_managed = store.get_all_skills().unwrap_or_default();
@@ -629,6 +636,7 @@ fn delete_agent_local_skill(
     agent: &str,
     skill_relative_path: &str,
 ) -> Result<(), AppError> {
+    let _guard = scenario_service::lock_preset_apply();
     let adapter = adapter_for_agent(store, agent)?;
     let skill = find_agent_skill(&adapter, skill_relative_path)?;
 

--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -113,6 +113,9 @@ pub async fn create_preset(
 ) -> Result<PresetDto, AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
+        // 创建新 Preset 会撤销旧活动 Preset 的磁盘目标；必须与 UI、托盘
+        // 及其他 Agent 配置命令串行，避免只完成一半的切换。
+        let _guard = scenario_service::lock_preset_apply();
         let now = chrono::Utc::now().timestamp_millis();
         let id = uuid::Uuid::new_v4().to_string();
         let previous_active_id = store.get_active_scenario_id().map_err(AppError::db)?;
@@ -188,6 +191,9 @@ pub async fn delete_preset(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
+        // 删除活动 Preset 同时包含撤销旧目标和应用后继 Preset，两步必须
+        // 作为一个受锁保护的工作区变更完成。
+        let _guard = scenario_service::lock_preset_apply();
         let was_active = store
             .get_active_scenario_id()
             .map_err(AppError::db)?
@@ -256,6 +262,9 @@ async fn apply_preset_to_default_impl(
     store: Arc<SkillStore>,
 ) -> Result<(), AppError> {
     let result = tauri::async_runtime::spawn_blocking(move || {
+        // 旧的全局应用入口同样会改写 `skill_targets` 与磁盘目录，必须与
+        // PresetBar 和托盘共用互斥锁，不能留下可交错的兼容路径。
+        let _guard = scenario_service::lock_preset_apply();
         scenario_service::apply_scenario_to_default(&store, &id)
     })
     .await?;
@@ -416,6 +425,9 @@ pub async fn apply_preset_to_coding_agents(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
+        // 这个兼容命令虽然已不由新 PresetBar 调用，仍要与托盘和精确
+        // Agent 批处理串行，避免旧前端或 CLI 触发并发写入。
+        let _guard = scenario_service::lock_preset_apply();
         scenario_service::ensure_scenario_exists(&store, &preset_id)?;
         let skill_ids = store
             .get_skill_ids_for_scenario(&preset_id)
@@ -440,16 +452,59 @@ pub async fn apply_preset_to_coding_agents(
     result
 }
 
+/// 将一个 Preset 精确应用到调用方指定的 Agent，不扩展到其他 Coding Agent。
+/// 工具校验、去重和逐项容错由 scenario_service 的报告型批处理统一完成。
+#[tauri::command]
+pub async fn apply_preset_to_tools(
+    app: tauri::AppHandle,
+    preset_id: String,
+    tool_keys: Vec<String>,
+    mode: PresetApplyMode,
+    store: State<'_, Arc<SkillStore>>,
+) -> Result<scenario_service::BatchApplyReport, AppError> {
+    let store = store.inner().clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        // UI 的 FIFO 只覆盖单个 WebView；此锁还需与托盘共用，避免两个入口
+        // 同时改写同一组目录和 `skill_targets`。
+        let _guard = scenario_service::lock_preset_apply();
+        apply_preset_to_tools_impl(&store, &preset_id, &tool_keys, mode)
+    })
+    .await?;
+    if result.is_ok() {
+        refresh_tray_menu_best_effort(&app);
+    }
+    result
+}
+
+fn apply_preset_to_tools_impl(
+    store: &SkillStore,
+    preset_id: &str,
+    tool_keys: &[String],
+    mode: PresetApplyMode,
+) -> Result<scenario_service::BatchApplyReport, AppError> {
+    scenario_service::ensure_scenario_exists(store, preset_id)?;
+    let skill_ids = store
+        .get_skill_ids_for_scenario(preset_id)
+        .map_err(AppError::db)?;
+    scenario_service::apply_skills_to_tools_with_report(
+        store,
+        &skill_ids,
+        tool_keys,
+        mode.into(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use crate::core::scenario_service::{
         collect_scenario_sync_targets, sync_desired_targets, unsync_obsolete_scenario_targets,
     };
     use crate::core::skill_store::SkillRecord;
     use crate::core::tool_adapters::{self, CustomToolDef};
-    use std::path::PathBuf;
     use std::fs;
+    use std::path::PathBuf;
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
     use tempfile::tempdir;
@@ -467,7 +522,7 @@ mod tests {
             source_revision: None,
             remote_revision: None,
             central_path: central_path.to_string_lossy().to_string(),
-            content_hash: None,
+            content_hash: Some(format!("hash-{id}")),
             enabled: true,
             created_at: 1,
             updated_at: 1,
@@ -505,6 +560,38 @@ mod tests {
             project_relative_skills_dir: None,
             category: Default::default(),
         }];
+        store
+            .set_setting(
+                "custom_tools",
+                &serde_json::to_string(&custom_tools).unwrap(),
+            )
+            .unwrap();
+        let disabled_builtin_tools: Vec<String> = tool_adapters::default_tool_adapters()
+            .into_iter()
+            .map(|adapter| adapter.key)
+            .collect();
+        store
+            .set_setting(
+                "disabled_tools",
+                &serde_json::to_string(&disabled_builtin_tools).unwrap(),
+            )
+            .unwrap();
+    }
+
+    fn configure_custom_tools(
+        store: &SkillStore,
+        tools: &[(&str, &std::path::Path)],
+    ) {
+        let custom_tools: Vec<CustomToolDef> = tools
+            .iter()
+            .map(|(key, target_base)| CustomToolDef {
+                key: (*key).to_string(),
+                display_name: format!("Test {key}"),
+                skills_dir: target_base.to_string_lossy().to_string(),
+                project_relative_skills_dir: None,
+                category: Default::default(),
+            })
+            .collect();
         store
             .set_setting(
                 "custom_tools",
@@ -639,5 +726,525 @@ mod tests {
         assert!(targets.iter().any(|target| {
             target.skill_id == "second" && target.target_path.ends_with("skill123-2")
         }));
+    }
+
+    #[test]
+    fn exact_preset_apply_deduplicates_tools_and_reports_skips() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let first_target = tmp.path().join("agent-one");
+        let second_target = tmp.path().join("agent-two");
+        fs::create_dir_all(&source_base).unwrap();
+        configure_custom_tools(
+            &store,
+            &[
+                ("agent_one", first_target.as_path()),
+                ("agent_two", second_target.as_path()),
+            ],
+        );
+        store.set_setting("sync_mode", "copy").unwrap();
+
+        store
+            .insert_scenario(&sample_scenario("preset", "Preset"))
+            .unwrap();
+        store
+            .insert_scenario(&sample_scenario("active", "Active"))
+            .unwrap();
+        store.set_active_scenario("active").unwrap();
+
+        for name in ["alpha", "beta"] {
+            let source = write_skill_dir(&source_base, name);
+            store
+                .insert_skill(&sample_skill(name, name, &source))
+                .unwrap();
+            store.add_skill_to_scenario("preset", name).unwrap();
+        }
+
+        let add = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &[
+                "agent_one".to_string(),
+                "agent_one".to_string(),
+            ],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        assert_eq!(add.applied, 2);
+        assert_eq!(add.skipped, 0);
+        assert!(add.failures.is_empty());
+        assert!(first_target.join("alpha/SKILL.md").exists());
+        assert!(first_target.join("beta/SKILL.md").exists());
+        assert!(!second_target.exists());
+        assert_eq!(
+            store.get_active_scenario_id().unwrap().as_deref(),
+            Some("active")
+        );
+        assert!(store
+            .get_all_targets()
+            .unwrap()
+            .iter()
+            .all(|target| target.tool == "agent_one"));
+
+        let duplicate_add = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        assert_eq!(duplicate_add.applied, 0);
+        assert_eq!(duplicate_add.skipped, 2);
+        assert!(duplicate_add.failures.is_empty());
+
+        let remove = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Remove,
+        )
+        .unwrap();
+        assert_eq!(remove.applied, 2);
+        assert_eq!(remove.skipped, 0);
+        assert!(remove.failures.is_empty());
+
+        let duplicate_remove = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Remove,
+        )
+        .unwrap();
+        assert_eq!(duplicate_remove.applied, 0);
+        assert_eq!(duplicate_remove.skipped, 2);
+        assert!(duplicate_remove.failures.is_empty());
+    }
+
+    #[test]
+    fn exact_preset_apply_rebuilds_missing_recorded_target() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let target_base = tmp.path().join("agent-one");
+        fs::create_dir_all(&source_base).unwrap();
+        configure_custom_tools(&store, &[("agent_one", target_base.as_path())]);
+        store.set_setting("sync_mode", "copy").unwrap();
+        store
+            .insert_scenario(&sample_scenario("preset", "Preset"))
+            .unwrap();
+        let source = write_skill_dir(&source_base, "alpha");
+        store
+            .insert_skill(&sample_skill("alpha", "alpha", &source))
+            .unwrap();
+        store.add_skill_to_scenario("preset", "alpha").unwrap();
+
+        let first = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        assert_eq!(first.applied, 1);
+        fs::remove_dir_all(target_base.join("alpha")).unwrap();
+
+        let repaired = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        assert_eq!(repaired.applied, 1);
+        assert_eq!(repaired.skipped, 0);
+        assert!(repaired.failures.is_empty());
+        assert!(target_base.join("alpha/SKILL.md").exists());
+        assert_eq!(store.get_targets_for_skill("alpha").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn exact_preset_apply_moves_stale_record_to_current_agent_path() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let old_target = tmp.path().join("agent-old");
+        let new_target = tmp.path().join("agent-new");
+        fs::create_dir_all(&source_base).unwrap();
+        configure_custom_tools(&store, &[("agent_one", old_target.as_path())]);
+        store.set_setting("sync_mode", "copy").unwrap();
+        store
+            .insert_scenario(&sample_scenario("preset", "Preset"))
+            .unwrap();
+        let source = write_skill_dir(&source_base, "alpha");
+        store
+            .insert_skill(&sample_skill("alpha", "alpha", &source))
+            .unwrap();
+        store.add_skill_to_scenario("preset", "alpha").unwrap();
+
+        apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        configure_custom_tools(&store, &[("agent_one", new_target.as_path())]);
+
+        let moved = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        assert_eq!(moved.applied, 1);
+        assert_eq!(moved.skipped, 0);
+        assert!(moved.failures.is_empty());
+        assert!(!old_target.join("alpha").exists());
+        assert!(new_target.join("alpha/SKILL.md").exists());
+        let rows = store.get_targets_for_skill("alpha").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(PathBuf::from(&rows[0].target_path), new_target.join("alpha"));
+    }
+
+    #[test]
+    fn exact_preset_apply_refreshes_stale_copy_hash() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let target_base = tmp.path().join("agent-one");
+        fs::create_dir_all(&source_base).unwrap();
+        configure_custom_tools(&store, &[("agent_one", target_base.as_path())]);
+        store.set_setting("sync_mode", "copy").unwrap();
+        store
+            .insert_scenario(&sample_scenario("preset", "Preset"))
+            .unwrap();
+        let source = write_skill_dir(&source_base, "alpha");
+        fs::write(source.join("version.txt"), "v1").unwrap();
+        let mut skill = sample_skill("alpha", "alpha", &source);
+        skill.content_hash = Some("h1".to_string());
+        store.insert_skill(&skill).unwrap();
+        store.add_skill_to_scenario("preset", "alpha").unwrap();
+
+        apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        fs::write(source.join("version.txt"), "v2").unwrap();
+        skill.content_hash = Some("h2".to_string());
+        store.upsert_skill(&skill).unwrap();
+
+        let refreshed = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        assert_eq!(refreshed.applied, 1);
+        assert_eq!(refreshed.skipped, 0);
+        assert!(refreshed.failures.is_empty());
+        assert_eq!(
+            fs::read_to_string(target_base.join("alpha/version.txt")).unwrap(),
+            "v2"
+        );
+        let rows = store.get_targets_for_skill("alpha").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].source_hash.as_deref(), Some("h2"));
+    }
+
+    #[test]
+    fn exact_preset_apply_keeps_previous_copy_when_source_build_fails() {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let store = SkillStore::new(&db_path).unwrap();
+        let source_base = tmp.path().join("central");
+        let target_base = tmp.path().join("agent-one");
+        fs::create_dir_all(&source_base).unwrap();
+        configure_custom_tools(&store, &[("agent_one", target_base.as_path())]);
+        store.set_setting("sync_mode", "copy").unwrap();
+        store
+            .insert_scenario(&sample_scenario("preset", "Preset"))
+            .unwrap();
+        let source = write_skill_dir(&source_base, "alpha");
+        fs::write(source.join("version.txt"), "v1").unwrap();
+        let mut skill = sample_skill("alpha", "alpha", &source);
+        skill.content_hash = Some("h1".to_string());
+        store.insert_skill(&skill).unwrap();
+        store.add_skill_to_scenario("preset", "alpha").unwrap();
+        apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+
+        fs::remove_dir_all(&source).unwrap();
+        skill.content_hash = Some("h2".to_string());
+        store.upsert_skill(&skill).unwrap();
+        let failed = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+
+        assert_eq!(failed.applied, 0);
+        assert_eq!(failed.failures.len(), 1);
+        assert_eq!(
+            fs::read_to_string(target_base.join("alpha/version.txt")).unwrap(),
+            "v1"
+        );
+        let rows = store.get_targets_for_skill("alpha").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].source_hash.as_deref(), Some("h1"));
+    }
+
+    #[test]
+    fn exact_preset_apply_restores_previous_copy_when_database_commit_fails() {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let store = SkillStore::new(&db_path).unwrap();
+        let source_base = tmp.path().join("central");
+        let target_base = tmp.path().join("agent-one");
+        fs::create_dir_all(&source_base).unwrap();
+        configure_custom_tools(&store, &[("agent_one", target_base.as_path())]);
+        store.set_setting("sync_mode", "copy").unwrap();
+        store
+            .insert_scenario(&sample_scenario("preset", "Preset"))
+            .unwrap();
+        let source = write_skill_dir(&source_base, "alpha");
+        fs::write(source.join("version.txt"), "v1").unwrap();
+        let mut skill = sample_skill("alpha", "alpha", &source);
+        skill.content_hash = Some("h1".to_string());
+        store.insert_skill(&skill).unwrap();
+        store.add_skill_to_scenario("preset", "alpha").unwrap();
+        apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+
+        fs::write(source.join("version.txt"), "v2").unwrap();
+        skill.content_hash = Some("h2".to_string());
+        store.upsert_skill(&skill).unwrap();
+        let trigger = rusqlite::Connection::open(&db_path).unwrap();
+        trigger
+            .execute_batch(
+                "CREATE TRIGGER fail_target_upsert BEFORE INSERT ON skill_targets
+                 BEGIN SELECT RAISE(ABORT, 'forced target write failure'); END;",
+            )
+            .unwrap();
+
+        let failed = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        assert_eq!(failed.applied, 0);
+        assert_eq!(failed.failures.len(), 1);
+        assert_eq!(
+            fs::read_to_string(target_base.join("alpha/version.txt")).unwrap(),
+            "v1"
+        );
+        let rows = store.get_targets_for_skill("alpha").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].source_hash.as_deref(), Some("h1"));
+        assert!(!tmp.path().join(".skills-manager-staging").exists());
+    }
+
+    #[test]
+    fn exact_preset_remove_restores_target_when_database_commit_fails() {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let store = SkillStore::new(&db_path).unwrap();
+        let source_base = tmp.path().join("central");
+        let target_base = tmp.path().join("agent-one");
+        fs::create_dir_all(&source_base).unwrap();
+        configure_custom_tools(&store, &[("agent_one", target_base.as_path())]);
+        store.set_setting("sync_mode", "copy").unwrap();
+        store
+            .insert_scenario(&sample_scenario("preset", "Preset"))
+            .unwrap();
+        let source = write_skill_dir(&source_base, "alpha");
+        store
+            .insert_skill(&sample_skill("alpha", "alpha", &source))
+            .unwrap();
+        store.add_skill_to_scenario("preset", "alpha").unwrap();
+        apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        let trigger = rusqlite::Connection::open(&db_path).unwrap();
+        trigger
+            .execute_batch(
+                "CREATE TRIGGER fail_target_delete BEFORE DELETE ON skill_targets
+                 BEGIN SELECT RAISE(ABORT, 'forced target delete failure'); END;",
+            )
+            .unwrap();
+
+        let failed = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Remove,
+        )
+        .unwrap();
+        assert_eq!(failed.applied, 0);
+        assert_eq!(failed.failures.len(), 1);
+        assert!(target_base.join("alpha/SKILL.md").exists());
+        assert_eq!(store.get_targets_for_skill("alpha").unwrap().len(), 1);
+        assert!(!tmp.path().join(".skills-manager-staging").exists());
+    }
+
+    #[test]
+    fn exact_preset_apply_preserves_shared_physical_agent_directory() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let shared_target = tmp.path().join("shared-agent-skills");
+        fs::create_dir_all(&source_base).unwrap();
+        fs::create_dir_all(&shared_target).unwrap();
+
+        // 第二个 Agent 故意使用带 `.` 的等价路径，验证分组和删除判定使用
+        // 规范化后的物理路径，而不是原始字符串。
+        let shared_target_alias = shared_target.join(".");
+        configure_custom_tools(
+            &store,
+            &[
+                ("agent_one", shared_target.as_path()),
+                ("agent_two", shared_target_alias.as_path()),
+            ],
+        );
+        store.set_setting("sync_mode", "copy").unwrap();
+        store
+            .insert_scenario(&sample_scenario("preset", "Preset"))
+            .unwrap();
+        let source = write_skill_dir(&source_base, "alpha");
+        store
+            .insert_skill(&sample_skill("alpha", "alpha", &source))
+            .unwrap();
+        store.add_skill_to_scenario("preset", "alpha").unwrap();
+
+        let add = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string(), "agent_two".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        assert_eq!(add.applied, 2);
+        assert!(add.failures.is_empty());
+        assert!(shared_target.join("alpha/SKILL.md").exists());
+        assert_eq!(store.get_all_targets().unwrap().len(), 2);
+
+        let remove_first = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Remove,
+        )
+        .unwrap();
+        assert_eq!(remove_first.applied, 1);
+        assert!(remove_first.failures.is_empty());
+        assert!(shared_target.join("alpha/SKILL.md").exists());
+        assert_eq!(store.get_all_targets().unwrap().len(), 1);
+
+        let remove_second = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_two".to_string()],
+            PresetApplyMode::Remove,
+        )
+        .unwrap();
+        assert_eq!(remove_second.applied, 1);
+        assert!(remove_second.failures.is_empty());
+        assert!(!shared_target.join("alpha").exists());
+        assert!(store.get_all_targets().unwrap().is_empty());
+    }
+
+    #[test]
+    fn exact_preset_apply_validates_all_tools_before_writing() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let target_base = tmp.path().join("agent-one");
+        fs::create_dir_all(&source_base).unwrap();
+        configure_custom_tools(&store, &[("agent_one", target_base.as_path())]);
+        store.set_setting("sync_mode", "copy").unwrap();
+        store
+            .insert_scenario(&sample_scenario("preset", "Preset"))
+            .unwrap();
+        let source = write_skill_dir(&source_base, "alpha");
+        store
+            .insert_skill(&sample_skill("alpha", "alpha", &source))
+            .unwrap();
+        store.add_skill_to_scenario("preset", "alpha").unwrap();
+
+        let error = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string(), "missing_agent".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error.kind,
+            crate::core::error::ErrorKind::InvalidInput
+        ));
+        assert!(!target_base.exists());
+        assert!(store.get_all_targets().unwrap().is_empty());
+    }
+
+    #[test]
+    fn exact_preset_apply_continues_after_a_single_skill_failure() {
+        let tmp = tempdir().unwrap();
+        let store = SkillStore::new(&tmp.path().join("test.db")).unwrap();
+        let source_base = tmp.path().join("central");
+        let target_base = tmp.path().join("agent-one");
+        fs::create_dir_all(&source_base).unwrap();
+        configure_custom_tools(&store, &[("agent_one", target_base.as_path())]);
+        store.set_setting("sync_mode", "copy").unwrap();
+        store
+            .insert_scenario(&sample_scenario("preset", "Preset"))
+            .unwrap();
+
+        let valid_source = write_skill_dir(&source_base, "valid");
+        store
+            .insert_skill(&sample_skill("valid", "valid", &valid_source))
+            .unwrap();
+        let missing_source = source_base.join("missing");
+        store
+            .insert_skill(&sample_skill("missing", "missing", &missing_source))
+            .unwrap();
+        store.add_skill_to_scenario("preset", "valid").unwrap();
+        store.add_skill_to_scenario("preset", "missing").unwrap();
+
+        let report = apply_preset_to_tools_impl(
+            &store,
+            "preset",
+            &["agent_one".to_string()],
+            PresetApplyMode::Add,
+        )
+        .unwrap();
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.skipped, 0);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].skill_id, "missing");
+        assert_eq!(report.failures[0].tool_key, "agent_one");
+        assert!(target_base.join("valid/SKILL.md").exists());
     }
 }

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
@@ -6,8 +5,7 @@ use crate::core::{
     error::AppError,
     scenario_service,
     skill_store::SkillStore,
-    sync_engine, sync_metadata, tool_adapters,
-    tool_service,
+    sync_metadata, tool_adapters, tool_service,
 };
 use serde::Serialize;
 
@@ -49,6 +47,7 @@ pub async fn sync_skill_to_tool(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
+        let _guard = scenario_service::lock_preset_apply();
         let outcome = (|| -> Result<(), AppError> {
             sync_skill_to_tool_internal(&store, &skill_id, &tool)?;
 
@@ -92,19 +91,13 @@ pub async fn unsync_skill_from_tool(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
+        let _guard = scenario_service::lock_preset_apply();
         let outcome = (|| -> Result<(), AppError> {
-            let targets = store
-                .get_targets_for_skill(&skill_id)
-                .map_err(AppError::db)?;
-
-            if let Some(target) = targets.iter().find(|t| t.tool == tool) {
-                let target_path = PathBuf::from(&target.target_path);
-                sync_engine::remove_target(&target_path).ok();
-            }
-
-            store
-                .delete_target(&skill_id, &tool)
-                .map_err(AppError::db)?;
+            scenario_service::remove_skill_target_preserving_shared_path(
+                &store,
+                &skill_id,
+                &tool,
+            )?;
 
             if let Ok(Some(active_id)) = store.get_active_scenario_id() {
                 let skill_ids = store
@@ -228,6 +221,7 @@ pub async fn set_skill_tool_toggle(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
+        let _guard = scenario_service::lock_preset_apply();
         let skill_ids = store
             .get_skill_ids_for_scenario(&preset_id)
             .map_err(AppError::db)?;
@@ -270,16 +264,11 @@ pub async fn set_skill_tool_toggle(
             if enabled {
                 sync_skill_to_tool_internal(&store, &skill_id, &tool)?;
             } else {
-                let targets = store
-                    .get_targets_for_skill(&skill_id)
-                    .map_err(AppError::db)?;
-                if let Some(target) = targets.iter().find(|target| target.tool == tool) {
-                    // Safe because the app currently guarantees a single active scenario.
-                    sync_engine::remove_target(&PathBuf::from(&target.target_path)).ok();
-                }
-                store
-                    .delete_target(&skill_id, &tool)
-                    .map_err(AppError::db)?;
+                scenario_service::remove_skill_target_preserving_shared_path(
+                    &store,
+                    &skill_id,
+                    &tool,
+                )?;
             }
         }
 
@@ -298,6 +287,7 @@ mod tests {
     use crate::core::skill_store::SkillRecord;
     use crate::core::tool_adapters::CustomToolDef;
     use std::fs;
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     fn sample_skill(id: &str, name: &str, central_path: &std::path::Path) -> SkillRecord {

--- a/src-tauri/src/commands/tools.rs
+++ b/src-tauri/src/commands/tools.rs
@@ -1,5 +1,4 @@
 use serde::Serialize;
-use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Instant;
@@ -9,7 +8,6 @@ use crate::core::error::AppError;
 use crate::core::scenario_service;
 use crate::core::scenario_service::sync_scenario_skills;
 use crate::core::skill_store::SkillStore;
-use crate::core::sync_engine;
 use crate::core::timing::should_log_first_or_slow;
 use crate::core::tool_adapters::{self, CustomToolDef, ToolCategory};
 use crate::core::tool_service::{
@@ -39,21 +37,21 @@ fn sync_active_scenario_to_tool(store: &SkillStore, tool_key: &str) {
 }
 
 /// Remove all synced skill files and target records for a given tool.
-fn unsync_all_for_tool(store: &SkillStore, tool_key: &str) {
-    let targets = store.get_all_targets().unwrap_or_default();
-    for target in targets.iter().filter(|t| t.tool == tool_key) {
-        sync_engine::remove_target(&PathBuf::from(&target.target_path)).ok();
-        store.delete_target(&target.skill_id, tool_key).ok();
-    }
+fn unsync_all_for_tool(store: &SkillStore, tool_key: &str) -> Result<(), AppError> {
+    scenario_service::remove_all_skill_targets_for_tool(store, tool_key)
 }
 
-fn reconcile_tool_sync_after_path_change(store: &SkillStore, tool_key: &str) {
+fn reconcile_tool_sync_after_path_change(
+    store: &SkillStore,
+    tool_key: &str,
+) -> Result<(), AppError> {
     // Remove existing synced artifacts/records (old path), then re-sync to current adapter path.
-    unsync_all_for_tool(store, tool_key);
+    unsync_all_for_tool(store, tool_key)?;
     let disabled = get_disabled_tools(store);
     if !disabled.contains(&tool_key.to_string()) {
         sync_active_scenario_to_tool(store, tool_key);
     }
+    Ok(())
 }
 
 static GET_TOOL_STATUS_FIRST_CALL: AtomicBool = AtomicBool::new(true);
@@ -106,6 +104,8 @@ pub async fn set_tool_enabled(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
+        // Agent 启停会同步或移除同一批全局工作区目标，需与 Preset 应用共锁。
+        let _guard = scenario_service::lock_preset_apply();
         let mut disabled = get_disabled_tools(&store);
         if enabled {
             disabled.retain(|k| k != &key);
@@ -116,7 +116,7 @@ pub async fn set_tool_enabled(
             if !disabled.contains(&key) {
                 disabled.push(key.clone());
             }
-            unsync_all_for_tool(&store, &key);
+            unsync_all_for_tool(&store, &key)?;
             set_disabled_tools(&store, &disabled)
         }
     })
@@ -135,6 +135,7 @@ pub async fn set_all_tools_enabled(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
+        let _guard = scenario_service::lock_preset_apply();
         if enabled {
             set_disabled_tools(&store, &[])?;
             // Re-sync active scenario skills to all (now-enabled) installed tools
@@ -146,7 +147,7 @@ pub async fn set_all_tools_enabled(
             let adapters = tool_adapters::all_tool_adapters(&store);
             let all_keys: Vec<String> = adapters.iter().map(|a| a.key.clone()).collect();
             for adapter in &adapters {
-                unsync_all_for_tool(&store, &adapter.key);
+                unsync_all_for_tool(&store, &adapter.key)?;
             }
             set_disabled_tools(&store, &all_keys)
         }
@@ -183,6 +184,8 @@ pub async fn set_custom_tool_path(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
+        // 路径切换会先清理旧目录再写入新目录，必须避免与 Preset 批处理交错。
+        let _guard = scenario_service::lock_preset_apply();
         let key = key.trim().to_string();
         let path = normalize_skills_dir_input(&path)?;
         if key.is_empty() || path.is_empty() {
@@ -206,7 +209,7 @@ pub async fn set_custom_tool_path(
         let new_adapter = tool_adapters::find_adapter_with_store(&store, &key)
             .ok_or_else(|| AppError::not_found(format!("Unknown tool: {key}")))?;
         if old_skills_dir != new_adapter.skills_dir() {
-            reconcile_tool_sync_after_path_change(&store, &key);
+            reconcile_tool_sync_after_path_change(&store, &key)?;
         }
         Ok(())
     })
@@ -220,6 +223,7 @@ pub async fn reset_custom_tool_path(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
+        let _guard = scenario_service::lock_preset_apply();
         let old_adapter = tool_adapters::find_adapter_with_store(&store, &key)
             .ok_or_else(|| AppError::not_found(format!("Unknown tool: {key}")))?;
         let old_skills_dir = old_adapter.skills_dir();
@@ -231,7 +235,7 @@ pub async fn reset_custom_tool_path(
         let new_adapter = tool_adapters::find_adapter_with_store(&store, &key)
             .ok_or_else(|| AppError::not_found(format!("Unknown tool: {key}")))?;
         if old_skills_dir != new_adapter.skills_dir() {
-            reconcile_tool_sync_after_path_change(&store, &key);
+            reconcile_tool_sync_after_path_change(&store, &key)?;
         }
         Ok(())
     })
@@ -246,6 +250,7 @@ pub async fn set_custom_tool_project_path(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
+        let _guard = scenario_service::lock_preset_apply();
         let key = key.trim().to_string();
         if key.is_empty() {
             return Err(AppError::invalid_input("Key is required"));
@@ -318,6 +323,7 @@ pub async fn add_custom_tool(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
+        let _guard = scenario_service::lock_preset_apply();
         let key = key.trim().to_string();
         let display_name = display_name.trim().to_string();
         let skills_dir = normalize_skills_dir_input(&skills_dir)?;
@@ -346,7 +352,7 @@ pub async fn add_custom_tool(
             category: Default::default(),
         });
         set_custom_tools(&store, &customs)?;
-        reconcile_tool_sync_after_path_change(&store, &key);
+        reconcile_tool_sync_after_path_change(&store, &key)?;
         Ok(())
     })
     .await?
@@ -359,12 +365,10 @@ pub async fn remove_custom_tool(
 ) -> Result<(), AppError> {
     let store = store.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        // Remove synced targets for this tool
-        let targets = store.get_all_targets().unwrap_or_default();
-        for target in targets.iter().filter(|t| t.tool == key) {
-            crate::core::sync_engine::remove_target(&PathBuf::from(&target.target_path)).ok();
-            store.delete_target(&target.skill_id, &key).ok();
-        }
+        // 删除自定义 Agent 会移除其全部磁盘目标和数据库记录，同样属于
+        // 全局工作区写操作。
+        let _guard = scenario_service::lock_preset_apply();
+        unsync_all_for_tool(&store, &key)?;
         // Remove from custom_tools list
         let mut customs = get_custom_tools(&store);
         customs.retain(|c| c.key != key);
@@ -390,6 +394,7 @@ mod tests {
     use super::*;
     use crate::core::skill_store::{ScenarioRecord, SkillRecord};
     use std::fs;
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     fn sample_skill(id: &str, name: &str, central_path: &std::path::Path) -> SkillRecord {

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, TryLockError};
 use std::time::Instant;
 
 use super::{
@@ -9,6 +10,124 @@ use super::{
     sync_engine, tool_adapters,
     tool_service,
 };
+
+/// UI 与托盘会同时修改 `skill_targets` 和对应磁盘目录，必须共用同一把进程内锁。
+///
+/// UI 调用会等待锁，保证连续点击的 Preset 完整执行；托盘调用使用
+/// `try_lock_preset_apply`，保留原有“已有任务时忽略重复点击”的交互语义。
+static PRESET_APPLY_LOCK: Mutex<()> = Mutex::new(());
+
+pub fn lock_preset_apply() -> MutexGuard<'static, ()> {
+    PRESET_APPLY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+pub fn try_lock_preset_apply() -> Option<MutexGuard<'static, ()>> {
+    match PRESET_APPLY_LOCK.try_lock() {
+        Ok(guard) => Some(guard),
+        Err(TryLockError::WouldBlock) => None,
+        Err(TryLockError::Poisoned(poisoned)) => Some(poisoned.into_inner()),
+    }
+}
+
+/// 将路径中最近的已存在祖先解析为真实位置，再接回尚未创建的尾段。
+///
+/// Agent 根可能位于 junction/symlink 下，而中间目录尚未创建。只尝试解析立即
+/// 父目录会漏掉这种别名；逐级向上解析既保留同一物理根，也不会跟随目标 Skill
+/// 自身的链接（否则两个独立 Agent 的链接都会被折叠到中央 Library）。
+fn canonicalize_with_missing_tail(path: &Path) -> Option<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(path)
+    };
+    let mut cursor = absolute.as_path();
+    let mut tail = Vec::new();
+
+    loop {
+        if let Ok(mut resolved) = std::fs::canonicalize(cursor) {
+            for component in tail.iter().rev() {
+                resolved.push(component);
+            }
+            return Some(resolved);
+        }
+        let name = cursor.file_name()?.to_os_string();
+        tail.push(name);
+        cursor = cursor.parent()?;
+    }
+}
+
+#[cfg(windows)]
+fn windows_path_key(path: &Path, fold_case: bool) -> String {
+    let raw = path.to_string_lossy().replace('/', "\\");
+    // `canonicalize` 返回 extended-length path，而词法回退通常没有该前缀；
+    // 统一去除后，同一物理路径不会因为 `\\?\` 表示法不同而被拆成两组。
+    let normalized = if let Some(rest) = raw.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else if let Some(rest) = raw.strip_prefix(r"\\?\") {
+        rest.to_string()
+    } else {
+        raw
+    };
+    if fold_case {
+        normalized.to_lowercase()
+    } else {
+        normalized
+    }
+}
+
+/// 返回用于共享目标判定的稳定键。
+///
+/// 已解析路径保留文件系统返回的精确大小写，避免把启用 per-directory case
+/// sensitivity 的 NTFS 目录错误合并；只有完全无法解析祖先时才对 Windows 的
+/// 词法回退做大小写折叠。
+fn normalized_target_key(path: &Path) -> String {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_default()
+            .join(path)
+    };
+    let canonical_parent = absolute
+        .parent()
+        .and_then(canonicalize_with_missing_tail)
+        .and_then(|parent| absolute.file_name().map(|name| parent.join(name)))
+        .map(|path| lexical_normalize(&path));
+    #[cfg(windows)]
+    {
+        match canonical_parent {
+            Some(path) => windows_path_key(&path, false),
+            None => windows_path_key(&lexical_normalize(&absolute), true),
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        // Unix 允许反斜杠作为普通文件名字符，不能将它误当作分隔符，
+        // 否则 `a/b` 与 `a\b` 会错误共享同一个同步目标。
+        canonical_parent
+            .unwrap_or_else(|| lexical_normalize(&absolute))
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
 
 #[derive(Debug, Clone)]
 pub struct ScenarioSyncTarget {
@@ -573,6 +692,37 @@ pub enum BatchApplyMode {
     Remove,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchApplyFailure {
+    pub skill_id: String,
+    pub tool_key: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchApplyReport {
+    pub applied: usize,
+    pub skipped: usize,
+    pub failures: Vec<BatchApplyFailure>,
+}
+
+impl BatchApplyReport {
+    fn push_failure(
+        &mut self,
+        skill_id: impl Into<String>,
+        tool_key: impl Into<String>,
+        message: impl Into<String>,
+    ) {
+        self.failures.push(BatchApplyFailure {
+            skill_id: skill_id.into(),
+            tool_key: tool_key.into(),
+            message: message.into(),
+        });
+    }
+}
+
 /// Apply a batch of `(skill_id × tool_key)` pairs in either Add or Remove mode
 /// without touching `active_scenario_id` or `scenario_skill_tools` toggles.
 ///
@@ -596,165 +746,932 @@ pub fn apply_skills_to_tools(
         return Ok(());
     }
 
-    match mode {
-        BatchApplyMode::Add => apply_add(store, skill_ids, tool_keys),
-        BatchApplyMode::Remove => apply_remove(store, skill_ids, tool_keys),
+    let report = apply_skills_to_tools_with_report(store, skill_ids, tool_keys, mode)?;
+    for failure in &report.failures {
+        log::warn!(
+            "apply_skills_to_tools: skill {} / tool {} failed: {}",
+            failure.skill_id,
+            failure.tool_key,
+            failure.message
+        );
     }
+    Ok(())
 }
 
-fn apply_add(
+/// 精确批量应用并返回逐项结果。与托盘保留的兼容入口不同，这个入口会在
+/// 任何磁盘写入之前完整校验目标 Agent，避免混合有效/无效目标导致部分提交。
+pub fn apply_skills_to_tools_with_report(
     store: &SkillStore,
     skill_ids: &[String],
     tool_keys: &[String],
-) -> Result<(), AppError> {
-    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
-    let disabled = tool_service::get_disabled_tools(store);
-
-    let mut adapters: HashMap<String, tool_adapters::ToolAdapter> = HashMap::new();
-    for key in tool_keys {
-        if disabled.contains(key) {
-            log::debug!("apply_skills_to_tools: skipping disabled tool {key}");
-            continue;
-        }
-        let Some(adapter) = tool_adapters::find_adapter_with_store(store, key) else {
-            log::warn!("apply_skills_to_tools: unknown tool {key}");
-            continue;
-        };
-        if !adapter.is_installed() {
-            log::debug!(
-                "apply_skills_to_tools: skipping uninstalled tool {} ({key})",
-                adapter.display_name
-            );
-            continue;
-        }
-        adapters.insert(key.clone(), adapter);
+    mode: BatchApplyMode,
+) -> Result<BatchApplyReport, AppError> {
+    let unique_skill_ids = deduplicate_strings(skill_ids);
+    if unique_skill_ids.is_empty() {
+        return Ok(BatchApplyReport::default());
     }
 
-    let mut synced = 0usize;
-    let mut failed = 0usize;
+    match mode {
+        BatchApplyMode::Add => {
+            let adapters = validate_batch_tools_for_add(store, tool_keys)?;
+            apply_add_with_report(store, &unique_skill_ids, &adapters)
+        }
+        BatchApplyMode::Remove => {
+            let unique_tool_keys = validate_batch_tools_for_remove(store, tool_keys)?;
+            apply_remove_with_report(store, &unique_skill_ids, &unique_tool_keys)
+        }
+    }
+}
+
+fn deduplicate_strings(values: &[String]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    values
+        .iter()
+        .filter(|value| seen.insert((*value).clone()))
+        .cloned()
+        .collect()
+}
+
+fn validate_batch_tools_for_add(
+    store: &SkillStore,
+    tool_keys: &[String],
+) -> Result<Vec<tool_adapters::ToolAdapter>, AppError> {
+    let unique_keys = deduplicate_strings(tool_keys);
+    if unique_keys.is_empty() {
+        return Err(AppError::invalid_input(
+            "At least one target Agent is required",
+        ));
+    }
+
+    let disabled = tool_service::get_disabled_tools(store);
+    let mut adapters = Vec::with_capacity(unique_keys.len());
+    for key in unique_keys {
+        let adapter = tool_adapters::find_adapter_with_store(store, &key)
+            .ok_or_else(|| AppError::invalid_input(format!("Unknown Agent: {key}")))?;
+        if !adapter.is_installed() {
+            return Err(AppError::invalid_input(format!(
+                "{} is not installed",
+                adapter.display_name
+            )));
+        }
+        if disabled.contains(&key) {
+            return Err(AppError::invalid_input(format!(
+                "{} is disabled",
+                adapter.display_name
+            )));
+        }
+        adapters.push(adapter);
+    }
+    Ok(adapters)
+}
+
+/// Remove 依据数据库中的既有目标执行，不要求 Agent 仍被检测为已安装或启用。
+/// 这样用户禁用 Agent、卸载客户端或临时断开网络盘后，仍能清理其受管记录。
+fn validate_batch_tools_for_remove(
+    store: &SkillStore,
+    tool_keys: &[String],
+) -> Result<Vec<String>, AppError> {
+    let unique_keys = deduplicate_strings(tool_keys);
+    if unique_keys.is_empty() {
+        return Err(AppError::invalid_input(
+            "At least one target Agent is required",
+        ));
+    }
+    for key in &unique_keys {
+        if tool_adapters::find_adapter_with_store(store, key).is_none() {
+            return Err(AppError::invalid_input(format!("Unknown Agent: {key}")));
+        }
+    }
+    Ok(unique_keys)
+}
+
+#[derive(Debug)]
+struct StagedTarget {
+    original: PathBuf,
+    staged: PathBuf,
+}
+
+/// 在 Agent 的 Skills 扫描根之外创建同卷暂存位置。
+///
+/// 暂存项必须与目标同卷，才能用 `rename` 完成原子切换；同时不能放在
+/// `skills_dir` 内，否则清理失败后残留的 `SKILL.md` 仍可能被 Agent 发现。
+fn unique_staging_path(target: &Path, purpose: &str) -> Result<PathBuf, AppError> {
+    let skills_root = target
+        .parent()
+        .ok_or_else(|| AppError::invalid_input("Target path has no Skills root"))?;
+    // Agent 根可能是跨卷 junction/symlink。必须跟随根目录本身，确保暂存项
+    // 和真实目标位于同一卷；继续使用词法父目录会让 Windows rename 返回
+    // ERROR_NOT_SAME_DEVICE。
+    let absolute_root = if skills_root.is_absolute() {
+        skills_root.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_default()
+            .join(skills_root)
+    };
+    let physical_root = canonicalize_with_missing_tail(&absolute_root)
+        .unwrap_or_else(|| lexical_normalize(&absolute_root));
+    let staging_parent = physical_root
+        .parent()
+        .ok_or_else(|| AppError::invalid_input("Skills root has no safe staging parent"))?;
+    let staging_root = staging_parent.join(".skills-manager-staging");
+    std::fs::create_dir_all(&staging_root).map_err(AppError::io)?;
+    Ok(staging_root.join(format!(
+        "{purpose}-{}",
+        uuid::Uuid::new_v4()
+    )))
+}
+
+fn path_exists_strict(path: &Path) -> Result<bool, AppError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(AppError::io(error)),
+    }
+}
+
+fn stage_existing_target(path: &Path, purpose: &str) -> Result<Option<StagedTarget>, AppError> {
+    if !path_exists_strict(path)? {
+        return Ok(None);
+    }
+    let staged = unique_staging_path(path, purpose)?;
+    std::fs::rename(path, &staged).map_err(AppError::io)?;
+    Ok(Some(StagedTarget {
+        original: path.to_path_buf(),
+        staged,
+    }))
+}
+
+fn remove_path_if_present(path: &Path) -> Result<(), AppError> {
+    if path_exists_strict(path)? {
+        sync_engine::remove_target(path).map_err(AppError::io)?;
+    }
+    Ok(())
+}
+
+fn cleanup_staging_parent(path: &Path) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::remove_dir(parent);
+    }
+}
+
+fn discard_staged_target(staged: StagedTarget) {
+    if let Err(error) = remove_path_if_present(&staged.staged) {
+        // 暂存位置不在任何 Agent 的扫描根内；清理失败不会重新启用 Skill，
+        // 但需要保留日志，便于用户手动处理权限或占用问题。
+        log::warn!(
+            "Failed to clean Preset staging path {}: {error}",
+            staged.staged.display()
+        );
+    }
+    cleanup_staging_parent(&staged.staged);
+}
+
+fn restore_staged_target(staged: &StagedTarget) -> Result<(), AppError> {
+    remove_path_if_present(&staged.original)?;
+    std::fs::rename(&staged.staged, &staged.original).map_err(AppError::io)?;
+    cleanup_staging_parent(&staged.staged);
+    Ok(())
+}
+
+fn restore_staged_targets(staged: &[StagedTarget]) -> Vec<String> {
+    staged
+        .iter()
+        .rev()
+        .filter_map(|entry| {
+            restore_staged_target(entry).err().map(|error| {
+                format!(
+                    "failed to restore {}: {error}",
+                    entry.original.display()
+                )
+            })
+        })
+        .collect()
+}
+
+fn target_record_is_current(
+    record: &SkillTargetRecord,
+    source: &Path,
+    desired_target: &Path,
+    desired_mode: sync_engine::SyncMode,
+    current_source_hash: Option<&str>,
+) -> bool {
+    record.status == "ok"
+        && normalized_target_key(Path::new(&record.target_path))
+            == normalized_target_key(desired_target)
+        && skip_check_mode(&record.mode, desired_mode).is_some_and(|check_mode| {
+            sync_engine::is_target_current(
+                source,
+                Path::new(&record.target_path),
+                check_mode,
+                record.source_hash.as_deref(),
+                current_source_hash,
+            )
+        })
+}
+
+fn push_group_failure(
+    report: &mut BatchApplyReport,
+    skill_id: &str,
+    members: &[(&tool_adapters::ToolAdapter, PathBuf)],
+    message: impl Into<String>,
+) {
+    let message = message.into();
+    for (adapter, _) in members {
+        report.push_failure(skill_id, &adapter.key, &message);
+    }
+}
+
+fn restore_after_add_failure(
+    desired_backup: Option<&StagedTarget>,
+    old_backups: &[StagedTarget],
+    desired_target: &Path,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    if let Err(error) = remove_path_if_present(desired_target) {
+        failures.push(format!(
+            "failed to remove the uncommitted target {}: {error}",
+            desired_target.display()
+        ));
+    }
+    if let Some(backup) = desired_backup {
+        if let Err(error) = restore_staged_target(backup) {
+            failures.push(format!(
+                "failed to restore the previous target {}: {error}",
+                backup.original.display()
+            ));
+        }
+    }
+    failures.extend(restore_staged_targets(old_backups));
+    failures
+}
+
+fn apply_add_with_report(
+    store: &SkillStore,
+    skill_ids: &[String],
+    adapters: &[tool_adapters::ToolAdapter],
+) -> Result<BatchApplyReport, AppError> {
+    let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
+    let mut report = BatchApplyReport::default();
+
     for skill_id in skill_ids {
-        let Ok(Some(skill)) = store.get_skill_by_id(skill_id) else {
-            log::warn!("apply_skills_to_tools: skill {skill_id} not found");
-            continue;
+        let skill = match store.get_skill_by_id(skill_id).map_err(AppError::db)? {
+            Some(skill) => skill,
+            None => {
+                for adapter in adapters {
+                    report.push_failure(skill_id, &adapter.key, "Skill not found");
+                }
+                continue;
+            }
         };
+
         let source = PathBuf::from(&skill.central_path);
         let target_name = sync_engine::target_dir_name(&source, &skill.name);
-        for (tool_key, adapter) in &adapters {
+        let mut groups: Vec<(String, Vec<(&tool_adapters::ToolAdapter, PathBuf)>)> = Vec::new();
+        for adapter in adapters {
             let target = adapter.skills_dir().join(&target_name);
-            let mode = sync_engine::sync_mode_for_tool(tool_key, configured_mode.as_deref());
-            match sync_engine::sync_skill(&source, &target, mode) {
-                Ok(actual_mode) => {
-                    let now = chrono::Utc::now().timestamp_millis();
-                    let target_record = SkillTargetRecord {
-                        id: uuid::Uuid::new_v4().to_string(),
+            let target_key = normalized_target_key(&target);
+            if let Some((_, members)) = groups.iter_mut().find(|(key, _)| *key == target_key) {
+                members.push((adapter, target));
+            } else {
+                groups.push((target_key, vec![(adapter, target)]));
+            }
+        }
+
+        for (target_key, members) in groups {
+            let all_targets = store.get_all_targets().map_err(AppError::db)?;
+            let first_target = &members[0].1;
+            let first_mode = sync_engine::sync_mode_for_tool(
+                &members[0].0.key,
+                configured_mode.as_deref(),
+            );
+            if let Err(error) = sync_engine::ensure_dst_not_inside_src(&source, first_target) {
+                push_group_failure(
+                    &mut report,
+                    skill_id,
+                    &members,
+                    format!("Unsafe source/target layout: {error}"),
+                );
+                continue;
+            }
+
+            let physical_records: Vec<&SkillTargetRecord> = all_targets
+                .iter()
+                .filter(|record| {
+                    normalized_target_key(Path::new(&record.target_path)) == target_key
+                })
+                .collect();
+            if physical_records
+                .iter()
+                .any(|record| record.skill_id != *skill_id)
+            {
+                push_group_failure(
+                    &mut report,
+                    skill_id,
+                    &members,
+                    "Target path is already managed by another Skill",
+                );
+                continue;
+            }
+
+            let mut current_tools = HashSet::new();
+            for (adapter, target) in &members {
+                if all_targets.iter().any(|record| {
+                    record.skill_id == *skill_id
+                        && record.tool == adapter.key
+                        && target_record_is_current(
+                            record,
+                            &source,
+                            target,
+                            sync_engine::sync_mode_for_tool(
+                                &adapter.key,
+                                configured_mode.as_deref(),
+                            ),
+                            skill.content_hash.as_deref(),
+                        )
+                }) {
+                    current_tools.insert(adapter.key.clone());
+                }
+            }
+            report.skipped += current_tools.len();
+            let pending_members: Vec<(&tool_adapters::ToolAdapter, PathBuf)> = members
+                .iter()
+                .filter(|(adapter, _)| !current_tools.contains(&adapter.key))
+                .map(|(adapter, target)| (*adapter, target.clone()))
+                .collect();
+            if pending_members.is_empty() {
+                continue;
+            }
+
+            // 另一个共享同一路径的 Agent 已证明物理内容是当前版本时，只需补齐
+            // 本组记录，不应重复替换该目录。
+            let current_physical = physical_records.iter().find(|record| {
+                target_record_is_current(
+                    record,
+                    &source,
+                    first_target,
+                    first_mode,
+                    skill.content_hash.as_deref(),
+                )
+            });
+
+            let target_exists = match path_exists_strict(first_target) {
+                Ok(exists) => exists,
+                Err(error) => {
+                    push_group_failure(&mut report, skill_id, &pending_members, error.to_string());
+                    continue;
+                }
+            };
+            if current_physical.is_none() && target_exists && physical_records.is_empty() {
+                push_group_failure(
+                    &mut report,
+                    skill_id,
+                    &pending_members,
+                    "Target directory already exists but is not managed by Skills Manager",
+                );
+                continue;
+            }
+
+            // 路径迁移时先把不再被其他记录引用的旧目标移出扫描根；数据库提交
+            // 失败会按相反顺序恢复，避免“旧副本已删、新副本未登记”。
+            let pending_tool_keys: HashSet<&str> = pending_members
+                .iter()
+                .map(|(adapter, _)| adapter.key.as_str())
+                .collect();
+            let mut old_backups = Vec::new();
+            let mut staged_old_keys = HashSet::new();
+            let mut staging_error = None;
+            for record in all_targets.iter().filter(|record| {
+                record.skill_id == *skill_id && pending_tool_keys.contains(record.tool.as_str())
+            }) {
+                let old_path = PathBuf::from(&record.target_path);
+                let old_key = normalized_target_key(&old_path);
+                if old_key == target_key || !staged_old_keys.insert(old_key.clone()) {
+                    continue;
+                }
+                let referenced_elsewhere = all_targets.iter().any(|other| {
+                    other.id != record.id
+                        && normalized_target_key(Path::new(&other.target_path)) == old_key
+                        && !(other.skill_id == *skill_id
+                            && pending_tool_keys.contains(other.tool.as_str()))
+                });
+                if referenced_elsewhere {
+                    continue;
+                }
+                match stage_existing_target(&old_path, "old") {
+                    Ok(Some(staged)) => old_backups.push(staged),
+                    Ok(None) => {}
+                    Err(error) => {
+                        staging_error = Some(error);
+                        break;
+                    }
+                }
+            }
+            if let Some(error) = staging_error {
+                let restore_failures = restore_staged_targets(&old_backups);
+                let suffix = if restore_failures.is_empty() {
+                    String::new()
+                } else {
+                    format!("; {}", restore_failures.join("; "))
+                };
+                push_group_failure(
+                    &mut report,
+                    skill_id,
+                    &pending_members,
+                    format!("Failed to stage the previous target: {error}{suffix}"),
+                );
+                continue;
+            }
+
+            let mut desired_backup = None;
+            let mut incoming_path = None;
+            let mode_name = if let Some(existing) = current_physical {
+                existing.mode.clone()
+            } else {
+                let incoming = match unique_staging_path(first_target, "incoming") {
+                    Ok(path) => path,
+                    Err(error) => {
+                        let restore_failures = restore_staged_targets(&old_backups);
+                        push_group_failure(
+                            &mut report,
+                            skill_id,
+                            &pending_members,
+                            format!(
+                                "Failed to prepare the new target: {error}{}",
+                                if restore_failures.is_empty() {
+                                    String::new()
+                                } else {
+                                    format!("; {}", restore_failures.join("; "))
+                                }
+                            ),
+                        );
+                        continue;
+                    }
+                };
+                let actual_mode = match sync_engine::sync_skill(&source, &incoming, first_mode) {
+                    Ok(mode) => mode,
+                    Err(error) => {
+                        let _ = remove_path_if_present(&incoming);
+                        cleanup_staging_parent(&incoming);
+                        let restore_failures = restore_staged_targets(&old_backups);
+                        push_group_failure(
+                            &mut report,
+                            skill_id,
+                            &pending_members,
+                            format!(
+                                "Failed to build the new target: {error}{}",
+                                if restore_failures.is_empty() {
+                                    String::new()
+                                } else {
+                                    format!("; {}", restore_failures.join("; "))
+                                }
+                            ),
+                        );
+                        continue;
+                    }
+                };
+
+                if let Some(parent) = first_target.parent() {
+                    if let Err(error) = std::fs::create_dir_all(parent) {
+                        let _ = remove_path_if_present(&incoming);
+                        cleanup_staging_parent(&incoming);
+                        let restore_failures = restore_staged_targets(&old_backups);
+                        push_group_failure(
+                            &mut report,
+                            skill_id,
+                            &pending_members,
+                            format!(
+                                "Failed to create the Agent Skills directory: {error}{}",
+                                if restore_failures.is_empty() {
+                                    String::new()
+                                } else {
+                                    format!("; {}", restore_failures.join("; "))
+                                }
+                            ),
+                        );
+                        continue;
+                    }
+                }
+
+                desired_backup = match stage_existing_target(first_target, "replaced") {
+                    Ok(staged) => staged,
+                    Err(error) => {
+                        let _ = remove_path_if_present(&incoming);
+                        cleanup_staging_parent(&incoming);
+                        let restore_failures = restore_staged_targets(&old_backups);
+                        push_group_failure(
+                            &mut report,
+                            skill_id,
+                            &pending_members,
+                            format!(
+                                "Failed to stage the current target: {error}{}",
+                                if restore_failures.is_empty() {
+                                    String::new()
+                                } else {
+                                    format!("; {}", restore_failures.join("; "))
+                                }
+                            ),
+                        );
+                        continue;
+                    }
+                };
+                if let Err(error) = std::fs::rename(&incoming, first_target) {
+                    let mut restore_failures = Vec::new();
+                    if let Some(backup) = desired_backup.as_ref() {
+                        if let Err(restore_error) = restore_staged_target(backup) {
+                            restore_failures.push(restore_error.to_string());
+                        }
+                    }
+                    restore_failures.extend(restore_staged_targets(&old_backups));
+                    let _ = remove_path_if_present(&incoming);
+                    cleanup_staging_parent(&incoming);
+                    push_group_failure(
+                        &mut report,
+                        skill_id,
+                        &pending_members,
+                        format!(
+                            "Failed to activate the new target: {error}{}",
+                            if restore_failures.is_empty() {
+                                String::new()
+                            } else {
+                                format!("; restore failed: {}", restore_failures.join("; "))
+                            }
+                        ),
+                    );
+                    continue;
+                }
+                incoming_path = Some(incoming);
+                actual_mode.as_str().to_string()
+            };
+
+            let now = chrono::Utc::now().timestamp_millis();
+            let expected_records: Vec<SkillTargetRecord> = all_targets
+                .iter()
+                .filter(|record| {
+                    record.skill_id == *skill_id
+                        && pending_tool_keys.contains(record.tool.as_str())
+                })
+                .cloned()
+                .collect();
+            let records: Vec<SkillTargetRecord> = pending_members
+                .iter()
+                .map(|(adapter, target)| {
+                    let existing = all_targets.iter().find(|record| {
+                        record.skill_id == *skill_id && record.tool == adapter.key
+                    });
+                    SkillTargetRecord {
+                        id: existing
+                            .map(|record| record.id.clone())
+                            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
                         skill_id: skill_id.clone(),
-                        tool: tool_key.clone(),
+                        tool: adapter.key.clone(),
                         target_path: target.to_string_lossy().to_string(),
-                        mode: actual_mode.as_str().to_string(),
+                        mode: mode_name.clone(),
                         status: "ok".to_string(),
                         synced_at: Some(now),
                         last_error: None,
                         source_hash: skill.content_hash.clone(),
-                    };
-                    if let Err(e) = store.insert_target(&target_record) {
-                        log::warn!(
-                            "apply_skills_to_tools: failed to insert target for skill {skill_id} / {tool_key}: {e}"
-                        );
-                        failed += 1;
-                    } else {
-                        synced += 1;
                     }
+                })
+                .collect();
+
+            if let Err(error) =
+                store.upsert_targets_if_unchanged(&records, &expected_records)
+            {
+                let restore_failures = if current_physical.is_some() {
+                    restore_staged_targets(&old_backups)
+                } else {
+                    restore_after_add_failure(
+                        desired_backup.as_ref(),
+                        &old_backups,
+                        first_target,
+                    )
+                };
+                if let Some(incoming) = incoming_path.as_ref() {
+                    cleanup_staging_parent(incoming);
                 }
-                Err(e) => {
-                    failed += 1;
-                    log::warn!(
-                        "apply_skills_to_tools: failed to sync skill {skill_id} ({}) to {}: {e}",
-                        skill.name,
-                        target.display()
-                    );
-                }
+                push_group_failure(
+                    &mut report,
+                    skill_id,
+                    &pending_members,
+                    format!(
+                        "Failed to record target: {error}{}",
+                        if restore_failures.is_empty() {
+                            String::new()
+                        } else {
+                            format!("; restore failed: {}", restore_failures.join("; "))
+                        }
+                    ),
+                );
+                continue;
             }
+
+            if let Some(backup) = desired_backup {
+                discard_staged_target(backup);
+            }
+            for backup in old_backups {
+                discard_staged_target(backup);
+            }
+            if let Some(incoming) = incoming_path.as_ref() {
+                cleanup_staging_parent(incoming);
+            }
+            report.applied += records.len();
         }
     }
 
     log::info!(
-        "apply_skills_to_tools(Add): skills={} tools={} synced={synced} failed={failed}",
+        "apply_skills_to_tools_with_report(Add): skills={} tools={} applied={} skipped={} failed={}",
         skill_ids.len(),
         adapters.len(),
+        report.applied,
+        report.skipped,
+        report.failures.len(),
     );
-    Ok(())
+    Ok(report)
 }
 
-fn apply_remove(
+fn apply_remove_with_report(
     store: &SkillStore,
     skill_ids: &[String],
     tool_keys: &[String],
-) -> Result<(), AppError> {
-    let tool_set: HashSet<&String> = tool_keys.iter().collect();
-
-    let mut to_delete: Vec<(String, String, PathBuf)> = Vec::new();
-    for skill_id in skill_ids {
-        let targets = store.get_targets_for_skill(skill_id).unwrap_or_default();
-        for target in targets {
-            if tool_set.contains(&target.tool) {
-                to_delete.push((
-                    skill_id.clone(),
-                    target.tool.clone(),
-                    PathBuf::from(&target.target_path),
-                ));
-            }
-        }
-    }
-
-    if to_delete.is_empty() {
-        return Ok(());
-    }
-
-    // Phase 1: drop the DB rows first so the post-delete recount below sees
-    // the new ground truth when deciding which filesystem paths to keep.
-    for (skill_id, tool, _) in &to_delete {
-        if let Err(e) = store.delete_target(skill_id, tool) {
-            log::warn!(
-                "apply_skills_to_tools(Remove): failed to delete target record for skill {skill_id} / {tool}: {e}"
-            );
-        }
-    }
-
-    // Phase 2: gather the paths the batch wanted to remove, then keep any path
-    // a remaining (skill_id, tool) row still points at. This prevents wiping a
-    // directory another adapter is sharing.
-    let candidate_paths: HashSet<PathBuf> = to_delete.iter().map(|(_, _, p)| p.clone()).collect();
-    let still_referenced: HashSet<PathBuf> = store
-        .get_all_targets()
-        .unwrap_or_default()
-        .into_iter()
-        .map(|t| PathBuf::from(&t.target_path))
+) -> Result<BatchApplyReport, AppError> {
+    let mut report = BatchApplyReport::default();
+    let all_targets = store.get_all_targets().map_err(AppError::db)?;
+    let requested_pairs: HashSet<(String, String)> = skill_ids
+        .iter()
+        .flat_map(|skill_id| {
+            tool_keys
+                .iter()
+                .map(move |tool_key| (skill_id.clone(), tool_key.clone()))
+        })
         .collect();
+    let selected: Vec<SkillTargetRecord> = all_targets
+        .iter()
+        .filter(|record| {
+            requested_pairs.contains(&(record.skill_id.clone(), record.tool.clone()))
+        })
+        .cloned()
+        .collect();
+    report.skipped = requested_pairs.len().saturating_sub(selected.len());
 
-    let mut removed = 0usize;
-    for path in candidate_paths {
-        if still_referenced.contains(&path) {
-            log::debug!(
-                "apply_skills_to_tools(Remove): keeping {} (still referenced by another target)",
-                path.display()
-            );
+    let selected_ids: HashSet<String> = selected.iter().map(|record| record.id.clone()).collect();
+    let mut groups: Vec<(String, Vec<SkillTargetRecord>)> = Vec::new();
+    for record in selected {
+        let key = normalized_target_key(Path::new(&record.target_path));
+        if let Some((_, records)) = groups.iter_mut().find(|(existing, _)| *existing == key) {
+            records.push(record);
+        } else {
+            groups.push((key, vec![record]));
+        }
+    }
+
+    for (path_key, records) in groups {
+        let physical_path = PathBuf::from(&records[0].target_path);
+        let referenced_elsewhere = all_targets.iter().any(|record| {
+            !selected_ids.contains(&record.id)
+                && normalized_target_key(Path::new(&record.target_path)) == path_key
+        });
+        let staged = if referenced_elsewhere {
+            None
+        } else {
+            match stage_existing_target(&physical_path, "removed") {
+                Ok(staged) => staged,
+                Err(error) => {
+                    for record in &records {
+                        report.push_failure(&record.skill_id, &record.tool, error.to_string());
+                    }
+                    continue;
+                }
+            }
+        };
+
+        if let Err(error) = store.delete_targets_exact_atomic(&records) {
+            let restore_note = staged
+                .as_ref()
+                .and_then(|entry| restore_staged_target(entry).err())
+                .map(|restore| format!("; restore failed: {restore}"))
+                .unwrap_or_default();
+            for record in &records {
+                report.push_failure(
+                    &record.skill_id,
+                    &record.tool,
+                    format!("Failed to delete target record: {error}{restore_note}"),
+                );
+            }
             continue;
         }
-        if let Err(e) = sync_engine::remove_target(&path) {
-            log::warn!(
-                "apply_skills_to_tools(Remove): failed to remove {}: {e}",
-                path.display()
-            );
-        } else {
-            removed += 1;
+
+        if let Some(staged) = staged {
+            // 数据库提交后再检查一次，若有新的共享引用出现，则把物理目标恢复；
+            // 读取失败时恢复原记录和目录，破坏性操作必须 fail closed。
+            match store.get_all_targets() {
+                Ok(remaining) => {
+                    let newly_referenced = remaining.iter().any(|record| {
+                        normalized_target_key(Path::new(&record.target_path)) == path_key
+                    });
+                    if newly_referenced {
+                        match path_exists_strict(&physical_path) {
+                            Ok(false) => {
+                                if let Err(error) = restore_staged_target(&staged) {
+                                    let row_restore = store
+                                        .upsert_targets_if_unchanged(&records, &[])
+                                        .err();
+                                    for record in &records {
+                                        report.push_failure(
+                                            &record.skill_id,
+                                            &record.tool,
+                                            format!(
+                                                "Failed to restore a newly referenced shared target: {error}{}",
+                                                row_restore
+                                                    .as_ref()
+                                                    .map(|restore| format!(
+                                                        "; record restore failed: {restore}"
+                                                    ))
+                                                    .unwrap_or_default()
+                                            ),
+                                        );
+                                    }
+                                    continue;
+                                }
+                            }
+                            Ok(true) => discard_staged_target(staged),
+                            Err(error) => {
+                                let row_restore = store
+                                    .upsert_targets_if_unchanged(&records, &[])
+                                    .err();
+                                let path_restore = restore_staged_target(&staged).err();
+                                let mut suffix = Vec::new();
+                                if let Some(restore) = row_restore {
+                                    suffix.push(format!("record restore failed: {restore}"));
+                                }
+                                if let Some(restore) = path_restore {
+                                    suffix.push(format!("path restore failed: {restore}"));
+                                }
+                                for record in &records {
+                                    report.push_failure(
+                                        &record.skill_id,
+                                        &record.tool,
+                                        format!(
+                                            "Failed to verify a newly referenced shared target: {error}{}",
+                                            if suffix.is_empty() {
+                                                String::new()
+                                            } else {
+                                                format!("; {}", suffix.join("; "))
+                                            }
+                                        ),
+                                    );
+                                }
+                                continue;
+                            }
+                        }
+                    } else {
+                        discard_staged_target(staged);
+                    }
+                }
+                Err(error) => {
+                    let row_restore = store
+                        .upsert_targets_if_unchanged(&records, &[])
+                        .err();
+                    let path_restore = restore_staged_target(&staged).err();
+                    let mut suffix = Vec::new();
+                    if let Some(restore) = row_restore {
+                        suffix.push(format!("record restore failed: {restore}"));
+                    }
+                    if let Some(restore) = path_restore {
+                        suffix.push(format!("path restore failed: {restore}"));
+                    }
+                    for record in &records {
+                        report.push_failure(
+                            &record.skill_id,
+                            &record.tool,
+                            format!(
+                                "Failed to verify shared target after removal: {error}{}",
+                                if suffix.is_empty() {
+                                    String::new()
+                                } else {
+                                    format!("; {}", suffix.join("; "))
+                                }
+                            ),
+                        );
+                    }
+                    continue;
+                }
+            }
         }
+        report.applied += records.len();
     }
 
     log::info!(
-        "apply_skills_to_tools(Remove): pairs={} fs_removed={removed}",
-        to_delete.len(),
+        "apply_skills_to_tools_with_report(Remove): skills={} tools={} applied={} skipped={} failed={}",
+        skill_ids.len(),
+        tool_keys.len(),
+        report.applied,
+        report.skipped,
+        report.failures.len(),
     );
-    Ok(())
+    Ok(report)
+}
+
+fn ensure_remove_report_succeeded(report: BatchApplyReport) -> Result<BatchApplyReport, AppError> {
+    if report.failures.is_empty() {
+        return Ok(report);
+    }
+    Err(AppError::io(
+        report
+            .failures
+            .iter()
+            .map(|failure| {
+                format!(
+                    "{}/{}: {}",
+                    failure.skill_id, failure.tool_key, failure.message
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; "),
+    ))
+}
+
+/// 从单个 Agent 移除一个受管 Skill，并保留仍被其他 Agent 引用的共享目录。
+/// 调用方必须持有 [`lock_preset_apply`]，以便与批量 Preset 写入串行。
+pub fn remove_skill_target_preserving_shared_path(
+    store: &SkillStore,
+    skill_id: &str,
+    tool_key: &str,
+) -> Result<bool, AppError> {
+    let report = apply_remove_with_report(
+        store,
+        &[skill_id.to_string()],
+        &[tool_key.to_string()],
+    )?;
+    let report = ensure_remove_report_succeeded(report)?;
+    Ok(report.applied == 1)
+}
+
+/// 安全移除一个 Agent 的全部受管目标；共享物理目录只删除该 Agent 的记录。
+/// 调用方必须持有 [`lock_preset_apply`]。
+pub fn remove_all_skill_targets_for_tool(
+    store: &SkillStore,
+    tool_key: &str,
+) -> Result<(), AppError> {
+    let skill_ids = store
+        .get_all_targets()
+        .map_err(AppError::db)?
+        .into_iter()
+        .filter(|target| target.tool == tool_key)
+        .map(|target| target.skill_id)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if skill_ids.is_empty() {
+        return Ok(());
+    }
+    let report = apply_remove_with_report(store, &skill_ids, &[tool_key.to_string()])?;
+    ensure_remove_report_succeeded(report).map(|_| ())
+}
+
+#[cfg(test)]
+mod preset_apply_lock_tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn preset_apply_lock_serializes_waiting_callers() {
+        let first_guard = lock_preset_apply();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+
+        let waiter = thread::spawn(move || {
+            let _second_guard = lock_preset_apply();
+            acquired_tx.send(()).unwrap();
+        });
+
+        // 第二个调用方必须在首个批处理释放锁之前保持等待，避免目录和
+        // skill_targets 被两个桌面命令交错改写。
+        assert!(acquired_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        drop(first_guard);
+        acquired_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("waiting preset apply did not acquire the released lock");
+        waiter.join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalized_target_key_preserves_backslash_filename_on_unix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested_parent = tmp.path().join("agent");
+        std::fs::create_dir_all(&nested_parent).unwrap();
+
+        let slash_path = nested_parent.join("skill");
+        let backslash_path = tmp.path().join(r"agent\skill");
+
+        assert_ne!(
+            normalized_target_key(&slash_path),
+            normalized_target_key(&backslash_path),
+            "Unix backslashes are filename characters, not separators"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/core/skill_store.rs
+++ b/src-tauri/src/core/skill_store.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::Serialize;
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -464,6 +464,121 @@ impl SkillStore {
         Ok(())
     }
 
+    /// 仅在 `(skill_id, tool)` 记录仍与调用方快照一致时原子更新整组目标。
+    ///
+    /// UI 队列和进程内锁覆盖正常桌面操作；这里的 compare-and-swap 校验还能
+    /// 阻止另一个写入方在文件准备期间替换记录后又被本次提交静默覆盖。
+    pub fn upsert_targets_if_unchanged(
+        &self,
+        targets: &[SkillTargetRecord],
+        expected: &[SkillTargetRecord],
+    ) -> Result<()> {
+        if targets.is_empty() {
+            return Ok(());
+        }
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        for target in targets {
+            let current = tx
+                .query_row(
+                    "SELECT id, target_path, mode, status, source_hash
+                     FROM skill_targets WHERE skill_id = ?1 AND tool = ?2",
+                    params![target.skill_id, target.tool],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, String>(2)?,
+                            row.get::<_, String>(3)?,
+                            row.get::<_, Option<String>>(4)?,
+                        ))
+                    },
+                )
+                .optional()?;
+            let snapshot = expected.iter().find(|record| {
+                record.skill_id == target.skill_id && record.tool == target.tool
+            });
+            let unchanged = match (current.as_ref(), snapshot) {
+                (None, None) => true,
+                (Some((id, path, mode, status, source_hash)), Some(record)) => {
+                    id == &record.id
+                        && path == &record.target_path
+                        && mode == &record.mode
+                        && status == &record.status
+                        && source_hash == &record.source_hash
+                }
+                _ => false,
+            };
+            if !unchanged {
+                return Err(anyhow::anyhow!(
+                    "target record changed while the Preset operation was running: {}/{}",
+                    target.skill_id,
+                    target.tool
+                ));
+            }
+        }
+
+        {
+            let mut stmt = tx.prepare(
+                "INSERT OR REPLACE INTO skill_targets (id, skill_id, tool, target_path, mode, status, synced_at, last_error, source_hash)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            )?;
+            for target in targets {
+                stmt.execute(params![
+                    target.id,
+                    target.skill_id,
+                    target.tool,
+                    target.target_path,
+                    target.mode,
+                    target.status,
+                    target.synced_at,
+                    target.last_error,
+                    target.source_hash,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// 只删除调用方刚刚读取到的精确记录，并在任一记录已变化时整体回滚。
+    ///
+    /// 与按 `(skill_id, tool)` 无条件删除相比，快照 ID 和路径校验可避免并发写入
+    /// 被本次 Preset 移除误删。进程内写锁负责正常桌面调用的串行化，此校验则
+    /// 为数据库层再提供一道失败即停止的保护。
+    pub fn delete_targets_exact_atomic(&self, targets: &[SkillTargetRecord]) -> Result<()> {
+        if targets.is_empty() {
+            return Ok(());
+        }
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "DELETE FROM skill_targets
+                 WHERE id = ?1 AND skill_id = ?2 AND tool = ?3 AND target_path = ?4",
+            )?;
+            for target in targets {
+                let changed = stmt.execute(params![
+                    target.id,
+                    target.skill_id,
+                    target.tool,
+                    target.target_path,
+                ])?;
+                if changed != 1 {
+                    return Err(anyhow::anyhow!(
+                        "target record changed while the Preset operation was running: {}/{}",
+                        target.skill_id,
+                        target.tool
+                    ));
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     pub fn get_targets_for_skill(&self, skill_id: &str) -> Result<Vec<SkillTargetRecord>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
@@ -482,7 +597,7 @@ impl SkillStore {
                 source_hash: row.get(8)?,
             })
         })?;
-        Ok(rows.filter_map(|r| r.ok()).collect())
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
     pub fn get_all_targets(&self) -> Result<Vec<SkillTargetRecord>> {
@@ -503,7 +618,7 @@ impl SkillStore {
                 source_hash: row.get(8)?,
             })
         })?;
-        Ok(rows.filter_map(|r| r.ok()).collect())
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
     pub fn delete_target(&self, skill_id: &str, tool: &str) -> Result<()> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,14 +10,6 @@ pub mod core;
 /// Shared flag: when true, CloseRequested should NOT be prevented.
 pub static QUITTING: AtomicBool = AtomicBool::new(false);
 
-/// Guards concurrent preset apply/remove from the tray so a quick double-click
-/// can't fire two batches at once. Intentionally separate from the
-/// `TRAY_CHECK_UPDATES_RUNNING` flag — update checks only touch
-/// `update_status` while preset apply touches `skill_targets`, so the two are
-/// orthogonal and shouldn't block each other. Sharing the lock would silently
-/// drop preset clicks during long-running update checks.
-static TRAY_PRESET_APPLY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 /// Tracks whether a manual "Check for skill updates" is currently running so the
 /// tray menu can render a disabled "Checking for updates..." label.
 static TRAY_CHECK_UPDATES_RUNNING: AtomicBool = AtomicBool::new(false);
@@ -459,9 +451,9 @@ fn apply_preset_from_tray<R: tauri::Runtime>(
         //               frontend about state changes that didn't occur)
         //   Err(_)    — failure inside the batch
         let result = tauri::async_runtime::spawn_blocking(move || -> Result<bool, String> {
-            let _guard = match TRAY_PRESET_APPLY_LOCK.try_lock() {
-                Ok(guard) => guard,
-                Err(_) => {
+            let _guard = match core::scenario_service::try_lock_preset_apply() {
+                Some(guard) => guard,
+                None => {
                     log::debug!(
                         "Another preset apply in flight, ignoring tray click for {preset_id_for_task}"
                     );
@@ -540,7 +532,7 @@ fn check_updates_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
 
     tauri::async_runtime::spawn(async move {
         let store_for_task = store.clone();
-        // Note: this intentionally does NOT take TRAY_PRESET_APPLY_LOCK.
+        // Note: this intentionally does NOT take the preset apply lock.
         // Update checks only mutate `update_status` columns; preset apply
         // mutates `skill_targets`. They're orthogonal, and sharing a lock
         // would silently drop preset clicks made during a long-running check.
@@ -1067,6 +1059,7 @@ pub fn run() {
             commands::presets::switch_preset,
             commands::presets::apply_preset_to_default,
             commands::presets::apply_preset_to_coding_agents,
+            commands::presets::apply_preset_to_tools,
             commands::presets::add_skill_to_preset,
             commands::presets::remove_skill_from_preset,
             commands::presets::reorder_presets,

--- a/src/components/PresetBar.test.tsx
+++ b/src/components/PresetBar.test.tsx
@@ -1,0 +1,333 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { PresetBar } from "./PresetBar";
+import type { ManagedSkill, Preset } from "../lib/tauri";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const preset = (id: string, name: string): Preset => ({
+  id,
+  name,
+  description: null,
+  icon: null,
+  sort_order: 0,
+  skill_count: 1,
+  created_at: 0,
+  updated_at: 0,
+});
+
+const skill = (id: string, presetId: string): ManagedSkill => ({
+  id,
+  name: id,
+  description: null,
+  source_type: "local",
+  source_ref: null,
+  source_ref_resolved: null,
+  source_subpath: null,
+  source_branch: null,
+  source_revision: null,
+  remote_revision: null,
+  update_status: "unknown",
+  last_checked_at: null,
+  last_check_error: null,
+  central_path: `C:\\skills\\${id}`,
+  enabled: true,
+  created_at: 0,
+  updated_at: 0,
+  status: "ready",
+  targets: [],
+  preset_ids: [presetId],
+  tags: [],
+});
+
+const presets = [
+  preset("preset-a", "11-软件工程-核心交付"),
+  preset("preset-b", "12-软件工程-架构规划"),
+];
+const managedSkills = [
+  skill("skill-a", "preset-a"),
+  skill("skill-b", "preset-b"),
+];
+
+describe("PresetBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("始终换行展示完整的 Preset 名称", () => {
+    render(
+      <PresetBar
+        presets={presets}
+        managedSkills={managedSkills}
+        agentKeys={["codex"]}
+        scopeKey="global:codex"
+        existsInWorkspace={() => false}
+        onApplyPreset={vi.fn().mockResolvedValue({ applied: 0, skipped: 0, failures: [] })}
+        onComplete={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    const list = screen.getByTestId("preset-list");
+    expect(list).toHaveClass("flex-wrap");
+    expect(list).not.toHaveClass("overflow-x-auto");
+
+    const fullLabel = screen.getByText("11-软件工程-核心交付");
+    expect(fullLabel).toHaveClass("whitespace-nowrap");
+    expect(fullLabel).not.toHaveClass("truncate");
+  });
+
+  it("显示没有成员的 Preset，但禁止执行空操作", () => {
+    const emptyPreset = preset("preset-empty", "99-未分类");
+    render(
+      <PresetBar
+        presets={[...presets, emptyPreset]}
+        managedSkills={managedSkills}
+        agentKeys={["codex"]}
+        scopeKey="global:codex"
+        existsInWorkspace={() => false}
+        onApplyPreset={vi.fn().mockResolvedValue({ applied: 0, skipped: 0, failures: [] })}
+        onComplete={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /99-未分类/ })).toBeDisabled();
+  });
+
+  it("批量失败时展示前三项明细并把完整报告写入控制台", async () => {
+    const failures = [
+      { skillId: "skill-1", toolKey: "codex", message: "disk full" },
+      { skillId: "skill-2", toolKey: "codex", message: "permission denied" },
+      { skillId: "skill-3", toolKey: "codex", message: "source missing" },
+      { skillId: "skill-4", toolKey: "codex", message: "database busy" },
+    ];
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <PresetBar
+        presets={presets}
+        managedSkills={managedSkills}
+        agentKeys={["codex"]}
+        scopeKey="global:codex"
+        existsInWorkspace={() => false}
+        onApplyPreset={vi.fn().mockResolvedValue({
+          applied: 0,
+          skipped: 0,
+          failures,
+        })}
+        onComplete={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /11-软件工程-核心交付/ }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "presetActions.partialFailedToast",
+        expect.objectContaining({
+          description: expect.stringContaining("skill-1 · codex: disk full"),
+        })
+      );
+    });
+    const toastOptions = vi.mocked(toast.error).mock.calls[0]?.[1] as
+      | { description?: string }
+      | undefined;
+    expect(toastOptions?.description).toContain("skill-2 · codex: permission denied");
+    expect(toastOptions?.description).toContain("skill-3 · codex: source missing");
+    expect(toastOptions?.description).not.toContain("skill-4 · codex: database busy");
+    expect(consoleError).toHaveBeenCalledWith(
+      "[PresetBar] Preset apply failures",
+      failures
+    );
+  });
+
+  it("连续点击不同 Preset 时按 FIFO 执行，且不禁用未入队项", async () => {
+    let resolveFirst!: () => void;
+    const first = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const callOrder: string[] = [];
+    const onApplyPreset = vi.fn(async (selected: Preset) => {
+      callOrder.push(`start:${selected.id}`);
+      if (selected.id === "preset-a") await first;
+      callOrder.push(`end:${selected.id}`);
+      return { applied: 1, skipped: 0, failures: [] };
+    });
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <PresetBar
+        presets={presets}
+        managedSkills={managedSkills}
+        agentKeys={["codex"]}
+        scopeKey="global:codex"
+        existsInWorkspace={() => false}
+        onApplyPreset={onApplyPreset}
+        onComplete={onComplete}
+      />
+    );
+
+    const firstButton = screen.getByRole("button", { name: /11-软件工程-核心交付/ });
+    const secondButton = screen.getByRole("button", { name: /12-软件工程-架构规划/ });
+    fireEvent.click(firstButton);
+
+    expect(firstButton).toBeDisabled();
+    expect(secondButton).not.toBeDisabled();
+
+    fireEvent.click(secondButton);
+    expect(secondButton).toBeDisabled();
+    expect(onApplyPreset).toHaveBeenCalledTimes(1);
+
+    resolveFirst();
+
+    await waitFor(() => expect(onApplyPreset).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(callOrder).toEqual([
+      "start:preset-a",
+      "end:preset-a",
+      "start:preset-b",
+      "end:preset-b",
+    ]);
+  });
+
+  it("同一个 Preset 在队列中时忽略重复点击", async () => {
+    let resolveApply!: () => void;
+    const applying = new Promise<void>((resolve) => {
+      resolveApply = resolve;
+    });
+    const onApplyPreset = vi.fn(async () => {
+      await applying;
+      return { applied: 1, skipped: 0, failures: [] };
+    });
+
+    render(
+      <PresetBar
+        presets={presets}
+        managedSkills={managedSkills}
+        agentKeys={["codex"]}
+        scopeKey="global:codex"
+        existsInWorkspace={() => false}
+        onApplyPreset={onApplyPreset}
+        onComplete={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: /11-软件工程-核心交付/ });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(onApplyPreset).toHaveBeenCalledTimes(1);
+
+    resolveApply();
+    await waitFor(() => expect(button).not.toBeDisabled());
+    expect(onApplyPreset).toHaveBeenCalledTimes(1);
+  });
+
+  it("切换 Agent 后允许同名 Preset 以新作用域入队，并使用新 Agent 的回调", async () => {
+    let resolveCodex1!: () => void;
+    const codex1Pending = new Promise<void>((resolve) => {
+      resolveCodex1 = resolve;
+    });
+    const applyCodex1 = vi.fn(async () => {
+      await codex1Pending;
+      return { applied: 1, skipped: 0, failures: [] };
+    });
+    const applyCodex2 = vi.fn().mockResolvedValue({
+      applied: 1,
+      skipped: 0,
+      failures: [],
+    });
+    const completeCodex1 = vi.fn().mockResolvedValue(undefined);
+    const completeCodex2 = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = render(
+      <PresetBar
+        presets={presets}
+        managedSkills={managedSkills}
+        agentKeys={["codex"]}
+        scopeKey="global:codex"
+        existsInWorkspace={() => false}
+        onApplyPreset={applyCodex1}
+        onComplete={completeCodex1}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /11-软件工程-核心交付/ }));
+
+    rerender(
+      <PresetBar
+        presets={presets}
+        managedSkills={managedSkills}
+        agentKeys={["codex_2"]}
+        scopeKey="global:codex_2"
+        existsInWorkspace={() => false}
+        onApplyPreset={applyCodex2}
+        onComplete={completeCodex2}
+      />
+    );
+    const codex2Button = screen.getByRole("button", { name: /11-软件工程-核心交付/ });
+    expect(codex2Button).not.toBeDisabled();
+    fireEvent.click(codex2Button);
+
+    resolveCodex1();
+
+    await waitFor(() => expect(applyCodex2).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(completeCodex2).toHaveBeenCalledTimes(1));
+    expect(applyCodex1).toHaveBeenCalledTimes(1);
+    expect(completeCodex1).not.toHaveBeenCalled();
+  });
+
+  it("切换 Agent 后即使没有新操作也只刷新当前页面", async () => {
+    let resolveCodex1!: () => void;
+    const codex1Pending = new Promise<void>((resolve) => {
+      resolveCodex1 = resolve;
+    });
+    const applyCodex1 = vi.fn(async () => {
+      await codex1Pending;
+      return { applied: 1, skipped: 0, failures: [] };
+    });
+    const completeCodex1 = vi.fn().mockResolvedValue(undefined);
+    const completeCodex2 = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = render(
+      <PresetBar
+        presets={presets}
+        managedSkills={managedSkills}
+        agentKeys={["codex"]}
+        scopeKey="global:codex"
+        existsInWorkspace={() => false}
+        onApplyPreset={applyCodex1}
+        onComplete={completeCodex1}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /11-软件工程-核心交付/ }));
+
+    rerender(
+      <PresetBar
+        presets={presets}
+        managedSkills={managedSkills}
+        agentKeys={["codex_2"]}
+        scopeKey="global:codex_2"
+        existsInWorkspace={() => false}
+        onApplyPreset={vi.fn().mockResolvedValue({ applied: 1, skipped: 0, failures: [] })}
+        onComplete={completeCodex2}
+      />
+    );
+    resolveCodex1();
+
+    await waitFor(() => expect(completeCodex2).toHaveBeenCalledTimes(1));
+    expect(completeCodex1).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/PresetBar.tsx
+++ b/src/components/PresetBar.tsx
@@ -1,34 +1,55 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Check, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { cn } from "../utils";
 import { computePresetStatus } from "../lib/presetStatus";
 import { getPresetIconOption } from "../lib/presetIcons";
-import type { ManagedSkill, Preset } from "../lib/tauri";
+import type {
+  ManagedSkill,
+  Preset,
+  PresetApplyMode,
+  PresetApplyReport,
+} from "../lib/tauri";
 import { getErrorMessage } from "../lib/error";
 
 export interface PresetBarProps {
   presets: Preset[];
   managedSkills: ManagedSkill[];
   agentKeys: string[];
+  scopeKey: string;
   existsInWorkspace: (skill: ManagedSkill, agentKey: string) => boolean;
-  onAddSkill: (skill: ManagedSkill, agentKey: string) => Promise<void>;
-  onRemoveSkill: (skill: ManagedSkill, agentKey: string) => Promise<void>;
+  onApplyPreset: (preset: Preset, mode: PresetApplyMode) => Promise<PresetApplyReport>;
   onComplete: () => Promise<void>;
 }
+
+interface QueuedPresetOperation {
+  preset: Preset;
+  mode: PresetApplyMode;
+  applyPreset: PresetBarProps["onApplyPreset"];
+}
+
+const getPendingOperationKey = (scopeKey: string, presetId: string) =>
+  JSON.stringify([scopeKey, presetId]);
 
 export function PresetBar({
   presets,
   managedSkills,
   agentKeys,
+  scopeKey,
   existsInWorkspace,
-  onAddSkill,
-  onRemoveSkill,
+  onApplyPreset,
   onComplete,
 }: PresetBarProps) {
   const { t } = useTranslation();
-  const [loadingKey, setLoadingKey] = useState<string | null>(null);
+  const queueRef = useRef<QueuedPresetOperation[]>([]);
+  const processingRef = useRef(false);
+  const pendingOperationKeysRef = useRef(new Set<string>());
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+  const [pendingOperationKeys, setPendingOperationKeys] = useState<Set<string>>(
+    () => new Set()
+  );
 
   const statuses = useMemo(() => {
     const map = new Map<string, ReturnType<typeof computePresetStatus>>();
@@ -38,86 +59,115 @@ export function PresetBar({
     return map;
   }, [presets, managedSkills, agentKeys, existsInWorkspace]);
 
-  const visiblePresets = useMemo(
-    () => presets.filter((p) => statuses.get(p.id)?.status !== "empty"),
-    [presets, statuses]
-  );
-
-  const handleActivate = useCallback(async (preset: Preset) => {
-    setLoadingKey(`${preset.id}-add`);
-    try {
-      const presetSkills = managedSkills.filter((s) => s.preset_ids.includes(preset.id));
-      let added = 0, skipped = 0, failed = 0;
-      for (const skill of presetSkills) {
-        for (const agentKey of agentKeys) {
-          if (existsInWorkspace(skill, agentKey)) { skipped++; continue; }
-          try { await onAddSkill(skill, agentKey); added++; }
-          catch { failed++; }
-        }
-      }
-      if (added > 0) {
-        toast.success(t("presetActions.addedToast", { added, skipped }));
+  const showResultToast = useCallback((mode: PresetApplyMode, report: PresetApplyReport) => {
+    const failed = report.failures.length;
+    if (mode === "add") {
+      if (report.applied > 0) {
+        toast.success(t("presetActions.addedToast", {
+          added: report.applied,
+          skipped: report.skipped,
+        }));
       } else if (failed === 0) {
         toast.info(t("presetActions.nothingToAdd"));
       }
-      if (failed > 0) toast.error(t("presetActions.partialFailedToast", { count: failed }));
-      await onComplete();
-    } catch (error) {
-      toast.error(getErrorMessage(error, t("common.error")));
-    } finally {
-      setLoadingKey(null);
-    }
-  }, [agentKeys, existsInWorkspace, managedSkills, onAddSkill, onComplete, t]);
-
-  const handleDeactivate = useCallback(async (preset: Preset) => {
-    setLoadingKey(`${preset.id}-remove`);
-    try {
-      const presetSkills = managedSkills.filter((s) => s.preset_ids.includes(preset.id));
-      let removed = 0, failed = 0;
-      for (const skill of presetSkills) {
-        for (const agentKey of agentKeys) {
-          if (!existsInWorkspace(skill, agentKey)) continue;
-          try { await onRemoveSkill(skill, agentKey); removed++; }
-          catch { failed++; }
-        }
-      }
-      if (removed > 0) {
-        toast.success(t("presetActions.removedToast", { removed }));
+    } else {
+      if (report.applied > 0) {
+        toast.success(t("presetActions.removedToast", { removed: report.applied }));
       } else if (failed === 0) {
         toast.info(t("presetActions.nothingToRemove"));
       }
-      if (failed > 0) toast.error(t("presetActions.partialFailedToast", { count: failed }));
-      await onComplete();
-    } catch (error) {
-      toast.error(getErrorMessage(error, t("common.error")));
-    } finally {
-      setLoadingKey(null);
     }
-  }, [agentKeys, existsInWorkspace, managedSkills, onComplete, onRemoveSkill, t]);
+    if (failed > 0) {
+      // Toast 保持简短，只展示前三项可操作信息；完整报告写入控制台，
+      // 既避免大量失败撑满界面，也让排障时不会丢失后续错误。
+      const failurePreview = report.failures
+        .slice(0, 3)
+        .map(({ skillId, toolKey, message }) => `${skillId} · ${toolKey}: ${message}`)
+        .join("\n");
+      console.error("[PresetBar] Preset apply failures", report.failures);
+      toast.error(t("presetActions.partialFailedToast", { count: failed }), {
+        description: failurePreview,
+      });
+    }
+  }, [t]);
 
-  if (visiblePresets.length === 0) return null;
+  const drainQueue = useCallback(async () => {
+    if (processingRef.current) return;
+    processingRef.current = true;
 
-  const busy = loadingKey !== null;
+    try {
+      // 队列按点击顺序串行执行，避免多个 Preset 同时复制重叠目录或竞争
+      // SQLite；刷新期间新加入的操作会在刷新结束后继续处理。
+      do {
+        let operation = queueRef.current.shift();
+        while (operation) {
+          try {
+            const report = await operation.applyPreset(operation.preset, operation.mode);
+            showResultToast(operation.mode, report);
+          } catch (error) {
+            toast.error(getErrorMessage(error, t("common.error")));
+          }
+          operation = queueRef.current.shift();
+        }
+
+        try {
+          // apply 回调必须快照精确 Agent；完成刷新则必须使用当前页面的最新
+          // 回调，避免从 Agent A 导航到 Agent B 后旧请求把 A 的列表写进 B 页面。
+          await onCompleteRef.current();
+        } catch (error) {
+          toast.error(getErrorMessage(error, t("common.error")));
+        }
+      } while (queueRef.current.length > 0);
+    } finally {
+      pendingOperationKeysRef.current.clear();
+      setPendingOperationKeys(new Set());
+      processingRef.current = false;
+    }
+  }, [showResultToast, t]);
+
+  const enqueuePreset = useCallback((preset: Preset, mode: PresetApplyMode) => {
+    // Preset ID 只在同一作用域内去重；Agent A/B 或 Project A/B 即使使用同名
+    // Preset，也必须能够各自加入同一条 FIFO 队列。
+    const operationKey = getPendingOperationKey(scopeKey, preset.id);
+    if (pendingOperationKeysRef.current.has(operationKey)) return;
+
+    pendingOperationKeysRef.current.add(operationKey);
+    setPendingOperationKeys(new Set(pendingOperationKeysRef.current));
+    // 路由切换时组件可能被复用；把当前 Agent 对应的回调快照到队列项，
+    // 防止 Agent B 的后续点击被仍在运行的 Agent A 队列错误提交到 A。
+    queueRef.current.push({
+      preset,
+      mode,
+      applyPreset: onApplyPreset,
+    });
+    void drainQueue();
+  }, [drainQueue, onApplyPreset, scopeKey]);
+
+  if (presets.length === 0) return null;
 
   return (
-    <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-      <span className="shrink-0 text-[12px] text-muted">{t("sidebar.presets")}</span>
-      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto scrollbar-hide">
-        {visiblePresets.map((preset) => {
+    <div className="flex min-w-0 flex-wrap items-start gap-1.5">
+      <span className="shrink-0 pt-0.5 text-[12px] text-muted">{t("sidebar.presets")}</span>
+      <div
+        data-testid="preset-list"
+        className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5"
+      >
+        {presets.map((preset) => {
           const s = statuses.get(preset.id)!;
           const presetIcon = getPresetIconOption(preset);
           const Icon = presetIcon.icon;
-          const isLoading = loadingKey?.startsWith(preset.id) ?? false;
+          const isPending = pendingOperationKeys.has(
+            getPendingOperationKey(scopeKey, preset.id)
+          );
 
           return (
             <button
               key={preset.id}
               onClick={() => {
-                if (busy) return;
-                if (s.status === "active") handleDeactivate(preset);
-                else handleActivate(preset);
+                enqueuePreset(preset, s.status === "active" ? "remove" : "add");
               }}
-              disabled={busy}
+              disabled={isPending || s.status === "empty"}
+              aria-busy={isPending}
               title={preset.name}
               className={cn(
                 "inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-0.5 text-[12px] font-medium transition-colors disabled:opacity-50",
@@ -128,14 +178,19 @@ export function PresetBar({
                   : "border-border-subtle text-faint hover:border-border hover:text-muted"
               )}
             >
-              {isLoading
+              {isPending
                 ? <Loader2 className="h-3 w-3 animate-spin" />
                 : <Icon className="h-3 w-3" />}
-              <span className="max-w-[140px] truncate">{preset.name}</span>
+              <span className="whitespace-nowrap">{preset.name}</span>
               {s.status === "active" && <Check className="h-3 w-3 shrink-0" />}
               {s.status === "partial" && (
                 <span className="rounded-full bg-amber-500/20 px-1.5 py-px text-[10px] font-semibold">
                   {s.installed}/{s.total}
+                </span>
+              )}
+              {s.status === "empty" && (
+                <span className="rounded-full bg-surface-hover px-1.5 py-px text-[10px] font-semibold">
+                  0
                 </span>
               )}
             </button>

--- a/src/lib/latestRequestGate.test.ts
+++ b/src/lib/latestRequestGate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { LatestRequestGate } from "./latestRequestGate";
+
+describe("LatestRequestGate", () => {
+  it("同一作用域只允许最后开始的请求提交结果", () => {
+    const gate = new LatestRequestGate();
+    gate.setScope("project-a");
+
+    const first = gate.begin("project-a");
+    const second = gate.begin("project-a");
+
+    expect(gate.isCurrent(first)).toBe(false);
+    expect(gate.isCurrent(second)).toBe(true);
+  });
+
+  it("切换作用域会立即使旧项目请求失效", () => {
+    const gate = new LatestRequestGate();
+    gate.setScope("project-a");
+    const projectARequest = gate.begin("project-a");
+
+    gate.setScope("project-b");
+    const projectBRequest = gate.begin("project-b");
+
+    expect(gate.isCurrent(projectARequest)).toBe(false);
+    expect(gate.isCurrent(projectBRequest)).toBe(true);
+  });
+
+  it("旧作用域的延迟回调不能重新夺回当前作用域", () => {
+    const gate = new LatestRequestGate();
+    gate.setScope("project-a");
+    gate.begin("project-a");
+
+    gate.setScope("project-b");
+    const projectBRequest = gate.begin("project-b");
+    const delayedProjectARequest = gate.begin("project-a");
+
+    expect(gate.isCurrent(delayedProjectARequest)).toBe(false);
+    expect(gate.isCurrent(projectBRequest)).toBe(true);
+  });
+
+  it("组件卸载时可以显式使尚未完成的请求失效", () => {
+    const gate = new LatestRequestGate();
+    gate.setScope("project-a");
+    const request = gate.begin("project-a");
+
+    gate.invalidate();
+
+    expect(gate.isCurrent(request)).toBe(false);
+  });
+});

--- a/src/lib/latestRequestGate.ts
+++ b/src/lib/latestRequestGate.ts
@@ -1,0 +1,44 @@
+export interface LatestRequestToken {
+  id: number;
+  scopeKey: string;
+}
+
+/**
+ * 为异步读取提供“最后一次请求生效”门禁。
+ *
+ * `setScope` 应在 committed layout effect 中响应路由变化，避免 render
+ * 副作用；`begin` 则让同一作用域中较晚发起的静默刷新取代较早的前台读取。
+ */
+export class LatestRequestGate {
+  private sequence = 0;
+  private activeScope: string | null = null;
+  private latestRequestId = 0;
+
+  setScope(scopeKey: string | null) {
+    if (this.activeScope === scopeKey) return;
+    this.activeScope = scopeKey;
+    this.latestRequestId = ++this.sequence;
+  }
+
+  begin(scopeKey: string): LatestRequestToken {
+    // 路由切换必须只由 committed layout effect 更新作用域。旧页面捕获的异步回调
+    // 可能在新页面提交后才开始刷新；此时不能让它把作用域重新切回旧页面。
+    if (this.activeScope !== scopeKey) {
+      return { id: -1, scopeKey };
+    }
+    const token = { id: ++this.sequence, scopeKey };
+    this.latestRequestId = token.id;
+    return token;
+  }
+
+  isCurrent(token: LatestRequestToken) {
+    return (
+      this.activeScope === token.scopeKey &&
+      this.latestRequestId === token.id
+    );
+  }
+
+  invalidate() {
+    this.latestRequestId = ++this.sequence;
+  }
+}

--- a/src/lib/projectAgentScope.test.ts
+++ b/src/lib/projectAgentScope.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  getReadyProjectAgentScope,
+  type ProjectAgentScopeState,
+} from "./projectAgentScope";
+
+const readyProjectA: ProjectAgentScopeState = {
+  projectId: "project-a",
+  status: "ready",
+  targets: [
+    {
+      key: "codex",
+      display_name: "Codex",
+      enabled: true,
+      installed: true,
+      is_custom: false,
+    },
+  ],
+  selectedExportAgents: ["codex"],
+};
+
+describe("getReadyProjectAgentScope", () => {
+  it("A 项目的已加载状态在路由切到 B 后立即不可用", () => {
+    expect(getReadyProjectAgentScope(readyProjectA, "project-b")).toBeNull();
+  });
+
+  it("当前项目仍在加载 targets 时不能启用 Preset", () => {
+    const loadingProjectB: ProjectAgentScopeState = {
+      projectId: "project-b",
+      status: "loading",
+      targets: [],
+      selectedExportAgents: [],
+    };
+
+    expect(
+      getReadyProjectAgentScope(loadingProjectB, "project-b")
+    ).toBeNull();
+  });
+
+  it("只有当前项目 targets 完整加载后才返回其选择状态", () => {
+    expect(getReadyProjectAgentScope(readyProjectA, "project-a")).toEqual(
+      readyProjectA
+    );
+  });
+});

--- a/src/lib/projectAgentScope.ts
+++ b/src/lib/projectAgentScope.ts
@@ -1,0 +1,38 @@
+import type { ProjectAgentTarget } from "./tauri";
+
+export type ProjectAgentScopeStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "error";
+
+export interface ProjectAgentScopeState {
+  projectId: string | null;
+  status: ProjectAgentScopeStatus;
+  targets: ProjectAgentTarget[];
+  selectedExportAgents: string[];
+}
+
+/**
+ * 只暴露与当前路由项目完全匹配的 Agent 状态。
+ *
+ * React 路由可能先 render Project B，再由 effect 发起 B 的 targets 请求；
+ * 这段纯函数确保该时间窗内 Project A 的已加载 targets 和默认选择不可见。
+ */
+export function getActiveProjectAgentScope(
+  state: ProjectAgentScopeState,
+  currentProjectId: string | undefined
+) {
+  if (!currentProjectId || state.projectId !== currentProjectId) {
+    return null;
+  }
+  return state;
+}
+
+export function getReadyProjectAgentScope(
+  state: ProjectAgentScopeState,
+  currentProjectId: string | undefined
+) {
+  const activeScope = getActiveProjectAgentScope(state, currentProjectId);
+  return activeScope?.status === "ready" ? activeScope : null;
+}

--- a/src/lib/projectPresetApply.test.ts
+++ b/src/lib/projectPresetApply.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import { applyProjectPresetOperation } from "./projectPresetApply";
+import type { ManagedSkill, ProjectSkill } from "./tauri";
+
+const managedSkill = (
+  id: string,
+  presetIds: string[]
+): ManagedSkill => ({
+  id,
+  name: id,
+  description: null,
+  source_type: "local",
+  source_ref: null,
+  source_ref_resolved: null,
+  source_subpath: null,
+  source_branch: null,
+  source_revision: null,
+  remote_revision: null,
+  update_status: "unknown",
+  last_checked_at: null,
+  last_check_error: null,
+  central_path: `C:\\skills\\${id}`,
+  enabled: true,
+  created_at: 0,
+  updated_at: 0,
+  status: "ready",
+  targets: [],
+  preset_ids: presetIds,
+  tags: [],
+});
+
+const projectSkill = (
+  centerSkillId: string,
+  agent: string
+): ProjectSkill => ({
+  name: centerSkillId,
+  dir_name: centerSkillId,
+  relative_path: centerSkillId,
+  description: null,
+  path: `C:\\project\\${centerSkillId}`,
+  files: ["SKILL.md"],
+  enabled: true,
+  agent,
+  agent_display_name: agent,
+  tags: [],
+  in_center: true,
+  sync_status: "in_sync",
+  center_skill_id: centerSkillId,
+});
+
+describe("applyProjectPresetOperation", () => {
+  it("每次队列操作都重新读取项目状态，因此重叠 Preset 不会重复导出", async () => {
+    const shared = managedSkill("shared", ["preset-a", "preset-b"]);
+    let liveSkills: ProjectSkill[] = [];
+    const loadProjectSkills = vi.fn(async () => [...liveSkills]);
+    const addSkill = vi.fn(async (skillId: string, agentKey: string) => {
+      liveSkills = [projectSkill(skillId, agentKey)];
+    });
+
+    const common = {
+      mode: "add" as const,
+      managedSkills: [shared],
+      agentKeys: ["codex"],
+      loadProjectSkills,
+      addSkill,
+      removeSkill: vi.fn(),
+      formatError: (error: unknown) => String(error),
+    };
+
+    const first = await applyProjectPresetOperation({
+      ...common,
+      presetId: "preset-a",
+    });
+    const second = await applyProjectPresetOperation({
+      ...common,
+      presetId: "preset-b",
+    });
+
+    expect(first).toEqual({ applied: 1, skipped: 0, failures: [] });
+    expect(second).toEqual({ applied: 0, skipped: 1, failures: [] });
+    expect(loadProjectSkills).toHaveBeenCalledTimes(2);
+    expect(addSkill).toHaveBeenCalledTimes(1);
+  });
+
+  it("移除操作也使用实时状态，因此重叠 Preset 不会重复删除", async () => {
+    const shared = managedSkill("shared", ["preset-a", "preset-b"]);
+    let liveSkills: ProjectSkill[] = [projectSkill("shared", "codex")];
+    const loadProjectSkills = vi.fn(async () => [...liveSkills]);
+    const removeSkill = vi.fn(async () => {
+      liveSkills = [];
+    });
+
+    const common = {
+      mode: "remove" as const,
+      managedSkills: [shared],
+      agentKeys: ["codex"],
+      loadProjectSkills,
+      addSkill: vi.fn(),
+      removeSkill,
+      formatError: (error: unknown) => String(error),
+    };
+
+    const first = await applyProjectPresetOperation({
+      ...common,
+      presetId: "preset-a",
+    });
+    const second = await applyProjectPresetOperation({
+      ...common,
+      presetId: "preset-b",
+    });
+
+    expect(first).toEqual({ applied: 1, skipped: 0, failures: [] });
+    expect(second).toEqual({ applied: 0, skipped: 1, failures: [] });
+    expect(loadProjectSkills).toHaveBeenCalledTimes(2);
+    expect(removeSkill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/projectPresetApply.ts
+++ b/src/lib/projectPresetApply.ts
@@ -1,0 +1,84 @@
+import type {
+  ManagedSkill,
+  PresetApplyMode,
+  PresetApplyReport,
+  ProjectSkill,
+} from "./tauri";
+
+export interface ApplyProjectPresetOperationOptions {
+  presetId: string;
+  mode: PresetApplyMode;
+  managedSkills: ManagedSkill[];
+  agentKeys: string[];
+  loadProjectSkills: () => Promise<ProjectSkill[]>;
+  addSkill: (skillId: string, agentKey: string) => Promise<void>;
+  removeSkill: (skillRelativePath: string, agentKey: string) => Promise<void>;
+  formatError: (error: unknown) => string;
+}
+
+const projectVariantKey = (skillId: string, agentKey: string) =>
+  `${skillId}::${agentKey}`;
+
+export function indexProjectPresetVariants(skills: ProjectSkill[]) {
+  const variants = new Map<string, ProjectSkill>();
+  for (const skill of skills) {
+    if (!skill.center_skill_id) continue;
+    variants.set(projectVariantKey(skill.center_skill_id, skill.agent), skill);
+  }
+  return variants;
+}
+
+/**
+ * 将一个 Preset 操作应用到 Project Workspace。
+ *
+ * PresetBar 会把多次点击排进 FIFO，但出于性能考虑只在整批操作完成后刷新 React
+ * 状态。因此每个队列项必须在真正开始时重新扫描项目目录，不能使用入队时的旧快照；
+ * 否则两个含重叠 Skill 的 Preset 会重复导出，或重复删除同一目录。
+ */
+export async function applyProjectPresetOperation({
+  presetId,
+  mode,
+  managedSkills,
+  agentKeys,
+  loadProjectSkills,
+  addSkill,
+  removeSkill,
+  formatError,
+}: ApplyProjectPresetOperationOptions): Promise<PresetApplyReport> {
+  const liveVariants = indexProjectPresetVariants(await loadProjectSkills());
+  const report: PresetApplyReport = { applied: 0, skipped: 0, failures: [] };
+  const presetSkills = managedSkills.filter((skill) =>
+    skill.preset_ids.includes(presetId)
+  );
+
+  for (const skill of presetSkills) {
+    for (const agentKey of agentKeys) {
+      const existingVariant =
+        liveVariants.get(projectVariantKey(skill.id, agentKey)) ?? null;
+      if (
+        (mode === "add" && existingVariant) ||
+        (mode === "remove" && !existingVariant)
+      ) {
+        report.skipped += 1;
+        continue;
+      }
+
+      try {
+        if (mode === "add") {
+          await addSkill(skill.id, agentKey);
+        } else {
+          await removeSkill(existingVariant!.relative_path, agentKey);
+        }
+        report.applied += 1;
+      } catch (error) {
+        report.failures.push({
+          skillId: skill.id,
+          toolKey: agentKey,
+          message: formatError(error),
+        });
+      }
+    }
+  }
+
+  return report;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -707,6 +707,35 @@ export const switchPreset = (id: string) =>
 export const applyPresetToDefault = (id: string) =>
   invoke<void>("apply_preset_to_default", { id });
 
+export type PresetApplyMode = "add" | "remove";
+
+export interface PresetApplyFailure {
+  skillId: string;
+  toolKey: string;
+  message: string;
+}
+
+export interface PresetApplyReport {
+  applied: number;
+  skipped: number;
+  failures: PresetApplyFailure[];
+}
+
+/**
+ * 将 Preset 精确应用到传入的 Agent。后端会先统一校验目标，再逐项执行并
+ * 返回失败明细，避免前端为每个 Skill 发起一次 IPC。
+ */
+export const applyPresetToTools = (
+  presetId: string,
+  toolKeys: string[],
+  mode: PresetApplyMode
+) =>
+  invoke<PresetApplyReport>("apply_preset_to_tools", {
+    presetId,
+    toolKeys,
+    mode,
+  });
+
 export const addSkillToPreset = (skillId: string, presetId: string) =>
   invoke<void>("add_skill_to_preset", { skillId, presetId });
 

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -1,4 +1,11 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
   FolderOpen,
@@ -35,12 +42,30 @@ import { DocumentDiffViewer } from "../components/DocumentDiffViewer";
 import { getTagActiveColor, getTagColor, UNTAGGED_FILTER } from "../lib/skillTags";
 import { cn } from "../utils";
 import * as api from "../lib/tauri";
-import type { ProjectSkill, ManagedSkill, ProjectAgentTarget } from "../lib/tauri";
+import type {
+  ManagedSkill,
+  Preset,
+  PresetApplyMode,
+  PresetApplyReport,
+  ProjectAgentTarget,
+  ProjectSkill,
+} from "../lib/tauri";
 import { getErrorMessage } from "../lib/error";
+import {
+  applyProjectPresetOperation,
+  indexProjectPresetVariants,
+} from "../lib/projectPresetApply";
+import { LatestRequestGate } from "../lib/latestRequestGate";
+import {
+  getReadyProjectAgentScope,
+  type ProjectAgentScopeState,
+} from "../lib/projectAgentScope";
 import { AddSkillsSheet } from "../components/AddSkillsSheet";
 
 const PROJECT_DEFAULT_EXPORT_AGENTS_KEY = "project_default_export_agents";
 const PROJECT_EXPORT_AGENT_PRIORITY = ["claude_code", "codex", "cursor", "gemini_cli", "github_copilot"];
+const EMPTY_PROJECT_AGENT_TARGETS: ProjectAgentTarget[] = [];
+const EMPTY_AGENT_KEYS: string[] = [];
 
 const projectLastUsedAgentsKey = (projectId: string) =>
   `project_last_used_export_agents:${projectId}`;
@@ -158,8 +183,13 @@ export function ProjectDetail() {
   const { t } = useTranslation();
   const { projects, presets, managedSkills, refreshManagedSkills, refreshPresets, refreshProjects } = useApp();
   const [skills, setSkills] = useState<ProjectSkill[]>([]);
-  const [projectAgentTargets, setProjectAgentTargets] = useState<ProjectAgentTarget[]>([]);
-  const [selectedExportAgents, setSelectedExportAgents] = useState<string[]>([]);
+  const [projectAgentScope, setProjectAgentScope] =
+    useState<ProjectAgentScopeState>({
+      projectId: null,
+      status: "idle",
+      targets: [],
+      selectedExportAgents: [],
+    });
   const [loading, setLoading] = useState(true);
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [filterMode, setFilterMode] = useState<"all" | "enabled" | "disabled">("all");
@@ -198,41 +228,108 @@ export function ProjectDetail() {
   };
 
   const project = projects.find((p) => p.id === id);
+  const readyProjectAgentScope = getReadyProjectAgentScope(
+    projectAgentScope,
+    id
+  );
+  const projectAgentTargetsReady = readyProjectAgentScope !== null;
+  const projectAgentTargets =
+    readyProjectAgentScope?.targets ?? EMPTY_PROJECT_AGENT_TARGETS;
+  const selectedExportAgents =
+    readyProjectAgentScope?.selectedExportAgents ?? EMPTY_AGENT_KEYS;
+  const skillsRequestGateRef = useRef(new LatestRequestGate());
+  const loadingProjectRef = useRef<string | null>(null);
   const getSkillKey = useCallback((skill: Pick<ProjectSkillGroup, "id">) => {
     return skill.id;
   }, []);
 
-  const loadSkills = useCallback(async () => {
+  const loadSkills = useCallback(async (options?: { silent?: boolean }) => {
     if (!id) return;
-    setLoading(true);
+    const projectId = id;
+    const requestGate = skillsRequestGateRef.current;
+    const requestToken = requestGate.begin(projectId);
+    // 路由切换后，旧项目事件处理器可能才进入刷新阶段；门禁拒绝后必须立即
+    // 返回，不能重新打开新项目的全页 loading。
+    if (!requestGate.isCurrent(requestToken)) return;
+    const silent = options?.silent ?? false;
+    if (!silent) {
+      loadingProjectRef.current = projectId;
+      setLoading(true);
+    }
     try {
-      const result = await api.getProjectSkills(id);
-      setSkills(result);
+      const result = await api.getProjectSkills(projectId);
+      if (requestGate.isCurrent(requestToken)) {
+        setSkills(result);
+      }
     } catch (e) {
-      console.error("Failed to load project skills:", e);
+      if (requestGate.isCurrent(requestToken)) {
+        console.error("Failed to load project skills:", e);
+      }
     } finally {
-      setLoading(false);
+      // 较新的静默刷新也可以完成较早前台读取开启的 loading；旧请求本身
+      // 无权关闭新项目或更新请求的加载状态。
+      if (
+        requestGate.isCurrent(requestToken) &&
+        loadingProjectRef.current === projectId
+      ) {
+        loadingProjectRef.current = null;
+        setLoading(false);
+      }
     }
   }, [id]);
 
+  useLayoutEffect(() => {
+    const requestGate = skillsRequestGateRef.current;
+    requestGate.setScope(id ?? null);
+    loadingProjectRef.current = null;
+    // 已提交到新项目路由后，在浏览器绘制前清空旧项目卡片。这样除了
+    // PresetBar 之外，普通 Skill 操作也不会在被动 effect 启动前短暂作用
+    // 到“新项目 ID + 旧项目目录”这一错误组合。
+    setSkills([]);
+    setLoading(Boolean(id));
+    return () => {
+      requestGate.invalidate();
+    };
+  }, [id]);
+
   useEffect(() => {
-    loadSkills();
+    void loadSkills();
   }, [loadSkills]);
 
   useEffect(() => {
     let cancelled = false;
     const loadProjectAgentTargets = async () => {
       if (!id) return;
+      const projectId = id;
+      setProjectAgentScope({
+        projectId,
+        status: "loading",
+        targets: [],
+        selectedExportAgents: [],
+      });
       try {
-        const result = await api.getProjectAgentTargets(id);
+        const result = await api.getProjectAgentTargets(projectId);
         if (!cancelled) {
-          setProjectAgentTargets(result);
+          setProjectAgentScope({
+            projectId,
+            status: "ready",
+            targets: result,
+            selectedExportAgents: [],
+          });
         }
       } catch (e) {
-        console.error("Failed to load project agent targets:", e);
+        if (!cancelled) {
+          setProjectAgentScope({
+            projectId,
+            status: "error",
+            targets: [],
+            selectedExportAgents: [],
+          });
+          console.error("Failed to load project agent targets:", e);
+        }
       }
     };
-    loadProjectAgentTargets();
+    void loadProjectAgentTargets();
     return () => {
       cancelled = true;
     };
@@ -337,9 +434,10 @@ export function ProjectDetail() {
   });
 
   const exportTargets = useMemo(() => {
+    if (!projectAgentTargetsReady) return [];
     if (projectAgentTargets.length > 0) return projectAgentTargets;
     return [{ key: "claude_code", display_name: "Claude Code", enabled: true, installed: true, is_custom: false }];
-  }, [projectAgentTargets]);
+  }, [projectAgentTargets, projectAgentTargetsReady]);
 
   const projectSkillDirNamesByAgent = useMemo(() => {
     const map: Record<string, string[]> = {};
@@ -364,14 +462,10 @@ export function ProjectDetail() {
     return map;
   }, [skills]);
 
-  const projectPresetVariants = useMemo(() => {
-    const map = new Map<string, ProjectSkill>();
-    for (const skill of skills) {
-      if (!skill.center_skill_id) continue;
-      map.set(`${skill.center_skill_id}::${skill.agent}`, skill);
-    }
-    return map;
-  }, [skills]);
+  const projectPresetVariants = useMemo(
+    () => indexProjectPresetVariants(skills),
+    [skills]
+  );
 
   const findProjectPresetVariant = useCallback(
     (skill: ManagedSkill, agentKey: string) =>
@@ -380,42 +474,68 @@ export function ProjectDetail() {
   );
 
   useEffect(() => {
+    if (!id || !projectAgentTargetsReady) return;
+    const projectId = id;
     let cancelled = false;
     const loadDefaultExportAgents = async () => {
       const savedValue = await api.getSettings(PROJECT_DEFAULT_EXPORT_AGENTS_KEY).catch(() => null);
       if (cancelled) return;
-      setSelectedExportAgents(getDefaultExportAgents(exportTargets, savedValue));
+      const nextSelectedAgents = getDefaultExportAgents(exportTargets, savedValue);
+      setProjectAgentScope((current) => {
+        if (current.projectId !== projectId || current.status !== "ready") {
+          return current;
+        }
+        return {
+          ...current,
+          selectedExportAgents: nextSelectedAgents,
+        };
+      });
     };
-    loadDefaultExportAgents();
+    void loadDefaultExportAgents();
     return () => {
       cancelled = true;
     };
-  }, [exportTargets]);
+  }, [exportTargets, id, projectAgentTargetsReady]);
 
-  const [lastUsedExportAgents, setLastUsedExportAgents] = useState<string[] | null>(null);
+  const [lastUsedExportAgentsState, setLastUsedExportAgentsState] = useState<{
+    projectId: string;
+    agents: string[] | null;
+  } | null>(null);
+  const lastUsedExportAgents =
+    lastUsedExportAgentsState?.projectId === id
+      ? lastUsedExportAgentsState?.agents ?? null
+      : null;
   useEffect(() => {
     if (!id) return;
+    const projectId = id;
     let cancelled = false;
-    api.getSettings(projectLastUsedAgentsKey(id))
+    api.getSettings(projectLastUsedAgentsKey(projectId))
       .then((raw) => {
         if (cancelled) return;
         if (!raw) {
-          setLastUsedExportAgents(null);
+          setLastUsedExportAgentsState({ projectId, agents: null });
           return;
         }
         try {
           const parsed = JSON.parse(raw);
           if (Array.isArray(parsed)) {
-            setLastUsedExportAgents(parsed.filter((x): x is string => typeof x === "string"));
+            setLastUsedExportAgentsState({
+              projectId,
+              agents: parsed.filter(
+                (x): x is string => typeof x === "string"
+              ),
+            });
             return;
           }
         } catch {
           // fall through
         }
-        setLastUsedExportAgents(null);
+        setLastUsedExportAgentsState({ projectId, agents: null });
       })
       .catch(() => {
-        if (!cancelled) setLastUsedExportAgents(null);
+        if (!cancelled) {
+          setLastUsedExportAgentsState({ projectId, agents: null });
+        }
       });
     return () => {
       cancelled = true;
@@ -424,8 +544,8 @@ export function ProjectDetail() {
 
   const handlePersistLastUsedAgents = useCallback(
     (agents: string[]) => {
-      setLastUsedExportAgents(agents);
       if (id) {
+        setLastUsedExportAgentsState({ projectId: id, agents });
         void api.setSettings(projectLastUsedAgentsKey(id), JSON.stringify(agents)).catch(() => {});
       }
     },
@@ -445,6 +565,13 @@ export function ProjectDetail() {
     const availableKeys = new Set(enabledInstalledAgentKeys(exportTargets));
     return selectedExportAgents.filter((key) => availableKeys.has(key));
   }, [exportTargets, selectedExportAgents]);
+  const presetBarScopeKey = useMemo(
+    () =>
+      `project:${id ?? "missing"}:agents:${[...presetBarAgentKeys]
+        .sort()
+        .join("|")}`,
+    [id, presetBarAgentKeys]
+  );
 
   const enabledCount = groupedSkills.filter((s) => s.enabledCount > 0).length;
   const allTags = useMemo(() => {
@@ -792,26 +919,30 @@ export function ProjectDetail() {
     [findProjectPresetVariant]
   );
 
-  const handleAddPresetSkillToProject = useCallback(
-    async (skill: ManagedSkill, agentKey: string) => {
-      if (!id) return;
-      await api.exportSkillToProject(skill.id, id, [agentKey]);
-    },
-    [id]
-  );
+  const handleApplyPresetToProject = useCallback(
+    async (preset: Preset, mode: PresetApplyMode): Promise<PresetApplyReport> => {
+      if (!id) throw new Error(t("project.notFound"));
 
-  const handleRemovePresetSkillFromProject = useCallback(
-    async (skill: ManagedSkill, agentKey: string) => {
-      if (!id) return;
-      const projectVariant = findProjectPresetVariant(skill, agentKey);
-      if (!projectVariant) throw new Error(t("project.skillDirectoryNotFound"));
-      await api.deleteProjectSkill(id, projectVariant.relative_path, agentKey);
+      return applyProjectPresetOperation({
+        presetId: preset.id,
+        mode,
+        managedSkills,
+        agentKeys: presetBarAgentKeys,
+        // FIFO 只保证写操作串行；这里在每个队列项开始时读取真实目录，
+        // 才能正确识别前一个重叠 Preset 刚刚添加或删除的 Skill。
+        loadProjectSkills: () => api.getProjectSkills(id),
+        addSkill: (skillId, agentKey) =>
+          api.exportSkillToProject(skillId, id, [agentKey]),
+        removeSkill: (skillRelativePath, agentKey) =>
+          api.deleteProjectSkill(id, skillRelativePath, agentKey),
+        formatError: (error) => getErrorMessage(error, t("common.error")),
+      });
     },
-    [findProjectPresetVariant, id, t]
+    [id, managedSkills, presetBarAgentKeys, t]
   );
 
   const handlePresetActionComplete = useCallback(async () => {
-    await Promise.all([loadSkills(), refreshProjects()]);
+    await Promise.all([loadSkills({ silent: true }), refreshProjects()]);
   }, [loadSkills, refreshProjects]);
 
   if (!project) return null;
@@ -863,7 +994,7 @@ export function ProjectDetail() {
 
             <div className="app-segmented shrink-0">
               <button
-                onClick={loadSkills}
+                onClick={() => void loadSkills()}
                 className="rounded-md p-2 text-muted transition-colors outline-none hover:bg-surface-hover hover:text-secondary"
                 title={t("common.refresh")}
               >
@@ -991,17 +1122,19 @@ export function ProjectDetail() {
         )}
 
         {/* Preset bar */}
-        {presets.length > 0 && presetBarAgentKeys.length > 0 && (
-          <PresetBar
-            presets={presets}
-            managedSkills={managedSkills}
-            agentKeys={presetBarAgentKeys}
-            existsInWorkspace={presetSkillExistsInProject}
-            onAddSkill={handleAddPresetSkillToProject}
-            onRemoveSkill={handleRemovePresetSkillFromProject}
-            onComplete={handlePresetActionComplete}
-          />
-        )}
+        {projectAgentTargetsReady &&
+          presets.length > 0 &&
+          presetBarAgentKeys.length > 0 && (
+            <PresetBar
+              presets={presets}
+              managedSkills={managedSkills}
+              agentKeys={presetBarAgentKeys}
+              scopeKey={presetBarScopeKey}
+              existsInWorkspace={presetSkillExistsInProject}
+              onApplyPreset={handleApplyPresetToProject}
+              onComplete={handlePresetActionComplete}
+            />
+          )}
       </div>
 
       {isMultiSelect && (

--- a/src/views/WorkspaceView.tsx
+++ b/src/views/WorkspaceView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useParams, useNavigate, Navigate } from "react-router-dom";
 import {
   ChevronRight,
@@ -26,8 +26,14 @@ import { DetailSheet } from "../components/DetailSheet";
 import { SkillMarkdown } from "../components/SkillMarkdown";
 import { DocumentDiffViewer } from "../components/DocumentDiffViewer";
 import * as api from "../lib/tauri";
-import type { ManagedSkill, ProjectSkill } from "../lib/tauri";
+import type {
+  ManagedSkill,
+  Preset,
+  PresetApplyMode,
+  ProjectSkill,
+} from "../lib/tauri";
 import { getErrorMessage } from "../lib/error";
+import { LatestRequestGate } from "../lib/latestRequestGate";
 import { getTagActiveColor, getTagColor, UNTAGGED_FILTER } from "../lib/skillTags";
 import { AddSkillsSheet } from "../components/AddSkillsSheet";
 import type { WorkspaceConfig } from "./workspaceConfigs";
@@ -222,6 +228,7 @@ export function WorkspaceView({ config }: { config: WorkspaceConfig }) {
   const [removingLocalSkillId, setRemovingLocalSkillId] = useState<string | null>(null);
   const [localSkills, setLocalSkills] = useState<ProjectSkill[]>([]);
   const [localSkillsLoading, setLocalSkillsLoading] = useState(false);
+  const [localSkillsRefreshing, setLocalSkillsRefreshing] = useState(false);
   const [localActionKey, setLocalActionKey] = useState<string | null>(null);
   const [localDetailSkill, setLocalDetailSkill] = useState<ProjectSkill | null>(null);
   const [localDocContent, setLocalDocContent] = useState<string | null>(null);
@@ -289,41 +296,68 @@ export function WorkspaceView({ config }: { config: WorkspaceConfig }) {
     [currentTool, installedTools]
   );
   const currentToolKey = currentTool?.key ?? null;
+  const presetBarScopeKey = useMemo(
+    () => currentToolKey
+      ? `${config.basePath}:agent:${currentToolKey}`
+      : `${config.basePath}:overview:${[...presetBarAgentKeys].sort().join("|")}`,
+    [config.basePath, currentToolKey, presetBarAgentKeys]
+  );
 
-  const localSkillsRequestRef = useRef(0);
-  const loadLocalSkills = useCallback(async () => {
-    const requestId = ++localSkillsRequestRef.current;
+  const localSkillsRequestGateRef = useRef(new LatestRequestGate());
+  const loadLocalSkills = useCallback(async (options?: { silent?: boolean }) => {
     if (!currentToolKey) {
       setLocalSkills([]);
+      setLocalSkillsLoading(false);
+      setLocalSkillsRefreshing(false);
       return;
     }
-    setLocalSkillsLoading(true);
+    const requestGate = localSkillsRequestGateRef.current;
+    const requestToken = requestGate.begin(currentToolKey);
+    // 已切换到其他 Agent 时，旧事件处理器可能仍在收尾；不再发起旧 Agent 的刷新。
+    if (!requestGate.isCurrent(requestToken)) return;
+    const silent = options?.silent ?? false;
+    if (!silent) setLocalSkillsLoading(true);
+    setLocalSkillsRefreshing(true);
     try {
       const skills = await api.getGlobalLocalSkills(currentToolKey);
-      if (localSkillsRequestRef.current === requestId) setLocalSkills(skills);
+      if (requestGate.isCurrent(requestToken)) setLocalSkills(skills);
     } catch (error: unknown) {
-      if (localSkillsRequestRef.current === requestId) {
+      if (requestGate.isCurrent(requestToken)) {
         toast.error(getErrorMessage(error, t("common.error")));
-        setLocalSkills([]);
+        // 后台刷新失败时保留当前卡片，避免一次 Preset 操作让整个页面闪空。
+        if (!silent) setLocalSkills([]);
       }
     } finally {
-      if (localSkillsRequestRef.current === requestId) setLocalSkillsLoading(false);
+      if (requestGate.isCurrent(requestToken)) {
+        // 最新请求无论前台还是后台都要收起可能由上一请求打开的首屏 loading；
+        // 否则初次扫描被一次 Preset 静默刷新取代时会永久停在“加载中”。
+        setLocalSkillsLoading(false);
+        setLocalSkillsRefreshing(false);
+      }
     }
   }, [currentToolKey, t]);
 
-  const loadedAgentKeyRef = useRef<string | null>(null);
+  useLayoutEffect(() => {
+    localSkillsRequestGateRef.current.setScope(currentToolKey);
+    // Agent 路由变化后、浏览器绘制前清空旧卡片和旧确认框，避免“新 Agent +
+    // 旧 relative_path”的短暂危险组合。
+    setLocalSkills([]);
+    setLocalSkillsLoading(Boolean(currentToolKey));
+    setLocalSkillsRefreshing(false);
+    localDetailRequestRef.current += 1;
+    setLocalDetailSkill(null);
+    setUploadConfirmSkill(null);
+    setPullConfirmSkill(null);
+    setDeleteLocalConfirmSkill(null);
+    setTagFilters(new Set());
+  }, [currentToolKey]);
+
   useEffect(() => {
-    if (!currentToolKey) {
-      loadedAgentKeyRef.current = null;
-      setLocalSkills([]);
-      return;
-    }
-    if (loadedAgentKeyRef.current === currentToolKey) return;
-    loadedAgentKeyRef.current = currentToolKey;
+    if (!currentToolKey) return;
+    const requestGate = localSkillsRequestGateRef.current;
     void loadLocalSkills();
     return () => {
-      localSkillsRequestRef.current += 1;
-      loadedAgentKeyRef.current = null;
+      requestGate.invalidate();
     };
   }, [currentToolKey, loadLocalSkills]);
 
@@ -366,15 +400,6 @@ export function WorkspaceView({ config }: { config: WorkspaceConfig }) {
     // fresh array via refreshManagedSkills (the file watcher triggers it), so
     // the overview counts re-scan and stay accurate (#287).
   }, [currentToolKey, installedTools, managedSkills]);
-
-  useEffect(() => {
-    localDetailRequestRef.current += 1;
-    setLocalDetailSkill(null);
-    setUploadConfirmSkill(null);
-    setPullConfirmSkill(null);
-    setDeleteLocalConfirmSkill(null);
-    setTagFilters(new Set());
-  }, [currentTool?.key]);
 
   const agentSkills = useMemo(
     () =>
@@ -574,16 +599,18 @@ export function WorkspaceView({ config }: { config: WorkspaceConfig }) {
     []
   );
 
-  const handlePresetAdd = useCallback(async (skill: ManagedSkill, agentK: string) => {
-    await api.syncSkillToTool(skill.id, agentK);
-  }, []);
-
-  const handlePresetRemove = useCallback(async (skill: ManagedSkill, agentK: string) => {
-    await api.unsyncSkillFromTool(skill.id, agentK);
-  }, []);
+  const handleApplyPreset = useCallback(
+    async (preset: Preset, mode: PresetApplyMode) =>
+      api.applyPresetToTools(preset.id, presetBarAgentKeys, mode),
+    [presetBarAgentKeys]
+  );
 
   const handlePresetComplete = useCallback(async () => {
-    await Promise.all([refreshManagedSkills(), refreshTools(), loadLocalSkills()]);
+    await Promise.all([
+      refreshManagedSkills(),
+      refreshTools(),
+      loadLocalSkills({ silent: true }),
+    ]);
   }, [loadLocalSkills, refreshManagedSkills, refreshTools]);
 
   const renderLocalSkillActions = (skill: ProjectSkill, variant: "grid" | "list") => {
@@ -719,9 +746,9 @@ export function WorkspaceView({ config }: { config: WorkspaceConfig }) {
               presets={presets}
               managedSkills={managedSkills}
               agentKeys={presetBarAgentKeys}
+              scopeKey={presetBarScopeKey}
               existsInWorkspace={existsInGlobal}
-              onAddSkill={handlePresetAdd}
-              onRemoveSkill={handlePresetRemove}
+              onApplyPreset={handleApplyPreset}
               onComplete={handlePresetComplete}
             />
           )}
@@ -798,11 +825,11 @@ export function WorkspaceView({ config }: { config: WorkspaceConfig }) {
             <div className="app-segmented shrink-0">
               <button
                 onClick={() => void loadLocalSkills()}
-                disabled={localSkillsLoading}
+                disabled={localSkillsRefreshing}
                 className="rounded-md p-2 text-muted transition-colors outline-none hover:text-tertiary disabled:opacity-50"
                 title={t("settings.refresh")}
               >
-                <RefreshCw className={cn("h-4 w-4", localSkillsLoading && "animate-spin")} />
+                <RefreshCw className={cn("h-4 w-4", localSkillsRefreshing && "animate-spin")} />
               </button>
               <button
                 onClick={() => setViewMode("grid")}
@@ -904,15 +931,15 @@ export function WorkspaceView({ config }: { config: WorkspaceConfig }) {
             presets={presets}
             managedSkills={managedSkills}
             agentKeys={presetBarAgentKeys}
+            scopeKey={presetBarScopeKey}
             existsInWorkspace={existsInGlobal}
-            onAddSkill={handlePresetAdd}
-            onRemoveSkill={handlePresetRemove}
+            onApplyPreset={handleApplyPreset}
             onComplete={handlePresetComplete}
           />
         )}
       </div>
 
-      {localSkillsLoading ? (
+      {localSkillsLoading && localSkills.length === 0 ? (
         <div className="flex items-center gap-2 py-4 text-[13px] text-muted">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
           {t("common.loading")}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    restoreMocks: true,
+  },
+});


### PR DESCRIPTION
## Summary

- Wrap preset pills onto multiple rows so large preset collections remain fully visible.
- Queue rapid preset add/remove actions in FIFO order while keeping unrelated pills and the skill grid interactive.
- Apply global-workspace presets to the exact requested agent targets in one backend operation with structured results.
- Prevent stale agent or project requests from replacing the active workspace after navigation.

## Why

With many presets, the single horizontal row clipped pills that did not fit in the workspace header. Applying one preset also disabled every pill and replaced the skill grid with a full-page loading state, so users could not quickly queue several presets.

The previous client-side loop issued one IPC call per skill and target. That made overlapping preset operations race with refreshes and made it possible for stale callbacks from a previous agent or project to update the newly selected scope.

## Changes

### UI and request lifecycle

- Render all preset pills in a wrapping flex container without truncating their names.
- Serialize rapid preset operations through a FIFO queue and only mark queued pills as busy.
- Refresh workspace contents silently after queued writes so existing cards stay visible.
- Scope queued callbacks and async refreshes to the active agent or project.
- Add focused Vitest coverage for wrapping, FIFO ordering, duplicate clicks, scope changes, and stale-request handling.

### Backend preset application

- Add `apply_preset_to_tools(presetId, toolKeys, mode)` with `applied`, `skipped`, and per-item failure details.
- Validate requested targets before writing and deduplicate repeated target keys.
- Share one application lock across preset, single-skill, tray, and agent-configuration workspace writes.
- Stage copy/remove operations outside agent scan roots and commit target metadata with compare-and-swap transactions.
- Group aliases that resolve to the same physical directory so removing one target cannot delete a directory still required by another target.
- Keep processing independent skills after an individual copy/remove failure and return the complete report to the UI.
- Run frontend tests, lint, and the production build in GitHub Actions whenever frontend sources or manifests change.

## Test plan

- [x] `npm ci`
- [x] `npm test -- --run` — 4 files, 16 tests passed
- [x] `npm run lint`
- [x] `npm run build`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml exact_preset` — 10 tests passed
- [x] Focused single-skill and agent-sync Rust tests — 2 tests passed
- [x] Agent-workspace upload, pull, and backfill Rust tests — 9 tests passed
- [x] Credential-migration regression with non-interactive Git settings — 1 test passed
- [x] `git diff --check`
- [x] Private-fork marker and updater-scope audit
- [ ] The full Rust suite was started locally with the two known Windows symlink-privilege tests excluded. It progressed through the long-running Git integration tests without reporting a failure, but exceeded the local eight-minute validation window; CI is expected to complete the platform matrix.

## Compatibility

- The official updater, application identifier, release configuration, and distribution flow are unchanged.
- Existing preset membership semantics are unchanged; this PR changes workspace application and request scheduling only.

## Related issues

- Closes #341
- Related to #159 — multiple presets already compose as a union; this fixes rapid sequential activation, not exclusivity.
- This does not duplicate #336: #336 changes preset membership editing, while this PR changes workspace preset application, queuing, and loading state.
