### PR TITLE
fix(workspace): re-point source_ref before an adoption replaces the import source dir (#425)

### DIFF
--- a/src-tauri/src/commands/agent_workspace.rs
+++ b/src-tauri/src/commands/agent_workspace.rs
@@ -627,6 +627,10 @@ fn update_agent_local_skill_from_center(
     let source = PathBuf::from(&managed.central_path);
     let configured_mode = store.get_setting("sync_mode").map_err(AppError::db)?;
     let mode = sync_engine::sync_mode_for_tool(agent, configured_mode.as_deref());
+    // The replacement below turns the agent's real directory into a deployment
+    // of central; any source_ref naming it must be re-pointed first, exactly
+    // like an adoption (#425).
+    scenario_service::detach_source_refs_from_adoption_target(store, Path::new(&target_path))?;
     // UserConfirmed: an explicit "update this agent copy from center" on a
     // skill the user picked, already guarded by the project_newer check above.
     // The target is a discovered agent skill dir, which carries no target row.
@@ -690,7 +694,7 @@ mod tests {
     use crate::core::content_hash;
     use crate::core::project_scanner::ProjectSkillInfo;
     use crate::core::skill_store::{ScenarioRecord, SkillRecord, SkillStore};
-    use crate::core::{central_repo, installer, tool_adapters, tool_service};
+    use crate::core::{central_repo, installer, sync_engine, tool_adapters, tool_service};
     use std::collections::HashMap;
 
     #[test]
@@ -1073,6 +1077,146 @@ mod tests {
                 .as_deref(),
             Some("")
         );
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    #[test]
+    fn backfill_repoints_source_ref_when_adopting_the_import_source_dir() {
+        let _guard = central_repo::test_base_dir_lock();
+        let temp = tempfile::tempdir().unwrap();
+        central_repo::set_test_base_dir_override(Some(temp.path().join("center")));
+
+        let db_path = temp.path().join("store.db");
+        let store = SkillStore::new(&db_path).unwrap();
+
+        let skills_root = temp.path().join("agent-skills");
+        let skill_dir = skills_root.join("imported-tool");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: imported-tool\ndescription: Agent copy\n---\nlocal\n",
+        )
+        .unwrap();
+
+        // The #425 shape: an *imported* skill whose source_ref names the agent
+        // directory it was imported from. The importer records no target row,
+        // so the backfill below is about to adopt that very directory as a
+        // deployment.
+        let existing = installer::install_from_local(&skill_dir, Some("imported-tool")).unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        store
+            .insert_skill(&SkillRecord {
+                id: "imported".to_string(),
+                name: "imported-tool".to_string(),
+                description: existing.description.clone(),
+                source_type: "import".to_string(),
+                source_ref: Some(skill_dir.to_string_lossy().to_string()),
+                source_ref_resolved: None,
+                source_subpath: None,
+                source_branch: None,
+                source_revision: None,
+                remote_revision: None,
+                central_path: existing.central_path.to_string_lossy().to_string(),
+                content_hash: Some(existing.content_hash.clone()),
+                enabled: true,
+                created_at: now,
+                updated_at: now,
+                status: "ok".to_string(),
+                update_status: "local_only".to_string(),
+                last_checked_at: Some(now),
+                last_check_error: None,
+            })
+            .unwrap();
+
+        store
+            .set_setting(
+                "custom_tools",
+                &serde_json::json!([
+                    {
+                        "key": "test_agent",
+                        "display_name": "Test Agent",
+                        "skills_dir": skills_root.to_string_lossy(),
+                        "project_relative_skills_dir": ".test-agent/skills"
+                    }
+                ])
+                .to_string(),
+            )
+            .unwrap();
+
+        // Stranded precondition: no targets at all.
+        assert!(store.get_all_targets().unwrap().is_empty());
+
+        let repaired = backfill_stranded_agent_targets(&store);
+        assert_eq!(repaired, 1);
+
+        // The adoption must have re-pointed source_ref at the central copy
+        // before replacing the directory: the agent dir is now a deployment,
+        // and a deployment can be removed at any time.
+        let skill = store.get_skill_by_id("imported").unwrap().unwrap();
+        assert_eq!(
+            skill.source_ref.as_deref(),
+            Some(existing.central_path.to_string_lossy().to_string().as_str())
+        );
+
+        // Simulate the agent cleaning up a deployment it does not recognize
+        // (what WorkBuddy did in #425): the source_ref must keep resolving, so
+        // the update check reports `up_to_date` instead of `source_missing`.
+        sync_engine::remove_target(&skill_dir).unwrap();
+        assert!(std::path::Path::new(skill.source_ref.as_deref().unwrap()).exists());
+
+        central_repo::set_test_base_dir_override(None);
+    }
+
+    #[test]
+    fn importing_an_agent_local_skill_leaves_source_ref_pointing_at_central() {
+        let _guard = central_repo::test_base_dir_lock();
+        let temp = tempfile::tempdir().unwrap();
+        central_repo::set_test_base_dir_override(Some(temp.path().join("center")));
+
+        let db_path = temp.path().join("store.db");
+        let store = SkillStore::new(&db_path).unwrap();
+
+        let skills_root = temp.path().join("agent-skills");
+        let skill_dir = skills_root.join("local-tool");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: local-tool\ndescription: Local test skill\n---\n",
+        )
+        .unwrap();
+
+        store
+            .set_setting(
+                "custom_tools",
+                &serde_json::json!([
+                    {
+                        "key": "test_agent",
+                        "display_name": "Test Agent",
+                        "skills_dir": skills_root.to_string_lossy(),
+                        "project_relative_skills_dir": ".test-agent/skills"
+                    }
+                ])
+                .to_string(),
+            )
+            .unwrap();
+
+        import_agent_local_skill_to_center(&store, "test_agent", "local-tool").unwrap();
+
+        let skills = store.get_all_skills().unwrap();
+        assert_eq!(skills.len(), 1);
+        // Importing adopts the agent directory as a managed deployment, so the
+        // recorded source must be the central copy — not the agent path that
+        // just became a removable link (#425).
+        assert_eq!(
+            skills[0].source_ref.as_deref(),
+            Some(skills[0].central_path.as_str())
+        );
+
+        // Removing that deployment later (agent cleanup, or an undeploy) must
+        // not dangle the source.
+        sync_engine::remove_target(&skill_dir).unwrap();
+        assert!(std::path::Path::new(skills[0].source_ref.as_deref().unwrap()).exists());
 
         central_repo::set_test_base_dir_override(None);
     }

--- a/src-tauri/src/core/scenario_service.rs
+++ b/src-tauri/src/core/scenario_service.rs
@@ -716,6 +716,54 @@ pub enum DeployIntent {
     AdoptExisting,
 }
 
+/// Re-point every `source_ref` that names `target` at the referring skill's own
+/// central copy, ahead of an adoption that replaces `target` with a managed
+/// deployment (#425).
+///
+/// An adopted directory stops being an independent copy the moment the
+/// adoption runs: it becomes a link to (or copy of) central that can be
+/// removed at any time — by the agent's own skill management cleaning up what
+/// it does not recognize, or by a later undeploy. A skill whose `source_ref`
+/// still names that directory then fails its update check with
+/// `source_missing` forever, even though the central copy is intact.
+///
+/// The central copy always exists while the skill row does, so re-pointing
+/// keeps the source resolvable; the content-hash comparison against it keeps
+/// reporting `up_to_date`. Matching is by exact string or canonicalized path,
+/// because import records can spell the same directory with mixed separators
+/// than the deployment target computed from the adapter.
+pub(crate) fn detach_source_refs_from_adoption_target(
+    store: &SkillStore,
+    target: &Path,
+) -> Result<(), AppError> {
+    let target_str = target.to_string_lossy().into_owned();
+    let target_canonical = std::fs::canonicalize(target).ok();
+    for skill in store.get_all_skills().map_err(AppError::db)? {
+        let Some(source_ref) = skill.source_ref.as_deref() else {
+            continue;
+        };
+        // Already re-pointed by a previous adoption — nothing to do.
+        if source_ref == skill.central_path {
+            continue;
+        }
+        let points_at_target = source_ref == target_str
+            || target_canonical.as_ref().is_some_and(|canonical| {
+                std::fs::canonicalize(source_ref).is_ok_and(|source| &source == canonical)
+            });
+        if points_at_target {
+            store
+                .update_skill_source_ref(&skill.id, &skill.central_path)
+                .map_err(AppError::db)?;
+            log::info!(
+                "adoption: re-pointed source_ref of skill '{}' at its central copy; \
+                 the adopted agent directory is now a deployment, not a source (#425)",
+                skill.name
+            );
+        }
+    }
+    Ok(())
+}
+
 pub fn sync_single_skill_to_tool(
     store: &SkillStore,
     skill_id: &str,
@@ -765,6 +813,13 @@ pub fn sync_single_skill_to_tool(
         DeployIntent::AdoptExisting => sync_engine::ReplacePolicy::UserConfirmed,
         DeployIntent::Managed => replace_policy(recorded_mode.as_deref()),
     };
+    if matches!(intent, DeployIntent::AdoptExisting) {
+        // The directory at `target` may still be the import source of the very
+        // skill being deployed (or of a sibling record): re-point those at
+        // central BEFORE the replacement, so a failure partway through the
+        // adoption can never leave a dangling source behind (#425).
+        detach_source_refs_from_adoption_target(store, &target)?;
+    }
     let actual_mode = sync_engine::sync_skill(&source, &target, mode, policy).map_err(AppError::io)?;
 
     let now = chrono::Utc::now().timestamp_millis();


### PR DESCRIPTION
Fixes #425

## 概述

收编操作（stranded-target backfill、"导入到中心库"、"从中心更新 agent 副本"）会把 agent skills 目录里的真实目录替换为指向中心库的托管部署物。任何 `source_ref` 仍指向该目录的 skill，都会在部署物消失的那一刻丢失导入源——部署物可能被 agent 自己的 skill 管理清理掉（#425 中的 WorkBuddy），也可能只是被一次普通的撤销部署移除——此后更新检查会永远报 `source_missing`，尽管中心库副本完好无损。

`detach_source_refs_from_adoption_target` 会在替换发生**之前**，把所有这类记录重新指向 skill 自己的中心库副本，这样收编中途失败也绝不会留下悬空的来源。中心库副本在 skill 记录存在期间始终存在，内容哈希比对也会继续报告 `up_to_date`。路径匹配采用精确字符串或规范化路径两种方式，因为导入记录拼写同一路径时使用的分隔符可能与适配器计算出的部署目标不一致。

覆盖的调用路径：

- `sync_single_skill_to_tool(DeployIntent::AdoptExisting)` —— stranded-target backfill，以及 `import_agent_local_skill_to_center` 的两个分支（已有匹配 / 新建 skill）
- `update_agent_local_skill_from_center` —— 不经过 target 记录、直接调 `sync_skill` 的收编路径

## 测试计划

- [x] 新增：`backfill_repoints_source_ref_when_adopting_the_import_source_dir` —— 完整复现 #425 场景（import 型 skill、source_ref 指向 agent 目录、backfill 收编），断言 source_ref 已改写为中心库路径；随后像 agent 那样删掉部署物，断言来源仍可解析
- [x] 新增：`importing_an_agent_local_skill_leaves_source_ref_pointing_at_central` —— 导入新建 skill 路径，断言记录的来源是中心库副本，且在部署物被移除后依然有效
- [x] 既有 `agent_workspace` 测试：11/11 通过（无回归）
- [x] Windows 全量测试：453 通过 / 3 忽略 —— 仅有的 2 个失败（`remove_target_removes_directory_symlink`、`remove_workspace_skill_target_removes_directory_symlink_without_touching_target`）在未修改的 `main` 上同样失败（本机无 `SeCreateSymbolicLinkPrivilege` 特权）；它们直接创建原始目录符号链接，与本次改动无关
