### PR TITLE
docs(readme): document Homebrew as a macOS install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@
 - **Flexible app settings** — Configure repo path, sync mode, theme, text size, language, tray behavior, proxy, Git remote, update checks, and the order agents appear throughout the app — all in one place.
 - **In-app updates** — The app tells you when a new version is out and installs it for you on macOS and Windows. Nothing downloads or installs on its own: checking only notifies, and installing and restarting each take a click.
 
+## Install
+
+### macOS
+
+Install with [Homebrew](https://brew.sh):
+
+```bash
+brew install --cask skills-manager
+```
+
+You can also download the `.dmg` for your Mac from the [latest release](https://github.com/xingkongliang/skills-manager/releases/latest).
+
+### Windows and Linux
+
+Download the installer for your platform from the [latest release](https://github.com/xingkongliang/skills-manager/releases/latest): `.exe` or `.msi` for Windows, and `.AppImage`, `.deb`, or `.rpm` for Linux (x64 and arm64).
+
 ## Quick Start
 
 1. Install skills from local folders, Git repositories, archives, or the marketplace.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,6 +77,22 @@
 - **灵活的应用设置** — 在一个页面里配置仓库路径、同步模式、主题、字号、语言、托盘行为、代理、Git 远程、更新检查，以及 Agent 在全应用中的显示顺序。
 - **应用内更新** — 有新版本时应用会主动提醒，并在 macOS 和 Windows 上直接完成安装。不会自行下载或安装：检查只负责告知，安装和重启各需一次点击。
 
+## 安装
+
+### macOS
+
+使用 [Homebrew](https://brew.sh) 安装：
+
+```bash
+brew install --cask skills-manager
+```
+
+也可以从 [最新 Release](https://github.com/xingkongliang/skills-manager/releases/latest) 直接下载 `.dmg`。
+
+### Windows 和 Linux
+
+从 [最新 Release](https://github.com/xingkongliang/skills-manager/releases/latest) 下载对应平台的安装包：Windows 为 `.exe` 或 `.msi`，Linux 为 `.AppImage`、`.deb` 或 `.rpm`（提供 x64 和 arm64）。
+
 ## 快速上手
 
 1. 从本地目录、Git 仓库、压缩包或市场安装 Skills。


### PR DESCRIPTION
This updates the README to add user-facing installation instructions, including the new Homebrew cask for macOS.

Currently the Quick Start opens at step 1 with "Install skills from local folders, Git repositories, archives, or the marketplace", which assumes Skills Manager is already running, and Getting Started is the development setup.

Two open issues ask for the same thing from the other direction: #284 and #375.

## The change

This adds an `## Install` section ahead of Quick Start in `README.md` and `README.zh-CN.md`:

- macOS leads with the Homebrew one-liner and keeps the `.dmg` as the alternative.
- Windows and Linux point at the release assets that already ship: `.exe` or `.msi`, and `.AppImage`, `.deb`, or `.rpm` for x64 and arm64.

Docs only. No code, no build changes, no CI changes.

## Maintenance

Regarding the homebrew cask, there is nothing for you to maintain. The cask is on Homebrew's autobump list (`"autobump": true` in the formulae API), so BrewTestBot opens the version-bump PR automatically when a release is tagged. The cask went in at 1.34.2 and is serving 1.35.1 today without anyone touching it.

## One thing outside this repo

skillsmanager.dev builds from somewhere I cannot see, so it is not covered here. Its download section probably wants the same Homebrew line. Happy to open a PR there if the source is public, or you can lift the two lines from this one.

Closes #284
Closes #375
