### PR TITLE
chore(dev): ignore Rust build artifacts in Vite watcher

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 1420,
     strictPort: true,
+    watch: {
+    ignored: ["**/src-tauri/target/**"],
+    },
   },
   preview: {
     host: "127.0.0.1",


### PR DESCRIPTION
## 改动说明 / What changed

在 Vite 开发服务器中忽略 `src-tauri/target` 目录。

Ignore `src-tauri/target` in Vite's development watcher.

## 原因 / Why

Rust 在执行 `tauri dev` 时会频繁更新这个编译输出目录；忽略它可以避免 Vite 将无关的文件变化误判为前端改动，从而减少不必要的页面刷新和文件监听开销。

Rust rebuilds update this directory frequently during `tauri dev`. Ignoring it prevents unrelated frontend refreshes and unnecessary file-watch work.

## 影响范围 / Impact

仅改善本地开发体验，不影响正式发布后的应用功能。

This improves local development only and does not change production behavior.

