### PR TITLE
feat(MySkills): 支持按导入来源分类/筛选/分组技能

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -390,8 +390,14 @@
       "local": "Local",
       "import": "Imported",
       "git": "Git",
-      "skillssh": "skills.sh"
+      "skillssh": "skills.sh",
+      "source": "Source",
+      "searchPlaceholder": "Search source",
+      "unknown": "Unknown source",
+      "noMatches": "No matching sources",
+      "selectedCount": "{{count}} source(s) selected"
     },
+    "groupBySource": "Group by source",
     "tags": {
       "filter": "Tags",
       "allTags": "All Tags",

--- a/src/i18n/zh-TW.json
+++ b/src/i18n/zh-TW.json
@@ -360,8 +360,14 @@
       "local": "本機",
       "import": "匯入",
       "git": "Git",
-      "skillssh": "skills.sh"
+      "skillssh": "skills.sh",
+      "source": "來源",
+      "searchPlaceholder": "搜尋來源",
+      "unknown": "未知來源",
+      "noMatches": "沒有相符的來源",
+      "selectedCount": "已選 {{count}} 個來源"
     },
+    "groupBySource": "按來源分組",
     "tags": {
       "filter": "標籤",
       "allTags": "全部標籤",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -390,8 +390,14 @@
       "local": "本地",
       "import": "导入",
       "git": "Git",
-      "skillssh": "skills.sh"
+      "skillssh": "skills.sh",
+      "source": "来源",
+      "searchPlaceholder": "搜索来源",
+      "unknown": "未知来源",
+      "noMatches": "没有匹配的来源",
+      "selectedCount": "已选 {{count}} 个来源"
     },
+    "groupBySource": "按来源分组",
     "tags": {
       "filter": "标签",
       "allTags": "全部标签",

--- a/src/lib/skillSource.ts
+++ b/src/lib/skillSource.ts
@@ -1,0 +1,176 @@
+import type { ManagedSkill } from "./tauri";
+
+export interface SkillSourceInfo {
+  key: string;
+  label: string;
+  type: string;
+  raw: string;
+}
+
+export interface SkillSourceGroup {
+  key: string;
+  label: string;
+  type: string;
+  raw: string;
+  count: number;
+  skills: ManagedSkill[];
+}
+
+const cleanPath = (value: string) =>
+  value.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+
+function parseGitRef(
+  ref: string,
+  type: string,
+  raw: string
+): SkillSourceInfo | null {
+  const trimmed = ref.trim();
+  if (!trimmed) return null;
+
+  let host = "";
+  let path = "";
+  const scp = trimmed.match(/^git@([^:/]+):(.+)$/i);
+  const url = trimmed.match(
+    /^(?:https?|ssh):\/\/(?:[^@/]+@)?([^\s:/]+)(?::\d+)?\/(.+)$/i
+  );
+  const shorthand = trimmed.match(
+    /^([a-zA-Z0-9._-]+)\/([a-zA-Z0-9._-]+)(\.git)?$/
+  );
+
+  if (scp) {
+    host = scp[1];
+    path = scp[2];
+  } else if (url) {
+    host = url[1];
+    path = url[2];
+  } else if (shorthand) {
+    host = "github.com";
+    path = `${shorthand[1]}/${shorthand[2]}`;
+  } else {
+    const slash = trimmed.indexOf("/");
+    if (slash > 0 && /^[a-zA-Z0-9.-]+$/.test(trimmed.slice(0, slash))) {
+      host = trimmed.slice(0, slash);
+      path = trimmed.slice(slash + 1);
+    } else {
+      path = trimmed;
+    }
+  }
+
+  path = cleanPath(path);
+  if (!path) return null;
+
+  const hostLower = host.toLowerCase();
+  if (hostLower === "github.com") {
+    return { key: path.toLowerCase(), label: path, type, raw };
+  }
+  if (host) {
+    const label = `${host}/${path}`;
+    return {
+      key: `${hostLower}/${path.toLowerCase()}`,
+      label,
+      type,
+      raw,
+    };
+  }
+  return { key: path.toLowerCase(), label: path, type, raw };
+}
+
+function parseSkillShRef(ref: string, type: string, raw: string): SkillSourceInfo | null {
+  const trimmed = ref.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split("/").filter(Boolean);
+  // For a full skillssh reference like `owner/repo/skill-id`, the source is
+  // `owner/repo`. Shorter references are treated as the source itself.
+  const source = parts.length > 2 ? parts.slice(0, -1).join("/") : trimmed;
+  if (!source) return null;
+  const label = `skills.sh/${source}`;
+  return { key: `skills.sh:${source.toLowerCase()}`, label, type, raw };
+}
+
+function parseLocalRef(ref: string, type: string, raw: string): SkillSourceInfo {
+  const trimmed = ref.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  if (!trimmed) {
+    return { key: `unknown:${type}`, label: "", type, raw: raw || trimmed };
+  }
+  const normalized = trimmed.toLowerCase();
+  const label = trimmed.split("/").filter(Boolean).pop() || trimmed;
+  return { key: `${type}:${normalized}`, label, type, raw: raw || trimmed };
+}
+
+export function getSkillSourceInfo(skill: ManagedSkill): SkillSourceInfo {
+  const resolved = skill.source_ref_resolved || "";
+  const ref = skill.source_ref || "";
+  const raw = ref || resolved;
+
+  if (skill.source_type === "git" && resolved) {
+    const gitInfo = parseGitRef(resolved, skill.source_type, raw);
+    if (gitInfo) return gitInfo;
+  }
+
+  if (skill.source_type === "skillssh") {
+    if (resolved) {
+      const gitInfo = parseGitRef(resolved, skill.source_type, raw);
+      if (gitInfo) return gitInfo;
+    }
+    if (ref) {
+      const skillShInfo = parseSkillShRef(ref, skill.source_type, raw);
+      if (skillShInfo) return skillShInfo;
+    }
+  }
+
+  if (skill.source_type === "local" || skill.source_type === "import") {
+    return parseLocalRef(resolved, skill.source_type, raw);
+  }
+
+  if (raw) {
+    return {
+      key: `${skill.source_type}:${raw.toLowerCase()}`,
+      label: raw,
+      type: skill.source_type,
+      raw,
+    };
+  }
+  return {
+    key: `unknown:${skill.source_type}`,
+    label: "",
+    type: skill.source_type,
+    raw,
+  };
+}
+
+/**
+ * Groups skills by normalized source.
+ *
+ * The input order is preserved inside each group. Group order is deterministic:
+ * larger groups first, then locale-aware label order (falling back to key).
+ */
+export function buildSourceGroups(skills: ManagedSkill[]): SkillSourceGroup[] {
+  const map = new Map<string, SkillSourceGroup>();
+  for (const skill of skills) {
+    const info = getSkillSourceInfo(skill);
+    const existing = map.get(info.key);
+    if (existing) {
+      existing.count += 1;
+      existing.skills.push(skill);
+    } else {
+      map.set(info.key, {
+        key: info.key,
+        label: info.label,
+        type: info.type,
+        raw: info.raw,
+        count: 1,
+        skills: [skill],
+      });
+    }
+  }
+
+  const groups = Array.from(map.values());
+  groups.sort(
+    (a, b) =>
+      b.count - a.count ||
+      (a.label || a.key).localeCompare(b.label || b.key, undefined, {
+        sensitivity: "base",
+      })
+  );
+  return groups;
+}

--- a/src/views/MySkills.tsx
+++ b/src/views/MySkills.tsx
@@ -22,6 +22,7 @@ import {
   CircleSlash,
   Pencil,
   Trash2,
+  ChevronDown,
 } from "lucide-react";
 import { open as dialogOpen } from "@tauri-apps/plugin-dialog";
 import { useNavigate } from "react-router-dom";
@@ -47,6 +48,7 @@ import type {
   SkillToolToggle,
 } from "../lib/tauri";
 import { getErrorMessage } from "../lib/error";
+import { getSkillSourceInfo, buildSourceGroups, type SkillSourceGroup } from "../lib/skillSource";
 import {
   DndContext,
   closestCenter,
@@ -64,6 +66,9 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+
+const VIEW_MODE_LS_KEY = "skills-manager.mySkillsViewMode";
+const GROUP_BY_SOURCE_LS_KEY = "skills-manager.mySkillsGroupBySource";
 
 interface SortableSkillItemProps {
   id: string;
@@ -144,9 +149,41 @@ export function MySkills() {
     projects,
     refreshProjects,
   } = useApp();
-  const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
+  const [viewMode, setViewMode] = useState<"grid" | "list">(() => {
+    try {
+      return localStorage.getItem(VIEW_MODE_LS_KEY) === "list" ? "list" : "grid";
+    } catch {
+      return "grid";
+    }
+  });
+  const [groupBySource, setGroupBySource] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(GROUP_BY_SOURCE_LS_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
   const [filterMode, setFilterMode] = useState<"all" | "enabled" | "available">("all");
   const [sourceFilters, setSourceFilters] = useState<Set<string>>(new Set());
+  const [selectedSources, setSelectedSources] = useState<Set<string>>(new Set());
+  const [sourceMenuOpen, setSourceMenuOpen] = useState(false);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(VIEW_MODE_LS_KEY, viewMode);
+    } catch {
+      // localStorage may be unavailable.
+    }
+  }, [viewMode]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(GROUP_BY_SOURCE_LS_KEY, String(groupBySource));
+    } catch {
+      // localStorage may be unavailable.
+    }
+  }, [groupBySource]);
+  const [sourceSearch, setSourceSearch] = useState("");
   const [tagFilters, setTagFilters] = useState<Set<string>>(new Set());
   const [allTags, setAllTags] = useState<string[]>([]);
   // Tag management from the filter bar (#233): right-click a tag pill to
@@ -247,11 +284,14 @@ export function MySkills() {
   const hasActiveFilters =
     search.trim() !== "" ||
     sourceFilters.size > 0 ||
+    selectedSources.size > 0 ||
     tagFilters.size > 0 ||
     filterMode !== "all";
   const clearFilters = () => {
     setSearch("");
     setSourceFilters(new Set());
+    setSelectedSources(new Set());
+    setSourceSearch("");
     setTagFilters(new Set());
     setFilterMode("all");
   };
@@ -275,8 +315,8 @@ export function MySkills() {
     return displayNames;
   }, [skills]);
 
-  const filtered = useMemo(() => {
-    const result = skills.filter((skill) => {
+  const baseFiltered = useMemo(() => {
+    return skills.filter((skill) => {
       const displayName = skillDisplayNames.get(skill.id) || skill.name;
       const matchesSearch =
         skill.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -289,8 +329,46 @@ export function MySkills() {
       if (tagFilters.size > 0) {
         const wantUntagged = tagFilters.has(UNTAGGED_FILTER);
         const matchUntagged = wantUntagged && skill.tags.length === 0;
-        const matchTag = skill.tags.some((t) => tagFilters.has(t));
+        const matchTag = skill.tags.some((tag) => tagFilters.has(tag));
         if (!matchUntagged && !matchTag) return false;
+      }
+
+      return true;
+    });
+  }, [skills, skillDisplayNames, search, sourceFilters, tagFilters]);
+
+  const sourceGroups = useMemo(() => buildSourceGroups(baseFiltered), [baseFiltered]);
+
+  useEffect(() => {
+    if (selectedSources.size === 0) return;
+    const validKeys = new Set(sourceGroups.map((group) => group.key));
+    const next = new Set([...selectedSources].filter((key) => validKeys.has(key)));
+    if (next.size !== selectedSources.size) setSelectedSources(next);
+  }, [sourceGroups, selectedSources]);
+
+  useEffect(() => {
+    if (!sourceMenuOpen) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setSourceMenuOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [sourceMenuOpen]);
+
+  const visibleSourceOptions = useMemo(() => {
+    const query = sourceSearch.trim().toLowerCase();
+    if (!query) return sourceGroups;
+    return sourceGroups.filter((group) =>
+      [group.key, group.label, group.raw].some((value) =>
+        value.toLowerCase().includes(query)
+      )
+    );
+  }, [sourceGroups, sourceSearch]);
+
+  const filtered = useMemo(() => {
+    const result = baseFiltered.filter((skill) => {
+      if (selectedSources.size > 0 && !selectedSources.has(getSkillSourceInfo(skill).key)) {
+        return false;
       }
 
       if (!viewedPreset) return true;
@@ -318,7 +396,21 @@ export function MySkills() {
     }
 
     return result;
-  }, [skills, skillDisplayNames, search, sourceFilters, tagFilters, filterMode, viewedPreset, presetSkillOrder]);
+  }, [baseFiltered, selectedSources, filterMode, viewedPreset, presetSkillOrder]);
+
+  const displayGroups = useMemo(
+    () => (groupBySource ? buildSourceGroups(filtered) : null),
+    [filtered, groupBySource]
+  );
+
+  const toggleSourceGroupFilter = useCallback(
+    (key: string) => {
+      setSelectedSources((prev) =>
+        prev.size === 1 && prev.has(key) ? new Set<string>() : new Set([key])
+      );
+    },
+    []
+  );
 
   const {
     isMultiSelect, setIsMultiSelect,
@@ -373,7 +465,7 @@ export function MySkills() {
     [filtered, viewedPreset]
   );
 
-  const canDrag = !!viewedPreset;
+  const canDrag = !!viewedPreset && !groupBySource;
 
   const refreshGitStatus = useCallback(async () => {
     try {
@@ -1025,6 +1117,27 @@ export function MySkills() {
   const sourceTypeLabel = (skill: ManagedSkill) =>
     skill.source_type === "skillssh" ? "skills.sh" : skill.source_type;
 
+  const renderSourceHeader = (group: SkillSourceGroup) => (
+    <div
+      key={`source-group-${group.key}`}
+      className={cn(
+        "flex items-center gap-2 px-1 pt-3 first:pt-0",
+        viewMode === "grid" && "col-span-full"
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => toggleSourceGroupFilter(group.key)}
+        className="inline-flex items-center gap-1.5 rounded-md px-1.5 py-0.5 text-[12px] font-semibold text-muted transition-colors hover:bg-surface-hover hover:text-secondary"
+        title={group.raw || group.key}
+      >
+        {sourceIcon(group.type)}
+        <span className="truncate">{group.label || t("mySkills.sourceFilter.unknown")}</span>
+        <span className="text-[11px] font-medium text-faint">{group.count}</span>
+      </button>
+    </div>
+  );
+
   const refreshLabel = (skill: ManagedSkill) =>
     skill.source_type === "local" || skill.source_type === "import"
       ? t("mySkills.updateActions.reimport")
@@ -1134,6 +1247,17 @@ export function MySkills() {
             {t("mySkills.updateActions.updateAvailable", { count: availableUpdateCount })}
           </button>
           <button
+            onClick={() => setGroupBySource((value) => !value)}
+            className={cn(
+              "rounded-md p-2 transition-colors outline-none",
+              groupBySource ? "bg-surface-active text-secondary" : "text-muted hover:text-tertiary"
+            )}
+            title={t("mySkills.groupBySource")}
+            aria-label={t("mySkills.groupBySource")}
+          >
+            <Layers className="h-4 w-4" />
+          </button>
+          <button
             onClick={() => setViewMode("grid")}
             className={cn(
               "rounded-md p-2 transition-colors outline-none",
@@ -1179,6 +1303,108 @@ export function MySkills() {
             {t(`mySkills.sourceFilter.${src}`)}
           </button>
         ))}
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setSourceMenuOpen((open) => !open)}
+            title={
+              selectedSources.size > 0
+                ? t("mySkills.sourceFilter.selectedCount", { count: selectedSources.size })
+                : t("mySkills.sourceFilter.source")
+            }
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[12px] font-medium transition-colors",
+              selectedSources.size > 0
+                ? "bg-accent text-white dark:bg-accent dark:text-white"
+                : "bg-surface-hover text-muted hover:text-secondary"
+            )}
+          >
+            <span className="max-w-[160px] truncate">
+              {selectedSources.size > 0
+                ? t("mySkills.sourceFilter.selectedCount", { count: selectedSources.size })
+                : t("mySkills.sourceFilter.source")}
+            </span>
+            <ChevronDown className={cn("h-3 w-3 transition-transform", sourceMenuOpen && "rotate-180")} />
+          </button>
+          {sourceMenuOpen && (
+            <>
+              <div
+                className="fixed inset-0 z-40"
+                onClick={() => {
+                  setSourceMenuOpen(false);
+                  setSourceSearch("");
+                }}
+              />
+              <div className="absolute left-0 top-full z-50 mt-1 w-72 overflow-hidden rounded-lg border border-border bg-surface shadow-2xl">
+                <div className="border-b border-border-subtle p-2">
+                  <input
+                    type="text"
+                    value={sourceSearch}
+                    onChange={(e) => setSourceSearch(e.target.value)}
+                    placeholder={t("mySkills.sourceFilter.searchPlaceholder")}
+                    className="app-input w-full"
+                    autoFocus
+                  />
+                </div>
+                <div className="max-h-64 overflow-y-auto p-1">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSelectedSources(new Set());
+                      setSourceMenuOpen(false);
+                      setSourceSearch("");
+                    }}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors",
+                      selectedSources.size === 0
+                        ? "bg-surface-active text-primary"
+                        : "text-secondary hover:bg-surface-hover"
+                    )}
+                  >
+                    <span>{t("mySkills.sourceFilter.all")}</span>
+                    <span className="text-[11px] text-muted">{baseFiltered.length}</span>
+                  </button>
+                  {visibleSourceOptions.map((option) => {
+                    const isSelected = selectedSources.has(option.key);
+                    return (
+                      <button
+                        key={option.key}
+                        type="button"
+                        onClick={() => setSelectedSources(toggleFilter(selectedSources, option.key))}
+                        className={cn(
+                          "flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors",
+                          isSelected
+                            ? "bg-surface-active text-primary"
+                            : "text-secondary hover:bg-surface-hover"
+                        )}
+                      >
+                        <span className="flex min-w-0 flex-1 items-center gap-2">
+                          {isSelected ? (
+                            <SquareCheck className="h-3.5 w-3.5 shrink-0 text-accent" />
+                          ) : (
+                            <Square className="h-3.5 w-3.5 shrink-0 text-faint" />
+                          )}
+                          <span
+                            className="min-w-0 truncate"
+                            title={option.raw || option.key}
+                          >
+                            {option.label || t("mySkills.sourceFilter.unknown")}
+                          </span>
+                        </span>
+                        <span className="shrink-0 text-[11px] text-muted">{option.count}</span>
+                      </button>
+                    );
+                  })}
+                  {visibleSourceOptions.length === 0 && (
+                    <div className="px-2 py-2 text-[13px] text-muted">
+                      {t("mySkills.sourceFilter.noMatches")}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
         {allTags.length > 0 && (
           <>
             <span className="mx-0.5 h-3 w-px bg-border-subtle" />
@@ -1284,7 +1510,8 @@ export function MySkills() {
                 : "flex flex-col gap-0.5"
             )}
           >
-          {filtered.map((skill) => {
+          {(() => {
+            const renderSkill = (skill: ManagedSkill) => {
             const enabledInPreset = viewedPreset
               ? skill.preset_ids.includes(viewedPreset.id)
               : false;
@@ -1758,7 +1985,15 @@ export function MySkills() {
               )}
               </SortableSkillItem>
             );
-          })}
+          };
+
+            return displayGroups
+              ? displayGroups.flatMap((group) => [
+                  renderSourceHeader(group),
+                  ...group.skills.map(renderSkill),
+                ])
+              : filtered.map(renderSkill);
+          })()}
         </div>
           </SortableContext>
         </DndContext>


### PR DESCRIPTION
## 背景

当前 My Skills 页面已经支持按来源类型（Local / Import / Git / skills.sh）筛选，但用户从多个具体来源导入技能后，往往还需要进一步区分“具体来自哪个仓库或路径”。例如：

- `mattpocock/skills`
- `obra/superpowers`
- 本地目录 `/Users/xxx/skills`
- 导入目录 `~/ImportedSkills`

这些都属于 `git`、`import` 或 `local` 类型，但来源并不相同。本次改动在 My Skills 视图中增加“按导入来源分类”的能力，让用户可以更清晰地管理和筛选技能库。

## 功能说明

本次改动为纯前端功能，不修改 Rust/Tauri 后端接口，也不改变技能数据结构。

主要功能包括：

1. 在 My Skills 页面增加“来源”筛选下拉菜单。
2. 支持多选具体来源，例如同时筛选 `mattpocock/skills` 和 `obra/superpowers`。
3. 支持“按来源分组”展示，列表视图和网格视图均支持。
4. 点击分组标题可快速隔离该来源；再次点击可取消筛选。
5. 视图模式（Grid / List）和是否按来源分组会保存在本地。
6. 来源筛选选择项本身不持久化，避免用户重新打开应用时看到过期的来源筛选状态。
7. 分组展示模式下禁用拖拽排序，避免全局 Preset 排序语义与局部分组展示混淆。

## 实现说明

### 1. 新增来源解析模块

新增文件：

```text
src/lib/skillSource.ts
```

该模块提供两个核心能力：

```ts
getSkillSourceInfo(skill: ManagedSkill): SkillSourceInfo
buildSourceGroups(skills: ManagedSkill[]): SkillSourceGroup[]
```

`getSkillSourceInfo` 负责把不同来源的 skill 归一化为稳定的来源 key 和展示 label。

#### Git 来源归一化

Git 来源会解析 `source_ref` 与 `source_ref_resolved`，支持常见格式：

```text
git@github.com:owner/repo.git
https://github.com/owner/repo.git
https://github.com/owner/repo
ssh://git@github.com/owner/repo.git
owner/repo
```

归一化规则：

- GitHub 来源统一归一为 `owner/repo`。
- URL 大小写会被标准化。
- `.git` 后缀会被去掉。
- 分支、子路径、revision 不作为主来源 key，因为它们只表示同一仓库中的不同版本或子目录。
- 非 GitHub 的 Git 来源会保留 host 前缀，避免不同 host 下的同名仓库冲突。

例如：

```text
git@github.com:obra/superpowers.git
https://github.com/obra/Superpowers.git
https://github.com/obra/superpowers
```

都会归一为：

```text
obra/superpowers
```

#### skills.sh 来源归一化

`skills.sh` 来源优先检查是否能解析到 GitHub 仓库。如果可以解析到 GitHub 仓库，则与对应 Git 来源合并为同一来源；否则使用 `skills.sh/<source>` 作为来源 key。

#### Local / Import 来源归一化

本地来源和导入来源按路径归一：

```text
local:/tmp/a
import:c:/skills/b
```

展示 label 默认取路径的最后一级名称。若没有路径，则归入 unknown。

### 2. 来源筛选逻辑

`MySkills.tsx` 中的筛选链路调整为：

1. 先用搜索词、来源类型、标签筛选得到候选技能。
2. 基于候选技能计算可显示的具体来源列表。
3. 再用具体来源多选对候选结果做进一步过滤。

这样设计可以避免一个逻辑问题：如果具体来源筛选也会影响来源候选列表，那么用户选中某个来源后，该来源可能从下拉菜单中消失，导致无法取消选择。

### 3. 分组展示

当开启“按来源分组”后，页面会按来源 key 对当前筛选结果分组，并显示分组标题。

分组顺序规则：

- 先按该来源下的技能数量降序；
- 数量相同则按 label 或 key 的 locale 排序。

组内技能保持当前筛选和排序结果顺序。

在 Preset 视图下，仍保持原有排序逻辑：已启用技能在前，Preset 自定义顺序优先。分组只是展示层变化，不改变 Preset 的启用状态或底层排序数据。

### 4. 分组标题交互

点击分组标题会把该来源设为唯一选中的来源筛选；再次点击同一分组标题则清空来源筛选。

交互目标是让用户可以快速“聚焦某个来源”，而不必每次都打开下拉菜单。

### 5. 状态持久化

新增两个 localStorage key：

```text
skills-manager.mySkillsViewMode
skills-manager.mySkillsGroupBySource
```

其中：

- `viewMode`：Grid / List，默认 Grid。
- `groupBySource`：是否按来源分组，默认 false。

具体来源筛选 `selectedSources` 不持久化，因为来源列表可能随技能库变化而变化，持久化容易产生过期的筛选状态。

### 6. 拖拽排序

当前拖拽排序对应的是 Preset 内全局技能顺序。分组展示下，视觉顺序是“来源分组 + 组内顺序”，与全局顺序不一致，因此分组模式下禁用拖拽，避免用户误操作改变 Preset 的全局排序。

## 改动文件

```text
src/lib/skillSource.ts
src/views/MySkills.tsx
src/i18n/en.json
src/i18n/zh.json
src/i18n/zh-TW.json
```

主要改动：

- 新增 `src/lib/skillSource.ts`，集中处理来源解析和分组逻辑。
- `MySkills.tsx` 增加来源筛选、分组展示、来源分组切换和状态持久化。
- i18n 增加 `selectedCount` 与 `groupBySource` 等文案。

## 验证

本地验证通过：

```bash
npm run build
npx eslint src/views/MySkills.tsx src/lib/skillSource.ts
```

并单独验证了 `skillSource.ts` 的纯函数逻辑，包括：

- `git@github.com:obra/superpowers.git` 与 `https://github.com/obra/Superpowers.git` 归一为同一来源；
- 分支、子路径不影响来源 key；
- `skills.sh` 可解析到 GitHub repo 时并入 repo 来源；
- `local/import` 路径按路径分组；
- 分组顺序按数量降序、label 升序；
- 组内顺序保持输入顺序。

## 截图

![Skill source categorization UI](https://raw.githubusercontent.com/ZhuYichuan/skills-manager/assets/source-category-screenshot/screenshots/source-category-screenshot.jpg)

## 兼容性与风险

- 不修改后端数据模型。
- 不修改已有 source type 筛选逻辑。
- 对旧数据是向前兼容的：无法识别来源的 skill 会归入 unknown 或 `type:ref` 兜底 key。
- 主要风险是复杂 Git URL 或自定义 host 的归一化边界；当前实现优先覆盖常见 Git/skills.sh/local/import 场景。

## 备注

截图文件托管在 fork 的 `assets/source-category-screenshot` 分支中，避免把图片文件混入本 PR 的代码 diff。
```
