### PR TITLE
feat: add z.ai zcode agent support

### DIFF
--- a/public/agent-icons/zcode.svg
+++ b/public/agent-icons/zcode.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Extracted from https://zcode.z.ai/en, selector: .relative.flex.items-center.gap-2 -->
+<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36" fill="none" role="img" aria-label="ZCode icon">
+  <defs>
+    <linearGradient id="zcode-logo-bg" x1="18" y1="0" x2="18" y2="36" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#000000"/>
+      <stop offset="1" stop-color="#151718"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0.5" y="0.5" width="35" height="35" rx="8" fill="url(#zcode-logo-bg)" stroke="#FFFFFF" stroke-opacity="0.2"/>
+
+  <svg x="7" y="8.68" width="22" height="18.64" viewBox="0 0 256 218" fill="none" aria-hidden="true" focusable="false">
+    <path fill="#FFFFFF" d="M134.4 0.130152L116.48 25.6022C113.665 29.5699 109.054 32.0019 104.064 32.0019H6.3999V0C6.3999 0.130149 134.4 0.130152 134.4 0.130152Z"/>
+    <path fill="#FFFFFF" d="M256 0.130127L102.401 217.732H0L153.599 0.130127H256Z"/>
+    <path fill="#FFFFFF" d="M121.601 217.732L139.65 192.134C142.465 188.166 147.076 185.734 152.067 185.734H249.604V217.736H121.601V217.732Z"/>
+  </svg>
+
+</svg>

--- a/src-tauri/src/core/tool_adapters.rs
+++ b/src-tauri/src/core/tool_adapters.rs
@@ -713,6 +713,18 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             project_relative_skills_dir: None,
         },
         ToolAdapter {
+            key: "zcode".into(),
+            display_name: "ZCode".into(),
+            relative_skills_dir: ".zcode/skills".into(),
+            relative_detect_dir: ".zcode".into(),
+            additional_scan_dirs: vec![],
+            override_skills_dir: None,
+            category: ToolCategory::Coding,
+            is_custom: false,
+            recursive_scan: false,
+            project_relative_skills_dir: None,
+        },
+        ToolAdapter {
             key: "adal".into(),
             display_name: "AdaL".into(),
             relative_skills_dir: ".adal/skills".into(),
@@ -1043,5 +1055,22 @@ mod tests {
         assert_eq!(adapter.relative_skills_dir, ".config/opencode/skills");
         // Project path under workspace: .opencode/skills
         assert_eq!(adapter.project_relative_skills_dir(), ".opencode/skills");
+    }
+
+    #[test]
+    fn zcode_uses_expected_default_paths() {
+        let adapter = default_tool_adapters()
+            .into_iter()
+            .find(|adapter| adapter.key == "zcode")
+            .expect("zcode adapter should exist");
+
+        assert_eq!(adapter.display_name, "ZCode");
+        assert_eq!(adapter.relative_skills_dir, ".zcode/skills");
+        assert_eq!(adapter.relative_detect_dir, ".zcode");
+        assert_eq!(adapter.project_relative_skills_dir(), ".zcode/skills");
+        assert_eq!(adapter.category, ToolCategory::Coding);
+        assert!(!adapter.is_custom);
+        assert!(!adapter.recursive_scan);
+        assert!(adapter.additional_scan_dirs.is_empty());
     }
 }

--- a/src/lib/agentIcons.ts
+++ b/src/lib/agentIcons.ts
@@ -47,6 +47,7 @@ const AGENT_ICON_FILES: Record<string, string> = {
   windsurf: "windsurf.svg",
   workbuddy: "workbuddy.png",
   zencoder: "zencoder.png",
+  zcode: "zcode.svg",
 };
 
 // Monochrome line-art icons that render black (no fill / `currentColor`) and


### PR DESCRIPTION
i only realized after finishing this that it overlaps with #338. the svg logo in that pr is a little rough, so this pr uses the svg downloaded directly from z.ai’s official website. if #338 is going ahead, would you mind letting me update the svg logo there?

## changes

- added support for the zcode agent and syncing `~/.zcode/skills`
- added support for the project-level path `<project>/.zcode/skills`
- added `zcode.svg` from zhipu’s official website

## verification

- all rust tests passed
- frontend lint and build passed

## related issue

close #243
close #319