### PR TITLE
feat(cli): add skills set-source to re-point a skill at a git source

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ npm run cli -- skills deploy <ref> --agent claude_code --agent codex  # deploy t
 npm run cli -- skills update --all
 npm run cli -- skills check --all
 
+# Re-point an installed skill at a git source, keeping its id, tags, presets
+# and deployments (e.g. a local skill you have since published)
+npm run cli -- skills set-source <ref> --git-url https://github.com/you/skills/tree/main/my-skill --dry-run
+npm run cli -- skills set-source <ref> --git-url you/skills --subpath my-skill --force
+
 # Search the skills.sh marketplace (no API key needed)
 npm run cli -- skills search react --limit 5
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -162,6 +162,11 @@ npm run cli -- skills show db
 npm run cli -- skills deploy db --agent claude_code --agent codex
 npm run cli -- skills status db
 
+# 把已安装的技能改指向 git 源，技能 id、标签、Preset 归属和已有部署都保留
+# （典型场景：本地写的技能后来发布到了 GitHub）
+npm run cli -- skills set-source db --git-url https://github.com/you/skills/tree/main/db --dry-run
+npm run cli -- skills set-source db --git-url you/skills --subpath db --force
+
 # 管理和部署 Preset（CRUD/成员调整只整理数据，deploy 才修改 Agent 文件）
 npm run cli -- presets create "Web Dev" --description "前端开发"
 npm run cli -- presets add-skill "Web Dev" db

--- a/src-tauri/src/bin/skills-manager-cli.rs
+++ b/src-tauri/src/bin/skills-manager-cli.rs
@@ -186,6 +186,29 @@ enum SkillsCommand {
         #[arg(long)]
         limit: Option<usize>,
     },
+    /// Re-point an installed skill at a git source in place, keeping its id,
+    /// tags, preset membership and deployments.
+    SetSource {
+        /// Skill ref (id / name / dir basename / central path)
+        reference: String,
+        /// Git URL or owner/repo, optionally a GitHub tree URL encoding branch and subpath
+        #[arg(long = "git-url")]
+        git_url: String,
+        /// Subpath inside the repo. Pass "" if the skill is at the repo root.
+        /// Overrides a subpath encoded in the URL.
+        #[arg(long)]
+        subpath: Option<String>,
+        /// Branch to track. Overrides a branch encoded in the URL.
+        #[arg(long)]
+        branch: Option<String>,
+        /// Overwrite the central copy when the new source's content differs.
+        /// Without this, a content difference is refused.
+        #[arg(long)]
+        force: bool,
+        /// Resolve and compare without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
     Adopt {
         /// Agent skill dirs to scan (e.g. ~/.claude/skills), or a single skill dir
         paths: Vec<PathBuf>,
@@ -887,6 +910,28 @@ fn run_skills(args: SkillsArgs, store: &SkillStore, json: bool) -> anyhow::Resul
         SkillsCommand::Search { query, limit } => {
             let hits = run_search(store, &query, limit)?;
             print_json(&hits, json);
+        }
+        SkillsCommand::SetSource {
+            reference,
+            git_url,
+            subpath,
+            branch,
+            force,
+            dry_run,
+        } => {
+            let skill = resolve_skill(store, &reference)?;
+            let report = cmd::set_git_source_internal(
+                store,
+                &skill.id,
+                &git_url,
+                subpath.as_deref(),
+                branch.as_deref(),
+                store.proxy_url().as_deref(),
+                force,
+                dry_run,
+            )
+            .map_err(map_app_err)?;
+            print_json(&report, json);
         }
         SkillsCommand::Adopt {
             paths,

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1765,8 +1765,11 @@ pub struct SetSourceResult {
     pub subpath: Option<String>,
     pub branch: Option<String>,
     pub revision: String,
-    /// Whether the new source's content differs from the current central copy.
-    /// False means the re-point is metadata-only — the library files are identical.
+    /// Whether the new source's content differs from the hash recorded for the
+    /// library copy. False means the re-point is metadata-only — no file is
+    /// rewritten. Compared against the recorded hash, not a fresh hash of the
+    /// central directory, so hand-edits made after install do not count as a
+    /// difference (and are left in place, since no file work runs).
     pub content_changed: bool,
     pub dry_run: bool,
 }
@@ -1842,8 +1845,11 @@ pub fn set_git_source_internal(
         .map_err(AppError::db)?
         .ok_or_else(|| AppError::not_found("Skill not found"))?;
 
+    // Validate before parsing: resolving a GitHub tree URL runs `ls-remote`, so
+    // an unvalidated URL would reach the network first. `install` validates its
+    // raw input the same way.
+    git_fetcher::validate_git_url(git_url).map_err(AppError::git)?;
     let parsed = git_fetcher::parse_git_source_resolved(git_url, proxy_url);
-    git_fetcher::validate_git_url(&parsed.clone_url).map_err(AppError::git)?;
 
     // An explicit flag wins over whatever the URL encodes. `--subpath ""` is the
     // caller saying "the skill is at the repo root", which is distinct from
@@ -1969,9 +1975,17 @@ pub fn set_git_source_internal(
         Err(e) => {
             // Only clear `updating` if this call actually set it. A refusal
             // (bad subpath, content differs without --force) touched nothing,
-            // so marking the skill as errored would be a lie.
+            // so marking the skill as errored would be a lie. Keep the revision
+            // just resolved rather than passing None, which would blank the
+            // column and lose the skill's known upstream position until the
+            // next check.
             if marked_updating.get() {
-                let _ = store.update_skill_check_state(skill_id, None, "error", Some(&e.message));
+                let _ = store.update_skill_check_state(
+                    skill_id,
+                    Some(&remote_revision),
+                    "error",
+                    Some(&e.message),
+                );
             }
             Err(e)
         }

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1873,6 +1873,7 @@ pub fn set_git_source_internal(
     // the network phase leaves no state to unwind — in particular the skill is
     // never left stuck in `updating`.
     let marked_updating = std::cell::Cell::new(false);
+    let source_committed = std::cell::Cell::new(false);
     let outcome = (|| -> Result<(String, bool), AppError> {
         git_fetcher::checkout_revision(&temp_dir, &remote_revision).map_err(AppError::git)?;
         let skill_dir = resolve_repoint_skill_dir(&temp_dir, subpath.as_deref())?;
@@ -1952,6 +1953,7 @@ pub fn set_git_source_internal(
                 "up_to_date",
             )
             .map_err(AppError::db)?;
+        source_committed.set(true);
         resync_copy_targets(store, &skill.id)?;
         sync_metadata::write_all_from_db_unlocked(store).map_err(AppError::db)?;
         Ok((resolved_subpath.unwrap_or_default(), content_changed))
@@ -1975,14 +1977,24 @@ pub fn set_git_source_internal(
         Err(e) => {
             // Only clear `updating` if this call actually set it. A refusal
             // (bad subpath, content differs without --force) touched nothing,
-            // so marking the skill as errored would be a lie. Keep the revision
-            // just resolved rather than passing None, which would blank the
-            // column and lose the skill's known upstream position until the
-            // next check.
+            // so marking the skill as errored would be a lie.
+            //
+            // `update_skill_check_state` always writes the revision column, so
+            // it has to be given the one that matches whichever source the row
+            // now describes: the new source's revision once the re-point
+            // committed, otherwise the revision the old source already had.
+            // Passing the newly resolved revision unconditionally would file a
+            // commit from the new repo under a skill still pointing at the old
+            // one; passing None would blank a revision that is still valid.
             if marked_updating.get() {
+                let revision = if source_committed.get() {
+                    Some(remote_revision.as_str())
+                } else {
+                    skill.remote_revision.as_deref()
+                };
                 let _ = store.update_skill_check_state(
                     skill_id,
-                    Some(&remote_revision),
+                    revision,
                     "error",
                     Some(&e.message),
                 );

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -13,7 +13,7 @@ use crate::core::{
     error::AppError,
     git_fetcher,
     install_cancel::InstallCancelRegistry,
-    installer,
+    installer, path_guard,
     repo_lock::RepoLock,
     scanner,
     skill_metadata::{self, is_valid_skill_dir},
@@ -1754,6 +1754,230 @@ pub fn update_git_skill_internal(
     }
 }
 
+#[derive(Debug, Serialize)]
+pub struct SetSourceResult {
+    pub skill_id: String,
+    pub name: String,
+    /// Source type before the change (`local`, `import`, `git`, `skillssh`).
+    pub previous_source_type: String,
+    pub previous_source_ref: Option<String>,
+    pub clone_url: String,
+    pub subpath: Option<String>,
+    pub branch: Option<String>,
+    pub revision: String,
+    /// Whether the new source's content differs from the current central copy.
+    /// False means the re-point is metadata-only — the library files are identical.
+    pub content_changed: bool,
+    pub dry_run: bool,
+}
+
+/// Resolve the skill directory inside a fresh checkout, strictly.
+///
+/// Unlike [`resolve_skill_dir`], an explicit subpath that does not land on a
+/// valid skill directory inside `repo_dir` is an error rather than a silent
+/// fallback to repo-wide discovery. Re-pointing establishes a *new* source of
+/// truth for an already-installed skill, so guessing is worse than failing: a
+/// typo would otherwise install some unrelated directory — or the whole repo —
+/// over the existing central copy.
+fn resolve_repoint_skill_dir(repo_dir: &Path, subpath: Option<&str>) -> Result<PathBuf, AppError> {
+    let Some(subpath) = subpath else {
+        return if is_valid_skill_dir(repo_dir) {
+            Ok(repo_dir.to_path_buf())
+        } else {
+            Err(AppError::invalid_input(
+                "Repository root is not a skill directory (no SKILL.md); pass --subpath",
+            ))
+        };
+    };
+
+    // `Path::join` returns the argument verbatim when it is absolute, and `..`
+    // segments climb out, so the candidate must be checked before it is used.
+    // `is_path_safe` canonicalizes both sides, which also catches symlinks that
+    // point outside the checkout.
+    let candidate = repo_dir.join(subpath);
+    if !path_guard::is_path_safe(repo_dir, &candidate) {
+        return Err(AppError::invalid_input(format!(
+            "Subpath '{subpath}' resolves outside the repository"
+        )));
+    }
+    if !candidate.is_dir() {
+        return Err(AppError::not_found(format!(
+            "Subpath '{subpath}' does not exist in the repository"
+        )));
+    }
+    if !is_valid_skill_dir(&candidate) {
+        return Err(AppError::invalid_input(format!(
+            "Subpath '{subpath}' is not a skill directory (no SKILL.md)"
+        )));
+    }
+    Ok(candidate)
+}
+
+/// Re-point an installed skill at a git source **in place**.
+///
+/// The skill row is updated by id, so the skill id, tags, preset membership and
+/// deployment targets all survive. This is the only safe way to convert a
+/// `local` skill to a `git` one: `install` reuses a central directory only when
+/// the content hash matches exactly (see `installer::unique_skill_dest`) and
+/// otherwise silently allocates `<name>-2`, while `remove` + `install` drops the
+/// id and everything keyed to it.
+///
+/// When the new source's content differs from the current central copy the
+/// command refuses unless `force` is set. Re-pointing is not an update: the
+/// remote is not yet known to be the authoritative copy, so overwriting local
+/// content that may exist nowhere else has to be a deliberate choice.
+#[allow(clippy::too_many_arguments)]
+pub fn set_git_source_internal(
+    store: &SkillStore,
+    skill_id: &str,
+    git_url: &str,
+    subpath: Option<&str>,
+    branch: Option<&str>,
+    proxy_url: Option<&str>,
+    force: bool,
+    dry_run: bool,
+) -> Result<SetSourceResult, AppError> {
+    let skill = store
+        .get_skill_by_id(skill_id)
+        .map_err(AppError::db)?
+        .ok_or_else(|| AppError::not_found("Skill not found"))?;
+
+    let parsed = git_fetcher::parse_git_source_resolved(git_url, proxy_url);
+    git_fetcher::validate_git_url(&parsed.clone_url).map_err(AppError::git)?;
+
+    // An explicit flag wins over whatever the URL encodes. `--subpath ""` is the
+    // caller saying "the skill is at the repo root", which is distinct from
+    // omitting the flag and letting the URL decide.
+    let branch = branch.map(str::to_string).or_else(|| parsed.branch.clone());
+    let subpath = match subpath {
+        Some("") => None,
+        Some(value) => Some(value.to_string()),
+        None => parsed.subpath.clone(),
+    };
+
+    let remote_revision =
+        git_fetcher::resolve_remote_revision(&parsed.clone_url, branch.as_deref(), proxy_url)
+            .map_err(|e| AppError::git(e.to_string()))?;
+
+    let temp_dir =
+        git_fetcher::clone_repo_ref(&parsed.clone_url, branch.as_deref(), None, proxy_url)
+            .map_err(AppError::classify_git_error)?;
+
+    // Nothing before this point has written to the store, so a failure during
+    // the network phase leaves no state to unwind — in particular the skill is
+    // never left stuck in `updating`.
+    let marked_updating = std::cell::Cell::new(false);
+    let outcome = (|| -> Result<(String, bool), AppError> {
+        git_fetcher::checkout_revision(&temp_dir, &remote_revision).map_err(AppError::git)?;
+        let skill_dir = resolve_repoint_skill_dir(&temp_dir, subpath.as_deref())?;
+        let resolved_subpath = git_fetcher::relative_subpath(&temp_dir, &skill_dir);
+
+        let new_hash =
+            crate::core::content_hash::hash_directory(&skill_dir).map_err(AppError::io)?;
+        let content_changed = skill.content_hash.as_deref() != Some(new_hash.as_str());
+
+        // Report before refusing: inspecting a skill whose content differs is
+        // exactly what --dry-run is for, so it must not need --force to run.
+        if dry_run {
+            return Ok((resolved_subpath.unwrap_or_default(), content_changed));
+        }
+        if content_changed && !force {
+            return Err(AppError::invalid_input(
+                "New source content differs from the current library copy; \
+                 re-run with --dry-run to inspect, or --force to overwrite",
+            ));
+        }
+
+        let _lock = RepoLock::acquire_foreground("set skill source").map_err(AppError::db)?;
+
+        // The clone happened outside the lock, so the skill may have been
+        // removed or re-pointed meanwhile. Re-read and refuse to apply a
+        // decision made against a stale snapshot.
+        let current = store
+            .get_skill_by_id(skill_id)
+            .map_err(AppError::db)?
+            .ok_or_else(|| AppError::not_found("Skill was removed while fetching the source"))?;
+        if current.central_path != skill.central_path
+            || current.content_hash != skill.content_hash
+            || current.source_type != skill.source_type
+            || current.source_ref != skill.source_ref
+        {
+            return Err(AppError::invalid_input(
+                "Skill changed while fetching the source; re-run the command",
+            ));
+        }
+
+        store
+            .update_skill_update_status(skill_id, "updating")
+            .map_err(AppError::db)?;
+        marked_updating.set(true);
+
+        // Identical content needs no file work — swapping would rewrite the
+        // central copy for a metadata-only change, and `installer` does not
+        // copy exactly the set of files `content_hash` covers, so the rewrite
+        // could alter files while still reporting `content_changed: false`.
+        let description = if content_changed {
+            let staged_path = staged_path_for(&skill.central_path);
+            let install_result =
+                installer::install_skill_dir_to_destination(&skill_dir, &skill.name, &staged_path)
+                    .inspect_err(|_| {
+                        let _ = std::fs::remove_dir_all(&staged_path);
+                    })
+                    .map_err(AppError::io)?;
+            swap_skill_directory(&staged_path, Path::new(&skill.central_path))?;
+            install_result.description
+        } else {
+            skill.description.clone()
+        };
+
+        store
+            .update_skill_after_reinstall(
+                &skill.id,
+                &skill.name,
+                description.as_deref(),
+                "git",
+                Some(&parsed.original_url),
+                Some(&parsed.clone_url),
+                resolved_subpath.as_deref(),
+                branch.as_deref(),
+                Some(&remote_revision),
+                Some(&remote_revision),
+                Some(&new_hash),
+                "up_to_date",
+            )
+            .map_err(AppError::db)?;
+        resync_copy_targets(store, &skill.id)?;
+        sync_metadata::write_all_from_db_unlocked(store).map_err(AppError::db)?;
+        Ok((resolved_subpath.unwrap_or_default(), content_changed))
+    })();
+
+    git_fetcher::cleanup_temp(&temp_dir);
+
+    match outcome {
+        Ok((resolved_subpath, content_changed)) => Ok(SetSourceResult {
+            skill_id: skill.id,
+            name: skill.name,
+            previous_source_type: skill.source_type,
+            previous_source_ref: skill.source_ref,
+            clone_url: parsed.clone_url,
+            subpath: (!resolved_subpath.is_empty()).then_some(resolved_subpath),
+            branch,
+            revision: remote_revision,
+            content_changed,
+            dry_run,
+        }),
+        Err(e) => {
+            // Only clear `updating` if this call actually set it. A refusal
+            // (bad subpath, content differs without --force) touched nothing,
+            // so marking the skill as errored would be a lie.
+            if marked_updating.get() {
+                let _ = store.update_skill_check_state(skill_id, None, "error", Some(&e.message));
+            }
+            Err(e)
+        }
+    }
+}
+
 pub fn reimport_local_skill_internal(
     store: &SkillStore,
     skill_id: &str,
@@ -2989,5 +3213,122 @@ mod tests {
         assert_eq!(dto.update_status, "unknown");
         let stored = repo.store.get_skill_by_id("skill-1").unwrap().unwrap();
         assert_eq!(stored.last_checked_at, None, "no network, no write");
+    }
+
+    fn write_skill(dir: &Path, name: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: d\n---\nbody\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn repoint_accepts_a_valid_subpath() {
+        let tmp = tempdir().unwrap();
+        let repo = tmp.path();
+        write_skill(&repo.join("note-manager"), "note-manager");
+
+        let resolved = resolve_repoint_skill_dir(repo, Some("note-manager")).unwrap();
+        assert_eq!(resolved, repo.join("note-manager"));
+    }
+
+    #[test]
+    fn repoint_accepts_repo_root_when_it_is_a_skill() {
+        let tmp = tempdir().unwrap();
+        write_skill(tmp.path(), "root-skill");
+
+        let resolved = resolve_repoint_skill_dir(tmp.path(), None).unwrap();
+        assert_eq!(resolved, tmp.path());
+    }
+
+    #[test]
+    fn repoint_rejects_repo_root_without_skill_md() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("some-dir")).unwrap();
+
+        let err = resolve_repoint_skill_dir(tmp.path(), None).unwrap_err();
+        assert!(
+            err.message.contains("not a skill directory"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn repoint_rejects_missing_subpath_instead_of_falling_back() {
+        let tmp = tempdir().unwrap();
+        let repo = tmp.path();
+        // A real skill exists elsewhere: the lenient resolver would discover it.
+        write_skill(&repo.join("other"), "other");
+
+        let err = resolve_repoint_skill_dir(repo, Some("typo")).unwrap_err();
+        assert!(err.message.contains("does not exist"), "{}", err.message);
+    }
+
+    #[test]
+    fn repoint_rejects_subpath_that_is_not_a_skill_dir() {
+        let tmp = tempdir().unwrap();
+        let repo = tmp.path();
+        fs::create_dir_all(repo.join("docs")).unwrap();
+
+        let err = resolve_repoint_skill_dir(repo, Some("docs")).unwrap_err();
+        assert!(
+            err.message.contains("not a skill directory"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn repoint_rejects_absolute_subpath() {
+        let tmp = tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        write_skill(&outside, "outside");
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+
+        // `Path::join` returns an absolute argument verbatim, so without the
+        // guard this would install a directory from outside the checkout.
+        let err = resolve_repoint_skill_dir(&repo, Some(outside.to_str().unwrap())).unwrap_err();
+        assert!(
+            err.message.contains("outside the repository"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn repoint_rejects_parent_traversal_subpath() {
+        let tmp = tempdir().unwrap();
+        write_skill(&tmp.path().join("outside"), "outside");
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+
+        let err = resolve_repoint_skill_dir(&repo, Some("../outside")).unwrap_err();
+        assert!(
+            err.message.contains("outside the repository"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repoint_rejects_symlink_escaping_the_checkout() {
+        let tmp = tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        write_skill(&outside, "outside");
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        std::os::unix::fs::symlink(&outside, repo.join("link")).unwrap();
+
+        let err = resolve_repoint_skill_dir(&repo, Some("link")).unwrap_err();
+        assert!(
+            err.message.contains("outside the repository"),
+            "{}",
+            err.message
+        );
     }
 }


### PR DESCRIPTION
## What

Adds `skills set-source`, a CLI-only command that re-points an installed skill at a git source **in place**.

Converting an installed skill from a local source to a git one had no safe path:

- `install` reuses a central directory only when the content hash matches exactly, otherwise it allocates `<name>-2` — you end up with a duplicate while the original keeps its tags and presets.
- `remove` + `install` drops the skill id and everything keyed to it: tags, preset membership, per-agent deployments.
- The GUI's `relink_local_skill_source` is local → local only and refuses git outright.

`set-source` updates the row by id, so the id, tags, presets and deployment targets all survive.

## Safety

- Subpath resolution is **strict**, unlike `resolve_skill_dir`: a subpath that does not exist, is not a skill directory, or resolves outside the checkout is an error rather than a silent fallback to repo-wide discovery. `path_guard::is_path_safe` catches absolute paths, `..` traversal, and symlinks pointing out of the checkout.
- A content difference is refused unless `--force`; `--dry-run` reports without needing `--force`.
- The clone happens outside the repo lock, so the row is re-read after locking and a decision made against a stale snapshot is refused.
- Identical content skips file work entirely, so a metadata-only re-point never rewrites the central copy.

## Verification

- `cargo test`: 427 lib + 2 bin tests green
- `npm run build` green
- End-to-end against a scratch library: dry-run → refusal without `--force` → forced re-point → all three subpath guards → metadata-only path → `check`/`update` after the re-point. Confirmed the skill id, tags, preset membership and the deployed symlink all survive.

## Known gap (pre-existing, not addressed here)

`update_git_skill_internal` does not revalidate its snapshot after taking the repo lock, so an update that was already mid-clone when a re-point commits can apply the old checkout afterwards. That race predates this command and lives in the shared update path; fixing it needs a guard honored by both operations and is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)