### PR TITLE
feat(agents): add ZCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ The Backup page offers three levels: **disconnect this machine** (other devices 
 
 ## Supported Tools
 
-52 agents are supported out of the box, including:
+53 agents are supported out of the box, including:
 
-Claude Code · Codex · Cursor · GitHub Copilot · Gemini CLI · OpenCode · OpenClaw · Hermes Agent · OpenHands · Cline · Goose · Windsurf · Continue · Grok · Antigravity · Qwen Code · Crush · Kilo Code · Roo Code · Amp · Kiro CLI · Droid · TRAE IDE · Warp · Qoder · CodeBuddy
+Claude Code · Codex · Cursor · ZCode · GitHub Copilot · Gemini CLI · OpenCode · OpenClaw · Hermes Agent · OpenHands · Cline · Goose · Windsurf · Continue · Grok · Antigravity · Qwen Code · Crush · Kilo Code · Roo Code · Amp · Kiro CLI · Droid · TRAE IDE · Warp · Qoder · CodeBuddy
 
 **Settings** lists them all, leading with the ones detected on your machine. You can also add custom tools there and manage their skills the same way.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -111,9 +111,9 @@
 
 ## 支持的工具
 
-开箱支持 52 个 Agent，包括：
+开箱支持 53 个 Agent，包括：
 
-Claude Code · Codex · Cursor · GitHub Copilot · Gemini CLI · OpenCode · OpenClaw · Hermes Agent · OpenHands · Cline · Goose · Windsurf · Continue · Grok · Antigravity · Qwen Code · Crush · Kilo Code · Roo Code · Amp · Kiro CLI · Droid · TRAE IDE · Warp · Qoder · CodeBuddy
+Claude Code · Codex · Cursor · ZCode · GitHub Copilot · Gemini CLI · OpenCode · OpenClaw · Hermes Agent · OpenHands · Cline · Goose · Windsurf · Continue · Grok · Antigravity · Qwen Code · Crush · Kilo Code · Roo Code · Amp · Kiro CLI · Droid · TRAE IDE · Warp · Qoder · CodeBuddy
 
 **设置**页会列出全部，并优先展示在你机器上检测到的那些。你也可以在那里添加自定义工具，以相同方式管理其 Skills。
 

--- a/public/agent-icons/zcode.svg
+++ b/public/agent-icons/zcode.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="zcode-bg" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#2563EB"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#zcode-bg)"/>
+  <path d="M19 19 H45 L19 45 H45" stroke="#FFFFFF" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <rect x="46" y="40" width="6" height="6" rx="1.5" fill="#FFFFFF" fill-opacity="0.9"/>
+</svg>

--- a/src-tauri/src/core/tool_adapters.rs
+++ b/src-tauri/src/core/tool_adapters.rs
@@ -171,6 +171,23 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
             project_relative_skills_dir: None,
         },
         ToolAdapter {
+            // ZCode mirrors the Claude Code layout: user-level skills live in
+            // `~/.zcode/skills/<name>/SKILL.md` and project-level skills in
+            // `<repo>/.zcode/skills`. Plugin skills under
+            // `~/.zcode/cli/plugins/cache/` are intentionally not scanned,
+            // matching the Claude Code plugin-marketplace policy above.
+            key: "zcode".into(),
+            display_name: "ZCode".into(),
+            relative_skills_dir: ".zcode/skills".into(),
+            relative_detect_dir: ".zcode".into(),
+            additional_scan_dirs: vec![],
+            override_skills_dir: None,
+            category: ToolCategory::Coding,
+            is_custom: false,
+            recursive_scan: false,
+            project_relative_skills_dir: None,
+        },
+        ToolAdapter {
             // oh-my-pi (omp) reads native skills from asymmetric paths: the
             // user-level scan is `~/.omp/agent/skills` (the active profile's
             // agent dir), while the project-level scan walks up for
@@ -975,6 +992,28 @@ mod tests {
             .expect("claude_code adapter should exist");
 
         assert!(adapter.additional_scan_dirs.is_empty());
+    }
+
+    #[test]
+    fn zcode_uses_claude_code_style_symmetric_paths() {
+        let adapter = default_tool_adapters()
+            .into_iter()
+            .find(|adapter| adapter.key == "zcode")
+            .expect("zcode adapter should exist");
+
+        assert_eq!(adapter.display_name, "ZCode");
+        assert_eq!(adapter.relative_skills_dir, ".zcode/skills");
+        assert_eq!(adapter.relative_detect_dir, ".zcode");
+        // Same shape globally (~/.zcode/skills) and per-project
+        // (<repo>/.zcode/skills), so no project override is needed.
+        assert_eq!(adapter.project_relative_skills_dir(), ".zcode/skills");
+        assert!(adapter.project_relative_skills_dir.is_none());
+        // Plugin skills under ~/.zcode/cli/plugins are not scanned by default,
+        // matching the Claude Code plugin-marketplace policy.
+        assert!(adapter.additional_scan_dirs.is_empty());
+        assert!(!adapter.is_custom);
+        assert!(!adapter.recursive_scan);
+        assert_eq!(adapter.category, ToolCategory::Coding);
     }
 
     #[test]

--- a/src/lib/agentIcons.ts
+++ b/src/lib/agentIcons.ts
@@ -47,6 +47,7 @@ const AGENT_ICON_FILES: Record<string, string> = {
   warp: "warp.svg",
   windsurf: "windsurf.svg",
   workbuddy: "workbuddy.png",
+  zcode: "zcode.svg",
   zencoder: "zencoder.png",
 };
 


### PR DESCRIPTION
## Summary

Adds built-in support for the **ZCode** coding agent, following the same adapter pattern as the other 52 built-in tools.

ZCode mirrors the Claude Code skill layout:

- user-level skills: `~/.zcode/skills/<name>/SKILL.md`
- project-level skills: `<repo>/.zcode/skills`

So it registers as a single symmetric adapter with no project-path override. Plugin skills under `~/.zcode/cli/plugins/` are intentionally not scanned, matching the existing Claude Code plugin-marketplace policy (skills deployed there are managed by the plugin system, not the user).

## Changes

- `src-tauri/src/core/tool_adapters.rs`: new `zcode` adapter (`ToolCategory::Coding`) + unit test asserting the path contract
- `src/lib/agentIcons.ts` + `public/agent-icons/zcode.svg`: icon mapping and a self-contained SVG icon
- `README.md` / `README.zh-CN.md`: supported-tool list entries (52 → 53)

## Testing

- [x] New unit test `zcode_uses_claude_code_style_symmetric_paths` passes
- [x] Full `cargo test` suite: 435 passed; the only 6 failures are pre-existing symlink-privilege tests that fail identically on pristine `main` in the same environment (no symlink creation permission outside an elevated shell)
- [x] Frontend `tsc -b && vite build` and `eslint` pass
- [x] Verified on a real machine with ZCode installed: the adapter detects `~/.zcode`, resolves the skills dir, and finds existing skills
- [x] Built and ran the full app locally (NSIS bundle) and confirmed ZCode appears in Settings with skills syncing correctly
