### PR TITLE
feat(i18n): detect the first-run language from the OS locale

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -19,10 +19,9 @@ function getStoredLanguage(): SupportedLanguage | null {
 }
 
 /**
- * First-run language, taken from the OS/browser locale list. Only reached when
- * neither the saved setting nor localStorage has a value, so an existing user's
- * choice is never overridden. Traditional-Chinese regions (TW/HK/MO) and the
- * Hant script map to zh-TW; any other Chinese tag maps to zh.
+ * First-run language, from the OS locale list. Only reached when neither the
+ * saved setting nor localStorage has a value, so an existing user's choice is
+ * never overridden.
  */
 function detectLanguage(): SupportedLanguage {
   const tags = navigator.languages?.length
@@ -32,6 +31,8 @@ function detectLanguage(): SupportedLanguage {
   for (const tag of tags) {
     const lower = tag.toLowerCase();
     if (lower.startsWith("zh")) {
+      // An explicit script wins over the region, so zh-Hans-HK stays Simplified.
+      if (lower.includes("hans")) return "zh";
       return /hant|-(tw|hk|mo)\b/.test(lower) ? "zh-TW" : "zh";
     }
     if (lower.startsWith("en")) return "en";

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -18,12 +18,34 @@ function getStoredLanguage(): SupportedLanguage | null {
   return isSupportedLanguage(stored) ? stored : null;
 }
 
+/**
+ * First-run language, taken from the OS/browser locale list. Only reached when
+ * neither the saved setting nor localStorage has a value, so an existing user's
+ * choice is never overridden. Traditional-Chinese regions (TW/HK/MO) and the
+ * Hant script map to zh-TW; any other Chinese tag maps to zh.
+ */
+function detectLanguage(): SupportedLanguage {
+  const tags = navigator.languages?.length
+    ? navigator.languages
+    : [navigator.language];
+
+  for (const tag of tags) {
+    const lower = tag.toLowerCase();
+    if (lower.startsWith("zh")) {
+      return /hant|-(tw|hk|mo)\b/.test(lower) ? "zh-TW" : "zh";
+    }
+    if (lower.startsWith("en")) return "en";
+  }
+
+  return "en";
+}
+
 export const i18nReady = (async () => {
   const storedLanguage = getStoredLanguage();
   const savedLanguage = await getSettings("language").catch(() => null);
   const lng = isSupportedLanguage(savedLanguage)
     ? savedLanguage
-    : storedLanguage || "zh";
+    : storedLanguage || detectLanguage();
 
   localStorage.setItem(LANGUAGE_STORAGE_KEY, lng);
 


### PR DESCRIPTION
## The problem

A fresh install always starts in Simplified Chinese: `src/i18n/index.ts` hardcodes `"zh"` as the first-run language. A non-Chinese user has to find 设置 -> 语言 in a UI they cannot read before the app becomes usable. All three locales are already complete (`en.json` and `zh.json` both carry 920 keys), so only the default was missing.

## The change

One file. `detectLanguage()` walks `navigator.languages` in preference order and takes the first tag the app can serve. An explicit script beats the region, so `zh-Hans-HK` stays Simplified.

| System locale | Result |
| --- | --- |
| `zh-CN`, `zh-Hans-*`, `zh` | `zh` |
| `zh-TW`, `zh-HK`, `zh-MO`, `zh-Hant-*` | `zh-TW` |
| `en-*` | `en` |
| anything else (`fr-FR`, `de-DE`) | `en` |

Existing users are unaffected: the new branch is only reached when both the saved setting and `localStorage` are empty, and line 28 has always written `localStorage` on every load.

## Open to changing

- Unmatched locales fall back to `en` rather than `zh` — say the word if you'd rather keep zh-first for everyone outside the three.
- `fallbackLng` stays `zh`, since it resolves missing keys rather than picking the default.
- No "Auto" option added to the Settings switcher; detection runs on first launch only.

## Testing

`npm run lint` and `npm run build` clean. Detection checked against 17 locale lists (every row above, plus mixed lists and an empty one). I haven't exercised it in a running `tauri dev` build, so a maintainer check of the first-launch path would be welcome. The repo has no frontend test runner — happy to add a test if you want one pulled in.