### PR TITLE
feat(window): persist and restore window geometry on startup

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4978,6 +4978,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tempfile",
  "tokio",
  "unicode-normalization",
@@ -5564,6 +5565,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip 4.6.1",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-window-state = "2"
 rusqlite = { version = "0.31", features = ["bundled"] }
 uuid = { version = "1", features = ["v4", "v7"] }
 sha2 = "0.10"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tauri::{Emitter, Manager};
+use tauri_plugin_window_state::{AppHandleExt, StateFlags, WindowExt};
 
 pub mod commands;
 pub mod core;
@@ -788,6 +789,12 @@ pub fn restart_app(app: &tauri::AppHandle) {
 
 fn teardown_before_exit(app: &tauri::AppHandle) {
     QUITTING.store(true, Ordering::SeqCst);
+    let _ = app.save_window_state(
+        StateFlags::SIZE
+            | StateFlags::POSITION
+            | StateFlags::MAXIMIZED
+            | StateFlags::FULLSCREEN,
+    );
     if let Some(w) = app.get_webview_window("main") {
         if let Err(err) = w.destroy() {
             log::error!("Failed to destroy main window while quitting: {err}");
@@ -822,6 +829,16 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(
+                    StateFlags::SIZE
+                        | StateFlags::POSITION
+                        | StateFlags::MAXIMIZED
+                        | StateFlags::FULLSCREEN,
+                )
+                .build(),
+        )
         .setup(move |app| {
             // Snapshot the builder->setup gap BEFORE doing any work in setup,
             // so the label reflects only the time Tauri spent constructing
@@ -962,8 +979,15 @@ pub fn run() {
                     api.prevent_close();
                 }
             });
+            let _ = win.restore_state(
+                StateFlags::SIZE
+                    | StateFlags::POSITION
+                    | StateFlags::MAXIMIZED
+                    | StateFlags::FULLSCREEN,
+            );
+            win.show()?;
             log::info!(
-                "startup: window handle + close hook in {} ms",
+                "startup: window handle + close hook + state restore in {} ms",
                 step.elapsed().as_millis()
             );
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,8 @@
         "fullscreen": false,
         "decorations": true,
         "titleBarStyle": "Overlay",
-        "hiddenTitle": true
+        "hiddenTitle": true,
+        "visible": false
       }
     ],
     "security": {


### PR DESCRIPTION
### Summary

Persists and restores window geometry (`size`, `position`, `maximized`, and `fullscreen`) across application restarts using the official Tauri `tauri-plugin-window-state` plugin, while ensuring a clean, flicker-free startup across all platforms.

### Motivation

Previously, the desktop application always launched with default dimensions (`1440x860`) centered on the screen. Any custom user layout adjustments (window resizing, positioning, maximizing, or fullscreen) were discarded on restart. 

Additionally, adjusting window dimensions after it is already visible causes visual flickering during startup.

### Key Changes

1. **Window State Persistence**:
   - Integrated `tauri-plugin-window-state` (v2) in `src-tauri/Cargo.toml` and registered it in `src-tauri/src/lib.rs`.
   - Tracked flags: `StateFlags::SIZE | StateFlags::POSITION | StateFlags::MAXIMIZED | StateFlags::FULLSCREEN`.

2. **Flicker-Free Startup**:
   - Set `"visible": false` on the main window in `src-tauri/tauri.conf.json`.
   - In `run().setup(...)`, restored window geometry via `win.restore_state(...)` before invoking `win.show()?`, ensuring the window appears only after reaching its target size and position.

3. **Safe Teardown Persistence**:
   - Explicitly invoked `app.save_window_state(...)` inside `teardown_before_exit` prior to `w.destroy()`, ensuring geometry is saved to disk before window handles are dropped.

### Design Considerations

- **Omitted `StateFlags::VISIBLE`**: Intentionally excluded `VISIBLE` from state flags so that closing/hiding the application to the system tray will not cause the window to remain hidden on subsequent cold launches.
- **Graceful Error Handling**: Used `let _ = win.restore_state(...)` so missing or corrupted state files degrade gracefully to defaults without crashing or blocking startup.
- **Clean Scope**: Modified only the necessary Rust/Tauri configurations without introducing unrelated lockfile or frontend diffs.

### Verification & Platform Testing

Tested and verified across multiple OS environments:
- [x] **Windows (11)**: Resize/move/maximize/fullscreen persistence & tray teardown verified.
- [x] **macOS**: Window restore, Dock hide/show, and tray restoration verified.

Specific scenarios covered:
- [x] **Resize & Reposition**: Resized and moved window -> Restarted app -> Restored to exact previous geometry.
- [x] **Maximized & Fullscreen**: Maximized window -> Restarted -> Remained maximized.
- [x] **Tray Integration**: Closed to tray -> Quit via tray -> Restarted -> Restored properly at previous size.
- [x] **Cold Start**: Deleted state file / first-time launch -> Opens cleanly with default `1440x860` window.
- [x] **Static Checks**: `npm run lint` passed with 0 errors.