### PR TITLE
fix(project): include all enabled agents in preset default export targets

### DIFF
--- a/src/lib/exportAgents.ts
+++ b/src/lib/exportAgents.ts
@@ -1,0 +1,36 @@
+import type { ProjectAgentTarget } from "./tauri";
+
+const PROJECT_EXPORT_AGENT_PRIORITY = ["claude_code", "codex", "cursor", "gemini_cli", "github_copilot"];
+
+// Keys of project agents that can actually receive skills right now: both
+// installed on disk and enabled by the user. Used everywhere export targets
+// are derived so disabled/uninstalled agents never get project-local skills.
+export function enabledInstalledAgentKeys(targets: ProjectAgentTarget[]): string[] {
+  return targets.filter((target) => target.installed && target.enabled).map((target) => target.key);
+}
+
+export function getDefaultExportAgents(targets: ProjectAgentTarget[], savedValue?: string | null) {
+  const enabledKeys = enabledInstalledAgentKeys(targets);
+  const availableKeys = new Set(enabledKeys);
+  if (savedValue) {
+    try {
+      const parsed = JSON.parse(savedValue);
+      if (Array.isArray(parsed)) {
+        const filtered = parsed.filter((item): item is string => typeof item === "string" && availableKeys.has(item));
+        if (filtered.length > 0) {
+          return Array.from(new Set(filtered));
+        }
+      }
+    } catch {
+      // Ignore invalid persisted settings and fall back to built-in defaults.
+    }
+  }
+
+  // Priority agents first, then every other enabled agent in its detected
+  // order. All enabled agents are included: preset export must reach each
+  // one the user has installed and enabled (issue #400 — non-priority
+  // agents like "pi" were silently dropped when any priority agent was on).
+  const prioritized = PROJECT_EXPORT_AGENT_PRIORITY.filter((key) => availableKeys.has(key));
+  const rest = enabledKeys.filter((key) => !prioritized.includes(key));
+  return Array.from(new Set([...prioritized, ...rest]));
+}

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -34,6 +34,7 @@ import { PresetBar } from "../components/PresetBar";
 import { SkillMarkdown } from "../components/SkillMarkdown";
 import { DocumentDiffViewer } from "../components/DocumentDiffViewer";
 import { getTagActiveColor, getTagColor, pruneStaleTagFilters, UNTAGGED_FILTER } from "../lib/skillTags";
+import { enabledInstalledAgentKeys, getDefaultExportAgents } from "../lib/exportAgents";
 import { cn } from "../utils";
 import * as api from "../lib/tauri";
 import type { ProjectSkill, ManagedSkill, ProjectAgentTarget } from "../lib/tauri";
@@ -41,7 +42,6 @@ import { getErrorMessage } from "../lib/error";
 import { AddSkillsSheet } from "../components/AddSkillsSheet";
 
 const PROJECT_DEFAULT_EXPORT_AGENTS_KEY = "project_default_export_agents";
-const PROJECT_EXPORT_AGENT_PRIORITY = ["claude_code", "codex", "cursor", "gemini_cli", "github_copilot"];
 
 const projectLastUsedAgentsKey = (projectId: string) =>
   `project_last_used_export_agents:${projectId}`;
@@ -60,35 +60,6 @@ interface ProjectSkillGroup {
   status: ProjectSkill["sync_status"];
   tags: string[];
   centerSkillIds: string[];
-}
-
-// Keys of project agents that can actually receive skills right now: both
-// installed on disk and enabled by the user. Used everywhere export targets
-// are derived so disabled/uninstalled agents never get project-local skills.
-function enabledInstalledAgentKeys(targets: ProjectAgentTarget[]): string[] {
-  return targets.filter((target) => target.installed && target.enabled).map((target) => target.key);
-}
-
-function getDefaultExportAgents(targets: ProjectAgentTarget[], savedValue?: string | null) {
-  const enabledKeys = enabledInstalledAgentKeys(targets);
-  const availableKeys = new Set(enabledKeys);
-  if (savedValue) {
-    try {
-      const parsed = JSON.parse(savedValue);
-      if (Array.isArray(parsed)) {
-        const filtered = parsed.filter((item): item is string => typeof item === "string" && availableKeys.has(item));
-        if (filtered.length > 0) {
-          return Array.from(new Set(filtered));
-        }
-      }
-    } catch {
-      // Ignore invalid persisted settings and fall back to built-in defaults.
-    }
-  }
-
-  const prioritized = PROJECT_EXPORT_AGENT_PRIORITY.filter((key) => availableKeys.has(key));
-  const fallback = enabledKeys;
-  return Array.from(new Set((prioritized.length > 0 ? prioritized : fallback).slice(0, 3)));
 }
 
 function getSyncStatusMeta(t: (key: string) => string, status: ProjectSkill["sync_status"]) {


### PR DESCRIPTION
# 项目工作区 Preset 同步覆盖全部已启用 Agent

Fixes #400

## 现象

项目工作区启用多个 Agent（如 Claude Code、Codex、Pi）时，点击 Preset 只会同步 `claude code` 和 `codex`，其他 Agent 需要手动逐个操作；禁用这两个、只留一个 Agent 时 Preset 才正常。

## 根因

`getDefaultExportAgents()`（原位于 `src/views/ProjectDetail.tsx`）计算"默认导出目标 Agent"的逻辑：

```ts
const prioritized = PROJECT_EXPORT_AGENT_PRIORITY.filter((key) => availableKeys.has(key));
const fallback = enabledKeys;
return Array.from(new Set((prioritized.length > 0 ? prioritized : fallback).slice(0, 3)));
```

两个问题叠加：

1. **优先级列表独占**：只要优先级列表（`claude_code/codex/cursor/gemini_cli/github_copilot`）中有任意 Agent 启用，三元表达式就返回且仅返回优先级子集；`fallback`（全部启用 Agent）不可达。因此不在列表里的 Agent（如 `pi`）永远不会进入 Preset 的同步/取消目标。
2. **`slice(0, 3)` 截断**：默认目标最多 3 个，启用超过 3 个 Agent 时尾部同样被静默丢弃。

Preset 条（`PresetBar`）的激活/取消都以这个集合为循环目标，所以"点击 Preset 只同步两个 Agent"正是上述逻辑的直接结果。

## 修复

1. **默认导出目标改为"全部启用 + 已安装"**：优先级 Agent 在前、其余启用且已安装的 Agent 按检测顺序追加，并移除 3 个的上限。这样项目工作区点击 Preset（激活或取消）都覆盖当前所有 `enabled && installed` 的 Agent，与 Rust 侧 `export_skill_to_project` 对请求 Agent 的 `installed && enabled` 过滤口径一致（Rust 侧无需改动）。
2. **纯函数提取**：`enabledInstalledAgentKeys` / `getDefaultExportAgents` 提取到新模块 `src/lib/exportAgents.ts`（与 `src/lib/` 其他纯逻辑模块的摆放方式一致），`ProjectDetail.tsx` 改为从中导入，便于直接针对该逻辑做回归验证。

## 验证

- 纯函数回归断言 9 项全部通过（含 #400 场景：`claude_code + codex + pi` 三者全部启用时默认目标包含 `pi`；单 Agent 场景保持可用；禁用/未安装 Agent 被排除；持久化设置仍优先；5 个启用 Agent 不再被截断；优先级顺序保留）。
- `tsc -b`、`eslint` 通过。
- `tauri build` 产出 `skills-manager_1.35.0_aarch64.dmg`，本机安装实测：启用 claude code / codex / pi 三个 Agent 后，项目工作区点击 Preset 三者同时同步，取消逻辑同样覆盖三者。
