### PR TITLE
fix(security): stop a crafted git URL resolving outside the checkout

### DIFF
--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -2444,19 +2444,54 @@ pub fn validate_clone_temp_path(temp_dir: &str) -> Result<PathBuf, AppError> {
     Err(AppError::invalid_input("Invalid temp directory"))
 }
 
+/// Resolve which directory of a fresh checkout holds the skill.
+///
+/// Both inputs are attacker-reachable. `subpath` comes from the path segment of
+/// a `…/tree/<branch>/<path>` URL the user pasted, and `skill_id` from the part
+/// after `@` in a skills.sh shorthand, which `parse_skillssh_shorthand` does not
+/// constrain to a single path segment. `Path::join` returns an absolute argument
+/// verbatim and `..` segments climb out of the checkout, so both are checked for
+/// containment: without that, `install` copies the resolved directory into the
+/// library — which for a git-backed library can then be pushed to the user's
+/// backup remote.
+///
+/// A subpath that stays inside the checkout but does not exist is a different
+/// case: it is only recoverable when a skills.sh locator can find the skill by
+/// id, which is how a skill that moved upstream is picked up again (#278).
+/// Without a locator, falling through to repo-wide discovery would install or
+/// update whatever that discovery happens to return — in a repository that
+/// groups its skills, the entire `skills/` container.
 pub fn resolve_skill_dir(
     repo_dir: &Path,
     subpath: Option<&str>,
     skill_id: Option<&str>,
 ) -> Result<PathBuf, AppError> {
     if let Some(subpath) = subpath {
-        let path = repo_dir.join(subpath);
-        if path.exists() && path.is_dir() {
-            return Ok(path);
+        let candidate = repo_dir.join(subpath);
+        if !path_guard::is_path_safe(repo_dir, &candidate) {
+            return Err(AppError::invalid_input(format!(
+                "Path '{subpath}' resolves outside the repository"
+            )));
+        }
+        if candidate.is_dir() {
+            return Ok(candidate);
+        }
+        if skill_id.is_none() {
+            return Err(AppError::not_found(format!(
+                "Path '{subpath}' does not exist in the repository"
+            )));
         }
     }
 
-    git_fetcher::find_skill_dir(repo_dir, skill_id).map_err(AppError::git)
+    // `find_skill_dir` joins the locator id onto the checkout in several places
+    // before falling back to a recursive search, so its answer is checked too.
+    let resolved = git_fetcher::find_skill_dir(repo_dir, skill_id).map_err(AppError::git)?;
+    if !path_guard::is_path_safe(repo_dir, &resolved) {
+        return Err(AppError::invalid_input(
+            "Resolved skill directory is outside the repository",
+        ));
+    }
+    Ok(resolved)
 }
 
 pub fn resolve_skillssh_install_target(
@@ -3356,5 +3391,136 @@ mod tests {
             "{}",
             err.message
         );
+    }
+
+    // ── resolve_skill_dir: install / update / preview resolution ───────────
+    //
+    // Both inputs reach this from a URL the user pasted. The cases below are
+    // the ones that let a crafted or merely wrong URL resolve to something the
+    // caller did not ask for.
+
+    #[test]
+    fn resolve_accepts_a_subpath_inside_the_checkout() {
+        let tmp = tempdir().unwrap();
+        write_skill(&tmp.path().join("skills").join("pdf"), "pdf");
+
+        let resolved = resolve_skill_dir(tmp.path(), Some("skills/pdf"), None).unwrap();
+        assert_eq!(resolved, tmp.path().join("skills").join("pdf"));
+    }
+
+    #[test]
+    fn resolve_still_returns_a_container_for_enumeration() {
+        // preview/confirm install walk a container to list the skills inside
+        // it, so an existing non-skill directory must keep resolving.
+        let tmp = tempdir().unwrap();
+        write_skill(&tmp.path().join("skills").join("pdf"), "pdf");
+        write_skill(&tmp.path().join("skills").join("docx"), "docx");
+
+        let resolved = resolve_skill_dir(tmp.path(), Some("skills"), None).unwrap();
+        assert_eq!(resolved, tmp.path().join("skills"));
+    }
+
+    #[test]
+    fn resolve_rejects_parent_traversal_with_and_without_a_locator() {
+        let tmp = tempdir().unwrap();
+        write_skill(&tmp.path().join("outside"), "outside");
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+
+        // A locator must not soften the traversal check: the escaping path is
+        // refused either way, never quietly ignored in favour of discovery.
+        for locator in [None, Some("outside")] {
+            let err = resolve_skill_dir(&repo, Some("../outside"), locator).unwrap_err();
+            assert!(
+                err.message.contains("outside the repository"),
+                "locator {locator:?}: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_rejects_absolute_subpath() {
+        let tmp = tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        write_skill(&outside, "outside");
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+
+        let err =
+            resolve_skill_dir(&repo, Some(outside.to_str().unwrap()), None).unwrap_err();
+        assert!(
+            err.message.contains("outside the repository"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_rejects_subpath_symlinked_out_of_the_checkout() {
+        let tmp = tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        write_skill(&outside, "outside");
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        std::os::unix::fs::symlink(&outside, repo.join("link")).unwrap();
+
+        let err = resolve_skill_dir(&repo, Some("link"), None).unwrap_err();
+        assert!(
+            err.message.contains("outside the repository"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_rejects_a_locator_that_escapes_the_checkout() {
+        // `owner/repo@../../x` survives parse_skillssh_shorthand, which only
+        // checks the owner/repo half, so the locator itself can climb out.
+        let tmp = tempdir().unwrap();
+        write_skill(&tmp.path().join("outside"), "outside");
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+
+        let err = resolve_skill_dir(&repo, None, Some("../outside")).unwrap_err();
+        assert!(
+            err.message.contains("outside the repository"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn resolve_refuses_a_missing_subpath_instead_of_discovering_the_container() {
+        // The measured bug: a tree URL naming a directory that does not exist
+        // installed the whole `skills/` container as one skill.
+        let tmp = tempdir().unwrap();
+        write_skill(&tmp.path().join("skills").join("pdf"), "pdf");
+
+        let err = resolve_skill_dir(tmp.path(), Some("artifacts-builder"), None).unwrap_err();
+        assert!(err.message.contains("does not exist"), "{}", err.message);
+    }
+
+    #[test]
+    fn resolve_lets_a_locator_recover_a_skill_that_moved_upstream() {
+        // #278's recovery path: the stored subpath is stale because upstream
+        // reorganized, and the locator finds the skill at its new home.
+        let tmp = tempdir().unwrap();
+        write_skill(&tmp.path().join("skills").join("db"), "db");
+
+        let resolved = resolve_skill_dir(tmp.path(), Some("db"), Some("db")).unwrap();
+        assert_eq!(resolved, tmp.path().join("skills").join("db"));
+    }
+
+    #[test]
+    fn resolve_errors_when_the_locator_finds_nothing() {
+        // Still #278: no match must not fall through to a container or root.
+        let tmp = tempdir().unwrap();
+        write_skill(&tmp.path().join("skills").join("db"), "db");
+
+        let err = resolve_skill_dir(tmp.path(), Some("gone"), Some("nope-not-here")).unwrap_err();
+        assert!(err.message.contains("not found"), "{}", err.message);
     }
 }

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -2473,7 +2473,17 @@ pub fn resolve_skill_dir(
                 "Path '{subpath}' resolves outside the repository"
             )));
         }
-        if candidate.is_dir() {
+        // With a locator to fall back on, the stored path is only taken when it
+        // still holds a skill. An upstream reorganization can leave the path
+        // occupied by a container or an unrelated directory, and copying that
+        // over the installed skill is the same mistake as guessing — let the
+        // locator look the skill up at its new home instead.
+        let usable = if skill_id.is_some() {
+            is_valid_skill_dir(&candidate)
+        } else {
+            candidate.is_dir()
+        };
+        if usable {
             return Ok(candidate);
         }
         if skill_id.is_none() {
@@ -3418,6 +3428,8 @@ mod tests {
 
         let resolved = resolve_skill_dir(tmp.path(), Some("skills"), None).unwrap();
         assert_eq!(resolved, tmp.path().join("skills"));
+        // What preview/confirm actually do with that container.
+        assert_eq!(collect_git_skill_dirs(&resolved).len(), 2);
     }
 
     #[test]
@@ -3474,7 +3486,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn resolve_rejects_a_locator_that_escapes_the_checkout() {
         // `owner/repo@../../x` survives parse_skillssh_shorthand, which only
@@ -3508,6 +3519,20 @@ mod tests {
         // #278's recovery path: the stored subpath is stale because upstream
         // reorganized, and the locator finds the skill at its new home.
         let tmp = tempdir().unwrap();
+        write_skill(&tmp.path().join("skills").join("db"), "db");
+
+        let resolved = resolve_skill_dir(tmp.path(), Some("db"), Some("db")).unwrap();
+        assert_eq!(resolved, tmp.path().join("skills").join("db"));
+    }
+
+    #[test]
+    fn resolve_lets_a_locator_override_a_path_that_is_no_longer_the_skill() {
+        // The harder half of a reorganization: the stored path still exists,
+        // but upstream turned it into a container and moved the skill. Taking
+        // the path would copy the container over the installed skill.
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("db")).unwrap();
+        write_skill(&tmp.path().join("db").join("nested"), "nested");
         write_skill(&tmp.path().join("skills").join("db"), "db");
 
         let resolved = resolve_skill_dir(tmp.path(), Some("db"), Some("db")).unwrap();


### PR DESCRIPTION
## The problem

`resolve_skill_dir` joined the subpath from a `…/tree/<branch>/<path>` URL onto the clone without a containment check. `Path::join` returns an absolute argument verbatim and `..` climbs out, so a URL whose path segment walked up far enough resolved to an arbitrary local directory, which the installer then copied into the library.

Measured on 1.33.0: a crafted tree URL installed a directory from outside the checkout and reported success. The library is git-backed with an optional auto-syncing remote, so content pulled in this way can leave the machine. The same code path is behind the desktop app's install-from-git-URL, not only the CLI.

The skills.sh locator is a second route to the same place: `find_skill_dir` joins the id onto the checkout in three spots, and `parse_skillssh_shorthand` does not constrain the part after `@` to a single path segment, so `owner/repo@../../x` climbs out too.

Separately, an explicit subpath that simply did not exist fell through to repo-wide discovery: `install .../tree/main/artifacts-builder`, whose real path upstream is `skills/web-artifacts-builder`, silently installed the entire `skills/` container — 17 unrelated skills — as one entry named "skills".

## The fix

- Both the subpath and the final resolved directory are checked with `path_guard::is_path_safe`, so neither route can leave the clone.
- An explicit path that does not exist is an error, except when a skills.sh locator can look the skill up by id — that is how #278 recovers a skill that moved upstream.
- With a locator present, the stored path is taken only when it still holds a skill. An upstream reorganization can leave it occupied by a container, and copying that over the installed skill is the same silent substitution.

Enumeration is unaffected: preview/confirm install resolve a container that exists and walk it as before.

## Verification

- 437 tests green, 10 of them new: traversal via `..`, absolute path and symlink, with and without a locator; missing path with no locator; locator recovery after a move; locator finding nothing; container enumeration.
- Re-ran both attacks against the patched binary — refused. Correct tree URL, skills.sh install, and `update --all` all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)