### PR TITLE
ci: add Linux arm64 release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             label: Linux-x64
+          - platform: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            label: Linux-arm64
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
             label: Windows-x64
@@ -60,7 +63,7 @@ jobs:
           save-if: false
 
       - name: Install Linux system dependencies
-        if: matrix.platform == 'ubuntu-22.04'
+        if: startsWith(matrix.platform, 'ubuntu-')
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -109,7 +112,7 @@ jobs:
             echo ""
             echo "### 当前校验状态"
             echo ""
-            echo "- ✅ 跨平台构建通过（macOS Intel / macOS ARM / Windows x64 / Linux x64）"
+            echo "- ✅ 跨平台构建通过（macOS Intel / macOS ARM / Windows x64 / Linux x64 / Linux ARM64）"
             echo "- ✅ TypeScript typecheck 通过"
             echo ""
             echo "---"
@@ -123,7 +126,7 @@ jobs:
             echo ""
             echo "### Current Verification"
             echo ""
-            echo "- ✅ Cross-platform build passed (macOS Intel / macOS ARM / Windows x64 / Linux x64)"
+            echo "- ✅ Cross-platform build passed (macOS Intel / macOS ARM / Windows x64 / Linux x64 / Linux ARM64)"
             echo "- ✅ TypeScript typecheck passed"
             echo ""
             echo "</details>"


### PR DESCRIPTION
## Summary

Add native Linux ARM64 release builds for Skills Manager.

This PR:

- adds `aarch64-unknown-linux-gnu` to the release matrix
- uses the `ubuntu-24.04-arm` runner for native ARM64 compilation
- installs the existing Tauri Linux dependencies on both x64 and ARM64 runners
- includes Linux ARM64 in the generated release verification notes

## Motivation

The current releases provide:

- Linux x86_64 packages
- macOS ARM64 packages
- Windows x64 packages

However, there is no package for Linux ARM64 devices. The macOS ARM64 `.dmg` and `.app.tar.gz` assets contain Mach-O binaries and cannot run on Linux ARM64.

## Validation

Validated on a real Ubuntu 22.04 ARM64 machine with:

- 12-core ARM Cortex-A78 CPU
- `aarch64` architecture
- WebKitGTK 4.1
- GTK 3
- Tauri 2

The following checks passed:

- frontend TypeScript/Vite production build
- `cargo check --locked` for `aarch64-unknown-linux-gnu`
- native ARM64 Rust/Tauri release build
- ARM64 `.deb` package generation
- ARM64 `.rpm` package generation
- package metadata reports `Architecture: arm64`
- generated executable is an ARM64 Linux ELF binary
- all required dynamic libraries resolve on Ubuntu 22.04
- packaged GUI starts successfully on the host
- frontend reaches `root_rendered` and `refresh_app_data_done`
- CLI installs and lists an isolated test skill successfully

The build was also reproduced in a native ARM64 Docker container using Node.js 22 and the official Tauri Linux dependencies.

Example runtime log:

```text
app start: version=1.28.3 os=linux arch=aarch64
frontend startup: root_rendered
frontend startup: refresh_app_data_done

## Generated package

The local Docker build produced:

skills-manager_1.28.3_arm64.deb

Package metadata:

Package: skills-manager
Version: 1.28.3
Architecture: arm64
Depends: libayatana-appindicator3-1, libwebkit2gtk-4.1-0, libgtk-3-0

## Notes for maintainers

Please confirm whether:

- ubuntu-24.04-arm is the preferred GitHub Actions runner label
- release assets should use arm64, aarch64, or linux-arm64
- Linux ARM64 should be included in updater metadata

The local Docker validation disabled updater artifact signing because the upstream TAURI_SIGNING_PRIVATE_KEY is not available in fork/local
environments. Application and .deb packaging completed successfully.