### PR TITLE
fix: install skills.sh website-synced skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ npm run cli -- skills show db
 npm run cli -- skills install ./my-skill                       # local path
 npm run cli -- skills install https://github.com/foo/bar.git   # git URL
 npm run cli -- skills install vercel-labs/agent-skills@react-best-practices  # skills.sh
+npm run cli -- skills install https://www.skills.sh/site/uizze.com/ui-radar # website-synced skill
 npm run cli -- skills deploy <ref> --agent claude_code --agent codex  # deploy to both agents
 
 # Update / check from upstream (git skills re-clone, local skills re-import source).

--- a/src-tauri/src/bin/skills-manager-cli.rs
+++ b/src-tauri/src/bin/skills-manager-cli.rs
@@ -8,6 +8,7 @@ use app_lib::core::{
     app_state, audit_log::AuditDraft, central_repo, error::AppError, git_backup, git_fetcher,
     installer, merge, repo_lock::RepoLock, scenario_service, skill_metadata,
     skill_store::SkillStore, skillssh_api, sync_engine, sync_metadata, tool_adapters, tool_service,
+    well_known,
 };
 use clap::{Args, Parser, Subcommand};
 use serde::Serialize;
@@ -641,6 +642,7 @@ enum InstallKind {
     Local,
     Git,
     Skillssh,
+    WellKnown,
 }
 
 enum SyncTarget {
@@ -1450,6 +1452,10 @@ fn classify_ref(
         return Ok(InstallKind::Skillssh);
     }
 
+    if well_known::is_site_ref(reference) {
+        return Ok(InstallKind::WellKnown);
+    }
+
     if reference.starts_with("./")
         || reference.starts_with("../")
         || reference.starts_with('/')
@@ -1513,6 +1519,9 @@ fn run_install(
         InstallKind::Local => install_local_action(store, reference, name, preset_id.as_deref())?,
         InstallKind::Git => install_git_action(store, reference, name, preset_id.as_deref())?,
         InstallKind::Skillssh => install_skillssh_action(store, reference, preset_id.as_deref())?,
+        InstallKind::WellKnown => {
+            install_well_known_action(store, reference, name, preset_id.as_deref())?
+        }
     };
 
     Ok(InstallReport {
@@ -1641,6 +1650,47 @@ fn install_skillssh_action(
     git_fetcher::cleanup_temp(&temp_dir);
     let (skill_id, install_name, central_path) = result?;
     Ok((skill_id, install_name, central_path, "skillssh".to_string()))
+}
+
+fn install_well_known_action(
+    store: &SkillStore,
+    site_url: &str,
+    name: Option<&str>,
+    active_scenario: Option<&str>,
+) -> anyhow::Result<(String, String, String, String)> {
+    let downloaded = well_known::download_site_skill(site_url, store.proxy_url().as_deref())?;
+    let result = (|| -> anyhow::Result<(String, String, String)> {
+        let _lock = RepoLock::acquire_foreground("cli install website skill")?;
+        let install_result = installer::install_from_local(&downloaded.skill_dir, name)?;
+        let metadata = cmd::InstallSourceMetadata {
+            source_type: "well-known".to_string(),
+            source_ref: Some(site_url.to_string()),
+            source_ref_resolved: Some(downloaded.resolved_url.clone()),
+            source_subpath: None,
+            source_branch: None,
+            source_revision: downloaded.revision.clone(),
+            remote_revision: downloaded.revision.clone(),
+            update_status: "local_only".to_string(),
+        };
+        let central_path = install_result.central_path.to_string_lossy().to_string();
+        let install_name = install_result.name.clone();
+        let skill_id = cmd::store_installed_skill_unlocked(
+            store,
+            &install_result,
+            &metadata,
+            active_scenario,
+        )
+        .map_err(map_app_err)?;
+        Ok((skill_id, install_name, central_path))
+    })();
+    well_known::cleanup_temp(&downloaded.temp_dir);
+    let (skill_id, install_name, central_path) = result?;
+    Ok((
+        skill_id,
+        install_name,
+        central_path,
+        "well-known".to_string(),
+    ))
 }
 
 /// Parse `owner/repo`, `owner/repo@skill`, or `owner/repo/skill` into

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1296,7 +1296,7 @@ pub async fn confirm_git_install(
                     return Ok(());
                 }
                 let skill_dir = well_known::skill_dir_from_temp(&temp_path)
-                    .map_err(AppError::invalid_input)?;
+                    .map_err(|error| AppError::invalid_input(error.to_string()))?;
                 let all_dirs = collect_git_skill_dirs(&skill_dir);
                 let _lock = RepoLock::acquire_foreground("confirm website skill install")
                     .map_err(AppError::db)?;

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -20,6 +20,7 @@ use crate::core::{
     skill_store::{SkillRecord, SkillStore, SkillTargetRecord},
     sync_engine, sync_metadata,
     timing::should_log_first_or_slow,
+    well_known,
 };
 
 #[derive(Debug, Serialize)]
@@ -940,6 +941,44 @@ pub async fn install_git(
                 .ok();
         };
 
+        if well_known::is_site_ref(&repo_url) {
+            let outcome = (|| -> Result<(String, String), AppError> {
+                emit_progress("cloning");
+                let downloaded = well_known::download_site_skill(&repo_url, proxy_url.as_deref())
+                    .map_err(AppError::network)?;
+                emit_progress("installing");
+                let result = (|| -> Result<(String, String), AppError> {
+                    let _lock = RepoLock::acquire_foreground("install website skill")
+                        .map_err(AppError::db)?;
+                    let install_result = installer::install_from_local(
+                        &downloaded.skill_dir,
+                        name.as_deref(),
+                    )
+                    .map_err(AppError::io)?;
+                    let metadata = InstallSourceMetadata {
+                        source_type: "well-known".to_string(),
+                        source_ref: Some(repo_url.clone()),
+                        source_ref_resolved: Some(downloaded.resolved_url.clone()),
+                        source_subpath: None,
+                        source_branch: None,
+                        source_revision: downloaded.revision.clone(),
+                        remote_revision: downloaded.revision.clone(),
+                        update_status: "local_only".to_string(),
+                    };
+                    let skill_name = install_result.name.clone();
+                    let skill_id =
+                        store_installed_skill_unlocked(&store, &install_result, &metadata, None)?;
+                    Ok((skill_id, skill_name))
+                })();
+                well_known::cleanup_temp(&downloaded.temp_dir);
+                result
+            })();
+            log_install_outcome(&store, "well-known", outcome.as_ref());
+            outcome?;
+            emit_progress("done");
+            return Ok(());
+        }
+
         let outcome = (|| -> Result<(String, String), AppError> {
             git_fetcher::validate_git_url(&repo_url).map_err(AppError::git)?;
             emit_progress("cloning");
@@ -1120,6 +1159,53 @@ pub async fn preview_git_install(
 
     tauri::async_runtime::spawn_blocking(move || {
         use tauri::Emitter;
+        if well_known::is_site_ref(&repo_url) {
+            app_handle
+                .emit(
+                    "install-progress",
+                    serde_json::json!({
+                        "skill_id": repo_url,
+                        "phase": "cloning",
+                    }),
+                )
+                .ok();
+            let downloaded = well_known::download_site_skill(&repo_url, proxy_url.as_deref())
+                .map_err(AppError::network)?;
+            let result = (|| -> Result<GitPreviewResult, AppError> {
+                let dirs = collect_git_skill_dirs(&downloaded.skill_dir);
+                if dirs.is_empty() {
+                    return Err(AppError::not_found("Downloaded source contains no skills"));
+                }
+                let skills = dirs
+                    .iter()
+                    .map(|dir| {
+                        let meta = skill_metadata::parse_skill_md(dir);
+                        let rel_path = skill_rel_key(&downloaded.skill_dir, dir);
+                        let basename = dir
+                            .file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_else(|| rel_path.clone());
+                        let name = meta
+                            .name
+                            .filter(|s| !s.trim().is_empty())
+                            .unwrap_or(basename);
+                        GitSkillPreview {
+                            rel_path,
+                            name,
+                            description: meta.description,
+                        }
+                    })
+                    .collect();
+                Ok(GitPreviewResult {
+                    temp_dir: downloaded.temp_dir.to_string_lossy().to_string(),
+                    skills,
+                })
+            })();
+            if result.is_err() {
+                well_known::cleanup_temp(&downloaded.temp_dir);
+            }
+            return result;
+        }
         app_handle
             .emit(
                 "install-progress",
@@ -1203,6 +1289,44 @@ pub async fn confirm_git_install(
     let store = store.inner().clone();
     let proxy_url = store.proxy_url();
     tauri::async_runtime::spawn_blocking(move || {
+        if well_known::is_site_ref(&repo_url) {
+            let temp_path = validate_clone_temp_path(&temp_dir)?;
+            let result: Result<(), AppError> = (|| {
+                if items.is_empty() {
+                    return Ok(());
+                }
+                let skill_dir = well_known::skill_dir_from_temp(&temp_path)
+                    .map_err(AppError::invalid_input)?;
+                let all_dirs = collect_git_skill_dirs(&skill_dir);
+                let _lock = RepoLock::acquire_foreground("confirm website skill install")
+                    .map_err(AppError::db)?;
+                for dir in &all_dirs {
+                    let rel_key = skill_rel_key(&skill_dir, dir);
+                    let item = match items.iter().find(|item| item.rel_path == rel_key) {
+                        Some(item) => item,
+                        None => continue,
+                    };
+                    let custom_name = item.name.trim();
+                    let install_name = (!custom_name.is_empty()).then_some(custom_name);
+                    let install_result = installer::install_from_local(dir, install_name)
+                        .map_err(AppError::io)?;
+                    let metadata = InstallSourceMetadata {
+                        source_type: "well-known".to_string(),
+                        source_ref: Some(repo_url.clone()),
+                        source_ref_resolved: Some(repo_url.clone()),
+                        source_subpath: None,
+                        source_branch: None,
+                        source_revision: None,
+                        remote_revision: None,
+                        update_status: "local_only".to_string(),
+                    };
+                    store_installed_skill_unlocked(&store, &install_result, &metadata, None)?;
+                }
+                Ok(())
+            })();
+            well_known::cleanup_temp(&temp_path);
+            return result;
+        }
         let temp_path = validate_clone_temp_path(&temp_dir)?;
 
         let result: Result<(), AppError> = (|| {
@@ -2766,7 +2890,9 @@ pub fn validate_clone_temp_path(temp_dir: &str) -> Result<PathBuf, AppError> {
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default();
-        if dir_name_str.starts_with(git_fetcher::CLONE_TEMP_PREFIX) {
+        if dir_name_str.starts_with(git_fetcher::CLONE_TEMP_PREFIX)
+            || dir_name_str.starts_with(well_known::TEMP_DIR_PREFIX)
+        {
             return Ok(temp_path);
         }
     }

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -32,3 +32,4 @@ pub mod sync_metadata;
 pub mod timing;
 pub mod tool_adapters;
 pub mod tool_service;
+pub mod well_known;

--- a/src-tauri/src/core/well_known.rs
+++ b/src-tauri/src/core/well_known.rs
@@ -88,9 +88,7 @@ pub fn download_site_skill(input: &str, proxy_url: Option<&str>) -> Result<Downl
         download_v1_entry(&client, &index, entry, &site.skill_name, &skill_dir)?
     };
 
-    let temp_dir = temp
-        .keep()
-        .map_err(|error| anyhow::anyhow!("Failed to keep skills download directory: {error}"))?;
+    let temp_dir = temp.keep();
     let skill_dir = temp_dir.join("skill");
     Ok(DownloadedSkill {
         temp_dir,

--- a/src-tauri/src/core/well_known.rs
+++ b/src-tauri/src/core/well_known.rs
@@ -1,0 +1,302 @@
+use anyhow::{bail, Context, Result};
+use reqwest::blocking::Client;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::io::Cursor;
+use std::path::{Component, Path, PathBuf};
+
+pub const TEMP_DIR_PREFIX: &str = "skills-manager-well-known-";
+
+const MAX_DOWNLOAD_BYTES: u64 = 50 * 1024 * 1024;
+const SITE_HOSTS: &[&str] = &["skills.sh", "www.skills.sh"];
+
+#[derive(Debug, Clone)]
+pub struct SiteRef {
+    pub source_url: String,
+    pub skill_name: String,
+}
+
+#[derive(Debug)]
+pub struct DownloadedSkill {
+    pub temp_dir: PathBuf,
+    pub skill_dir: PathBuf,
+    pub resolved_url: String,
+    pub revision: Option<String>,
+}
+
+struct DiscoveryIndex {
+    url: reqwest::Url,
+    well_known_path: &'static str,
+    payload: Value,
+}
+
+pub fn parse_site_ref(input: &str) -> Result<SiteRef> {
+    let parsed = reqwest::Url::parse(input.trim()).context("Invalid skills.sh URL")?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| anyhow::anyhow!("skills.sh URL is missing a host"))?;
+    if !SITE_HOSTS.contains(&host) {
+        bail!("Expected a skills.sh /site/<domain>/<skill> URL");
+    }
+
+    let segments: Vec<&str> = parsed
+        .path_segments()
+        .map(|segments| segments.collect())
+        .unwrap_or_default();
+    if segments.len() != 3 || segments[0] != "site" {
+        bail!("Expected a skills.sh /site/<domain>/<skill> URL");
+    }
+    if !is_safe_segment(segments[1]) || !is_safe_segment(segments[2]) {
+        bail!("Invalid skills.sh site reference");
+    }
+
+    Ok(SiteRef {
+        source_url: format!("https://{}/", segments[1]),
+        skill_name: segments[2].to_string(),
+    })
+}
+
+pub fn is_site_ref(input: &str) -> bool {
+    parse_site_ref(input).is_ok()
+}
+
+pub fn download_site_skill(input: &str, proxy_url: Option<&str>) -> Result<DownloadedSkill> {
+    let site = parse_site_ref(input)?;
+    let client = crate::core::skillssh_api::build_http_client(proxy_url, 30);
+    let index = fetch_index(&client, &site.source_url)?;
+    let entry = index
+        .payload
+        .get("skills")
+        .and_then(Value::as_array)
+        .and_then(|skills| {
+            skills.iter().find(|skill| {
+                skill.get("name").and_then(Value::as_str) == Some(site.skill_name.as_str())
+            })
+        })
+        .ok_or_else(|| anyhow::anyhow!("Skill '{}' was not found at {}", site.skill_name, site.source_url))?;
+
+    let temp = tempfile::Builder::new()
+        .prefix(TEMP_DIR_PREFIX)
+        .tempdir()
+        .context("Failed to create skills download directory")?;
+    let skill_dir = temp.path().join("skill");
+    std::fs::create_dir_all(&skill_dir)?;
+
+    let (resolved_url, revision) = if index.payload.get("$schema").is_some() {
+        download_v2_entry(&client, &index, entry, &skill_dir)?
+    } else {
+        download_v1_entry(&client, &index, entry, &site.skill_name, &skill_dir)?
+    };
+
+    let temp_dir = temp
+        .keep()
+        .map_err(|error| anyhow::anyhow!("Failed to keep skills download directory: {error}"))?;
+    let skill_dir = temp_dir.join("skill");
+    Ok(DownloadedSkill {
+        temp_dir,
+        skill_dir,
+        resolved_url,
+        revision,
+    })
+}
+
+pub fn skill_dir_from_temp(temp_dir: &Path) -> Result<PathBuf> {
+    let skill_dir = temp_dir.join("skill");
+    if !skill_dir.is_dir() || !skill_dir.join("SKILL.md").is_file() {
+        bail!("Downloaded skill is missing SKILL.md");
+    }
+    Ok(skill_dir)
+}
+
+pub fn cleanup_temp(temp_dir: &Path) {
+    let _ = std::fs::remove_dir_all(temp_dir);
+}
+
+fn fetch_index(client: &Client, source_url: &str) -> Result<DiscoveryIndex> {
+    for well_known_path in [".well-known/agent-skills", ".well-known/skills"] {
+        let url = reqwest::Url::parse(source_url)?.join(&format!("{well_known_path}/index.json"))?;
+        let response = client.get(url.clone()).send();
+        let Ok(response) = response else { continue };
+        if !response.status().is_success() {
+            continue;
+        }
+        let payload: Value = response
+            .json()
+            .with_context(|| format!("Failed to parse skills index at {url}"))?;
+        if payload.get("skills").and_then(Value::as_array).is_some() {
+            return Ok(DiscoveryIndex {
+                url,
+                well_known_path,
+                payload,
+            });
+        }
+    }
+    bail!("No supported skills index found at {source_url}");
+}
+
+fn download_v1_entry(
+    client: &Client,
+    index: &DiscoveryIndex,
+    entry: &Value,
+    skill_name: &str,
+    skill_dir: &Path,
+) -> Result<(String, Option<String>)> {
+    let files = entry
+        .get("files")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("skills index entry is missing files"))?;
+    let base = index
+        .url
+        .join("./")?
+        .join(&format!("{skill_name}/"))?;
+    for file in files {
+        let file = file
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("skills index contains an invalid file path"))?;
+        let relative = safe_relative_path(file)?;
+        let destination = skill_dir.join(&relative);
+        if let Some(parent) = destination.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let url = base.join(file)?;
+        std::fs::write(destination, get_bytes(client, &url)?)?;
+    }
+    if !skill_dir.join("SKILL.md").is_file() {
+        bail!("skills index entry is missing SKILL.md");
+    }
+    Ok((base.join("SKILL.md")?.to_string(), None))
+}
+
+fn download_v2_entry(
+    client: &Client,
+    index: &DiscoveryIndex,
+    entry: &Value,
+    skill_dir: &Path,
+) -> Result<(String, Option<String>)> {
+    let kind = entry
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("skills index entry is missing type"))?;
+    let artifact = entry
+        .get("url")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("skills index entry is missing url"))?;
+    let url = index.url.join(artifact)?;
+    let bytes = get_bytes(client, &url)?;
+    let digest = entry.get("digest").and_then(Value::as_str);
+    if let Some(digest) = digest {
+        verify_digest(&bytes, digest)?;
+    }
+
+    match kind {
+        "skill-md" => {
+            std::fs::write(skill_dir.join("SKILL.md"), bytes)?;
+        }
+        "archive" => extract_zip(&bytes, skill_dir)?,
+        other => bail!("Unsupported skills index entry type: {other}"),
+    }
+
+    if !skill_dir.join("SKILL.md").is_file() {
+        bail!("Downloaded skill is missing SKILL.md");
+    }
+    Ok((url.to_string(), digest.map(str::to_string)))
+}
+
+fn get_bytes(client: &Client, url: &reqwest::Url) -> Result<Vec<u8>> {
+    let response = client
+        .get(url.clone())
+        .send()
+        .with_context(|| format!("Failed to download {url}"))?
+        .error_for_status()
+        .with_context(|| format!("Failed to download {url}"))?;
+    if response.content_length().is_some_and(|size| size > MAX_DOWNLOAD_BYTES) {
+        bail!("Download exceeds the {} MiB limit", MAX_DOWNLOAD_BYTES / 1024 / 1024);
+    }
+    let bytes = response.bytes()?.to_vec();
+    if bytes.len() as u64 > MAX_DOWNLOAD_BYTES {
+        bail!("Download exceeds the {} MiB limit", MAX_DOWNLOAD_BYTES / 1024 / 1024);
+    }
+    Ok(bytes)
+}
+
+fn verify_digest(bytes: &[u8], expected: &str) -> Result<()> {
+    let Some(expected) = expected.strip_prefix("sha256:") else {
+        bail!("Unsupported skills index digest");
+    };
+    let actual = format!("{:x}", Sha256::digest(bytes));
+    if actual != expected {
+        bail!("Downloaded skill failed its SHA-256 digest check");
+    }
+    Ok(())
+}
+
+fn extract_zip(bytes: &[u8], destination: &Path) -> Result<()> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes))?;
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index)?;
+        let Some(relative) = entry.enclosed_name() else {
+            bail!("Archive contains an unsafe path");
+        };
+        let target = destination.join(relative);
+        if !target.starts_with(destination) {
+            bail!("Archive contains an unsafe path");
+        }
+        if entry.is_dir() {
+            std::fs::create_dir_all(target)?;
+            continue;
+        }
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut file = std::fs::File::create(target)?;
+        std::io::copy(&mut entry, &mut file)?;
+    }
+    Ok(())
+}
+
+fn safe_relative_path(path: &str) -> Result<PathBuf> {
+    if path.is_empty() || path.contains('\\') {
+        bail!("Invalid skill file path");
+    }
+    let path = Path::new(path);
+    if path.components().any(|component| {
+        matches!(component, Component::ParentDir | Component::RootDir | Component::Prefix(_))
+    }) {
+        bail!("Invalid skill file path");
+    }
+    Ok(path.to_path_buf())
+}
+
+fn is_safe_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment
+            .chars()
+            .all(|char| char.is_ascii_alphanumeric() || matches!(char, '.' | '-'))
+        && !segment.starts_with('.')
+        && !segment.ends_with('.')
+        && !segment.starts_with('-')
+        && !segment.ends_with('-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_site_ref, parse_site_ref, safe_relative_path};
+
+    #[test]
+    fn parses_website_synced_skills_sh_refs() {
+        let parsed = parse_site_ref("https://www.skills.sh/site/uizze.com/ui-radar").unwrap();
+        assert_eq!(parsed.source_url, "https://uizze.com/");
+        assert_eq!(parsed.skill_name, "ui-radar");
+    }
+
+    #[test]
+    fn does_not_treat_github_urls_as_site_refs() {
+        assert!(!is_site_ref("https://github.com/uizze/uizze"));
+    }
+
+    #[test]
+    fn rejects_unsafe_skill_file_paths() {
+        assert!(safe_relative_path("../SKILL.md").is_err());
+        assert!(safe_relative_path("references/guide.md").is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

- recognize `https://www.skills.sh/site/<domain>/<skill>` references before Git URL classification
- install website-synced skills through the public Agent Skills well-known index
- support both the desktop preview/confirm flow and the CLI
- verify v2 artifact digests and safely extract downloaded archives
- document the website-synced install form

Fixes #381.

## Validation

- `git diff --check`
- Added parser and path-safety regression tests
- Full `cargo test --manifest-path src-tauri/Cargo.toml` and Linux `cargo check` run in CI
