### PR TITLE
feat(sidebar): make sidebar width resizable

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,6 +30,50 @@ import * as api from "../lib/tauri";
 import type { SyncHealth, ToolCategory, ToolInfo } from "../lib/tauri";
 import { getPresetIconOption } from "../lib/presetIcons";
 
+const SIDEBAR_WIDTH_STORAGE_KEY = "skills-manager:sidebar-width";
+const DEFAULT_SIDEBAR_WIDTH = 220;
+const MIN_SIDEBAR_WIDTH = 220;
+const MAX_SIDEBAR_WIDTH = 420;
+const MAIN_CONTENT_MIN_WIDTH = 600;
+
+function clampSidebarWidth(width: number, maxWidth = MAX_SIDEBAR_WIDTH): number {
+  return Math.min(Math.max(Math.round(width), MIN_SIDEBAR_WIDTH), maxWidth);
+}
+
+function readStoredSidebarWidth(): number {
+  try {
+    const raw = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+    if (raw === null || raw.trim() === "") return DEFAULT_SIDEBAR_WIDTH;
+    const stored = Number(raw);
+    return Number.isFinite(stored) ? clampSidebarWidth(stored) : DEFAULT_SIDEBAR_WIDTH;
+  } catch {
+    return DEFAULT_SIDEBAR_WIDTH;
+  }
+}
+
+function persistSidebarWidth(width: number) {
+  try {
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(clampSidebarWidth(width)));
+  } catch {
+    // localStorage may be unavailable; resizing still works for this session.
+  }
+}
+
+function getAppScale(): number {
+  const scale = Number.parseFloat(
+    getComputedStyle(document.documentElement).getPropertyValue("--app-scale")
+  );
+  return Number.isFinite(scale) && scale > 0 ? scale : 1;
+}
+
+function getAvailableMaxSidebarWidth(): number {
+  const availableWidth = window.innerWidth / getAppScale() - MAIN_CONTENT_MIN_WIDTH;
+  return Math.max(
+    MIN_SIDEBAR_WIDTH,
+    Math.min(MAX_SIDEBAR_WIDTH, Math.floor(availableWidth))
+  );
+}
+
 function getSyncHealthIndicator(health: SyncHealth, skillCount: number): { color: string; title: string } | null {
   if (skillCount === 0) return null;
   if (health.diverged > 0) return { color: "bg-red-400", title: `${health.diverged} diverged` };
@@ -73,6 +117,16 @@ export function Sidebar() {
   const [projectsOpen, setProjectsOpen] = useState(true);
   const [globalWorkspaceOpen, setGlobalWorkspaceOpen] = useState(true);
   const [lobsterWorkspaceOpen, setLobsterWorkspaceOpen] = useState(true);
+  const [sidebarWidth, setSidebarWidth] = useState(readStoredSidebarWidth);
+  const [availableMaxSidebarWidth, setAvailableMaxSidebarWidth] = useState(getAvailableMaxSidebarWidth);
+  const sidebarWidthRef = useRef(sidebarWidth);
+  const resizeDragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startWidth: number;
+    scale: number;
+  } | null>(null);
+  const effectiveSidebarWidth = Math.min(sidebarWidth, availableMaxSidebarWidth);
 
   const globalSkillsByAgent = useMemo(() => {
     const map: Record<string, number> = {};
@@ -86,6 +140,16 @@ export function Sidebar() {
 
   useEffect(() => { setOrderedPresets(presets); }, [presets]);
   useEffect(() => { setOrderedProjects(projects); }, [projects]);
+  useEffect(() => {
+    const updateAvailableWidth = () => setAvailableMaxSidebarWidth(getAvailableMaxSidebarWidth());
+    const observer = new ResizeObserver(updateAvailableWidth);
+    observer.observe(document.documentElement);
+    window.addEventListener("resize", updateAvailableWidth);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateAvailableWidth);
+    };
+  }, []);
   useEffect(() => {
     const stored = localStorage.getItem("skills-manager:tool-order");
     const storedOrder: string[] = stored ? JSON.parse(stored) : [];
@@ -162,6 +226,42 @@ export function Sidebar() {
       setOrderedCodingTools(reordered);
       localStorage.setItem("skills-manager:tool-order", JSON.stringify(reordered.map((t) => t.key)));
     }
+  };
+
+  const updateSidebarWidth = (width: number, maxWidth = availableMaxSidebarWidth) => {
+    const nextWidth = clampSidebarWidth(width, maxWidth);
+    sidebarWidthRef.current = nextWidth;
+    setSidebarWidth(nextWidth);
+    return nextWidth;
+  };
+
+  const handleResizePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    resizeDragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: effectiveSidebarWidth,
+      scale: getAppScale(),
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handleResizePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = resizeDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    const delta = (event.clientX - drag.startX) / drag.scale;
+    updateSidebarWidth(drag.startWidth + delta, getAvailableMaxSidebarWidth());
+  };
+
+  const finishSidebarResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = resizeDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    resizeDragRef.current = null;
+    persistSidebarWidth(sidebarWidthRef.current);
   };
 
   const NAV_ITEMS = [
@@ -334,7 +434,7 @@ export function Sidebar() {
                                       isActive ? "border-accent/30 bg-accent/10" : "group-hover:border-border"
                                     )}
                                   />
-                                  <span className="flex-1 truncate">{tool.display_name}</span>
+                                  <span className="flex-1 truncate" title={tool.display_name}>{tool.display_name}</span>
                                   <span className="ml-auto flex h-[18px] w-[32px] shrink-0 items-center justify-end group-hover:hidden">
                                     {skillCount > 0 && (
                                       <span className={cn(
@@ -376,7 +476,10 @@ export function Sidebar() {
 
   return (
     <>
-      <div className="w-[220px] flex-shrink-0 bg-bg-secondary border-r border-border-subtle h-full flex flex-col select-none relative z-10">
+      <div
+        className="flex-shrink-0 bg-bg-secondary border-r border-border-subtle h-full flex flex-col select-none relative z-10"
+        style={{ width: effectiveSidebarWidth }}
+      >
         {/* Traffic-light safe zone */}
         <div className="h-[38px] shrink-0" />
         {/* App logo — sits below macOS window controls */}
@@ -476,7 +579,7 @@ export function Sidebar() {
                                   >
                                     <PresetIcon className="h-3 w-3" />
                                   </span>
-                                  <span className="flex-1 truncate">{preset.name}</span>
+                                  <span className="flex-1 truncate" title={preset.name}>{preset.name}</span>
                                   <span className="ml-auto flex h-[18px] w-[32px] shrink-0 items-center justify-end group-hover:hidden">
                                     {preset.skill_count > 0 && (
                                       <span
@@ -637,7 +740,7 @@ export function Sidebar() {
                                       ? <Link2 className="h-3 w-3" />
                                       : <FolderOpen className="h-3 w-3" />}
                                   </span>
-                                  <span className="flex-1 truncate">{project.name}</span>
+                                  <span className="flex-1 truncate" title={project.name}>{project.name}</span>
                                   <span className="ml-auto flex h-[18px] w-[52px] shrink-0 items-center justify-end gap-2 group-hover:hidden">
                                     {healthIndicator && (
                                       <span
@@ -730,6 +833,18 @@ export function Sidebar() {
               />
             )}
           </Link>
+        </div>
+
+        <div
+          aria-hidden="true"
+          title={t("sidebar.resize")}
+          onPointerDown={handleResizePointerDown}
+          onPointerMove={handleResizePointerMove}
+          onPointerUp={finishSidebarResize}
+          onPointerCancel={finishSidebarResize}
+          className="group absolute inset-y-0 -right-1 z-20 w-2 touch-none cursor-col-resize outline-none"
+        >
+          <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-accent/50" />
         </div>
       </div>
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -13,7 +13,8 @@
     "newPreset": "New Preset",
     "projects": "Project Workspaces",
     "addProject": "Link Project",
-    "settings": "Settings"
+    "settings": "Settings",
+    "resize": "Resize sidebar"
   },
   "help": {
     "eyebrow": "Guide",

--- a/src/i18n/zh-TW.json
+++ b/src/i18n/zh-TW.json
@@ -13,7 +13,8 @@
     "newPreset": "新增 Preset",
     "projects": "專案工作區",
     "addProject": "關聯專案",
-    "settings": "設定"
+    "settings": "設定",
+    "resize": "調整側邊欄寬度"
   },
   "help": {
     "eyebrow": "操作指南",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -13,7 +13,8 @@
     "newPreset": "新建 Preset",
     "projects": "项目工作区",
     "addProject": "关联项目",
-    "settings": "设置"
+    "settings": "设置",
+    "resize": "调整侧边栏宽度"
   },
   "help": {
     "eyebrow": "操作指南",


### PR DESCRIPTION
## 背景

Sidebar 目前固定为 220px，较长的 Agent、Preset 和 Project 名称难以辨认。本 PR 实现 #387 所需的可调宽度能力。

## 改动

- 支持用鼠标拖动 Sidebar 边缘，宽度范围为 220–420px。
- 使用 localStorage 记忆宽度；异常值会自动回退或限制到合法范围。
- 根据窗口宽度和字号动态限制 Sidebar，始终为主内容保留至少 600px。
- 为 Agent、Preset 和 Project 的截断名称增加原生 tooltip。
- 增加英文、简体中文和繁体中文的调整宽度提示。
- 仅修改前端，不涉及 Rust、数据库、同步逻辑或依赖。

## 验证

- `npm run lint`
- `npm run build`
- 使用独立 bundle identifier、临时 HOME/XDG 配置和禁止正式目录写入的 macOS debug App 测试：
  - 默认和最小宽度为 220px。
  - 最大宽度为 420px。
  - 鼠标拖动连续正常。
  - 293px 宽度在重启后正确恢复。
  - Small、Default、Large、Extra Large 字号下布局正常。
  - 长 Project 名称 tooltip 正常。
  - 正式 App、Skills、Preset 和 Project Workspace 未受影响。

## 截图

### 默认宽度（220px）

<img width="1212" height="872" alt="默认宽度（220px）" src="https://github.com/user-attachments/assets/97c7a705-e96a-4edb-9509-d1fd686c6c91" />

### 最大宽度（420px）

<img width="1212" height="872" alt="最大宽度（420px）" src="https://github.com/user-attachments/assets/ee1b1e8b-0f7a-4701-a2f2-fd581efbae1c" />

Fixes #387
Related to #195
